### PR TITLE
chore: Bump version to 1.2.0

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,5 +3,5 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 __version_info__ = tuple(int(part) for part in __version__.split("."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iam-policy-validator"
-version = "1.1.2"
+version = "1.2.0"
 description = "Validate AWS IAM policies for correctness and security using AWS Service Reference API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "iam-policy-validator"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bump version to 1.2.0 to prepare for release.

## Changes
- Updated version in `iam_validator/__version__.py` from 1.1.2 to 1.2.0
- Updated version in `pyproject.toml` from 1.1.2 to 1.2.0
- Updated `uv.lock` with new version

## Next Steps
After merging this PR, create the v1.2.0 release tag.