### PR TITLE
fix: Validate global condition keys against action-specific support

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,9 @@ Use as a library in your Python applications:
 
 ```python
 import asyncio
-from iam_validator.core import PolicyLoader, validate_policies, ReportGenerator
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.report import ReportGenerator
 
 async def main():
     # Load policies
@@ -626,6 +628,10 @@ async def main():
 
 asyncio.run(main())
 ```
+
+**📚 For comprehensive Python library documentation, see:**
+- **[Python Library Usage Guide](docs/python-library-usage.md)** - Complete guide with examples
+- **[Library Examples](examples/library-usage/)** - Runnable code examples
 
 ## Validation Checks
 

--- a/aws_services/_manifest.json
+++ b/aws_services/_manifest.json
@@ -1,5 +1,5 @@
 {
-  "download_date": "2025-10-29T23:23:11.519006+00:00",
+  "download_date": "2025-10-31T23:41:25.480606+00:00",
   "total_services": 430,
   "successful_downloads": 430,
   "failed_downloads": 0,

--- a/aws_services/aps.json
+++ b/aws_services/aps.json
@@ -48,6 +48,30 @@
       }
     },
     {
+      "Name": "CreateAnomalyDetector",
+      "ActionConditionKeys": [
+        "aws:RequestTag/${TagKey}",
+        "aws:TagKeys"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "CreateLoggingConfiguration",
       "ActionConditionKeys": [
         "aws:ResourceTag/${TagKey}"
@@ -211,6 +235,32 @@
       }
     },
     {
+      "Name": "DeleteAnomalyDetector",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "anomalydetector"
+        },
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "DeleteLoggingConfiguration",
       "ActionConditionKeys": [
         "aws:ResourceTag/${TagKey}"
@@ -326,6 +376,29 @@
       }
     },
     {
+      "Name": "DeleteScraperLoggingConfiguration",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "scraper"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "DeleteWorkspace",
       "ActionConditionKeys": [
         "aws:ResourceTag/${TagKey}"
@@ -369,6 +442,32 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "DescribeAnomalyDetector",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "anomalydetector"
+        },
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {
@@ -484,6 +583,29 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "DescribeScraperLoggingConfiguration",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "scraper"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {
@@ -778,6 +900,29 @@
       }
     },
     {
+      "Name": "ListAnomalyDetectors",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": true,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "ListRuleGroupsNamespaces",
       "ActionConditionKeys": [
         "aws:ResourceTag/${TagKey}"
@@ -854,6 +999,9 @@
       },
       "Resources": [
         {
+          "Name": "anomalydetector"
+        },
+        {
           "Name": "rulegroupsnamespace"
         },
         {
@@ -881,6 +1029,29 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "PreviewAnomalyDetector",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {
@@ -920,6 +1091,32 @@
         }
       },
       "Resources": [
+        {
+          "Name": "workspace"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
+      "Name": "PutAnomalyDetector",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "anomalydetector"
+        },
         {
           "Name": "workspace"
         }
@@ -1037,6 +1234,9 @@
       },
       "Resources": [
         {
+          "Name": "anomalydetector"
+        },
+        {
           "Name": "rulegroupsnamespace"
         },
         {
@@ -1065,6 +1265,9 @@
         }
       },
       "Resources": [
+        {
+          "Name": "anomalydetector"
+        },
         {
           "Name": "rulegroupsnamespace"
         },
@@ -1153,6 +1356,29 @@
       }
     },
     {
+      "Name": "UpdateScraperLoggingConfiguration",
+      "ActionConditionKeys": [
+        "aws:ResourceTag/${TagKey}"
+      ],
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "scraper"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "UpdateWorkspaceAlias",
       "ActionConditionKeys": [
         "aws:ResourceTag/${TagKey}"
@@ -1220,6 +1446,17 @@
     }
   ],
   "Resources": [
+    {
+      "Name": "anomalydetector",
+      "ARNFormats": [
+        "arn:${Partition}:aps:${Region}:${Account}:anomalydetector/${WorkspaceId}/${AnomalyDetectorId}"
+      ],
+      "ConditionKeys": [
+        "aws:RequestTag/${TagKey}",
+        "aws:ResourceTag/${TagKey}",
+        "aws:TagKeys"
+      ]
+    },
     {
       "Name": "cluster",
       "ARNFormats": [

--- a/aws_services/bedrock.json
+++ b/aws_services/bedrock.json
@@ -2951,6 +2951,26 @@
       }
     },
     {
+      "Name": "InvokeTool",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "system-tool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "ListAgentActionGroups",
       "Annotations": {
         "Properties": {
@@ -5182,6 +5202,12 @@
       ],
       "ConditionKeys": [
         "aws:ResourceTag/${TagKey}"
+      ]
+    },
+    {
+      "Name": "system-tool",
+      "ARNFormats": [
+        "arn:${Partition}:bedrock::${Account}:system-tool/${ResourceId}"
       ]
     }
   ],

--- a/aws_services/cognito-idp.json
+++ b/aws_services/cognito-idp.json
@@ -720,6 +720,26 @@
       }
     },
     {
+      "Name": "CreateTerms",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "userpool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "CreateUserImportJob",
       "Annotations": {
         "Properties": {
@@ -877,6 +897,26 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "DeleteTerms",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "userpool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {
@@ -1067,6 +1107,26 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "DescribeTerms",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "userpool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {
@@ -1560,6 +1620,26 @@
       }
     },
     {
+      "Name": "ListTerms",
+      "Annotations": {
+        "Properties": {
+          "IsList": true,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "userpool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "ListUserImportJobs",
       "Annotations": {
         "Properties": {
@@ -2024,6 +2104,26 @@
       "SupportedBy": {
         "IAM Access Analyzer Policy Generation": true,
         "IAM Action Last Accessed": true
+      }
+    },
+    {
+      "Name": "UpdateTerms",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "userpool"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
       }
     },
     {

--- a/aws_services/emr-containers.json
+++ b/aws_services/emr-containers.json
@@ -159,6 +159,26 @@
       }
     },
     {
+      "Name": "DeleteSecurityConfiguration",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": true
+        }
+      },
+      "Resources": [
+        {
+          "Name": "securityConfiguration"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "DeleteVirtualCluster",
       "Annotations": {
         "Properties": {

--- a/aws_services/iotmanagedintegrations.json
+++ b/aws_services/iotmanagedintegrations.json
@@ -612,6 +612,26 @@
       }
     },
     {
+      "Name": "GetManagedThingCertificate",
+      "Annotations": {
+        "Properties": {
+          "IsList": false,
+          "IsPermissionManagement": false,
+          "IsTaggingOnly": false,
+          "IsWrite": false
+        }
+      },
+      "Resources": [
+        {
+          "Name": "managed-thing"
+        }
+      ],
+      "SupportedBy": {
+        "IAM Access Analyzer Policy Generation": false,
+        "IAM Action Last Accessed": false
+      }
+    },
+    {
       "Name": "GetManagedThingConnectivityData",
       "Annotations": {
         "Properties": {

--- a/default-config.yaml
+++ b/default-config.yaml
@@ -687,8 +687,6 @@ action_condition_enforcement_check:
     # Prevents cross-organization writes for data exfiltration (when used with AWS Organizations)
     - actions:
         - "s3:PutObject"
-        - "s3:DeleteObject"
-        - "s3:CreateBucket"
       # - action_patterns:
       #     - "^s3:Put.*$"
       #     - "^s3:Delete.*$"

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,12 @@ This directory contains comprehensive documentation for the IAM Policy Validator
 ## Documentation Index
 
 ### User Guides
+- **[Python Library Usage](python-library-usage.md)** ⭐ - Using IAM Policy Validator as a Python library
 - **[AWS Services Backup](aws-services-backup.md)** - Download AWS services for offline validation
 - **[Configuration Reference](configuration.md)** - YAML configuration options and examples
 - **[Custom Checks Guide](custom-checks.md)** - Creating custom validation rules
 - **[Privilege Escalation Detection](privilege-escalation.md)** - Policy-level privilege escalation patterns
-- **[Smart Filtering](smart-filtering.md)** ⭐ - Automatic IAM policy detection and filtering
+- **[Smart Filtering](smart-filtering.md)** - Automatic IAM policy detection and filtering
 
 ### Integration Guides
 - **[GitHub Actions Workflows](github-actions-workflows.md)** - Complete workflow setup guide with OIDC

--- a/docs/python-library-usage.md
+++ b/docs/python-library-usage.md
@@ -1,0 +1,1028 @@
+# Using IAM Policy Validator as a Python Library
+
+This guide shows you how to use IAM Policy Validator as a Python library in your own applications, scripts, and automation tools.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Configuration Methods](#configuration-methods)
+- [Common Use Cases](#common-use-cases)
+- [Advanced Usage](#advanced-usage)
+- [API Reference](#api-reference)
+- [Examples](#examples)
+
+## Installation
+
+Install the package using pip or uv:
+
+```bash
+# Using pip
+pip install iam-policy-validator
+
+# Using uv (recommended)
+uv add iam-policy-validator
+
+# For development
+uv add --dev iam-policy-validator
+```
+
+## Quick Start
+
+The simplest way to validate IAM policies programmatically:
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.report import ReportGenerator
+
+async def validate_policies_example():
+    # Load policies from file or directory
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/my-policy.json")
+
+    # Validate policies (uses default configuration)
+    results = await validate_policies(policies)
+
+    # Generate and print report
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+    generator.print_console_report(report)
+
+    # Check if all policies are valid
+    all_valid = all(r.is_valid for r in results)
+    return 0 if all_valid else 1
+
+# Run the validation
+exit_code = asyncio.run(validate_policies_example())
+```
+
+**Key Points:**
+- All validation is **asynchronous** (uses `async`/`await`)
+- Returns `PolicyValidationResult` objects with issues and metadata
+- Default configuration includes all built-in security checks
+
+## Configuration Methods
+
+There are multiple ways to configure the validator based on your needs.
+
+### 1. Default Configuration (No Config)
+
+Use built-in defaults - suitable for testing and simple validation:
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def validate_with_defaults():
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Uses all built-in checks with default settings
+    results = await validate_policies(policies)
+    return results
+
+asyncio.run(validate_with_defaults())
+```
+
+### 2. YAML Configuration File
+
+Use a YAML file for persistent, shareable configuration:
+
+**Create `iam-validator.yaml`:**
+```yaml
+settings:
+  fail_on_severity: ["error", "critical"]
+  cache_enabled: true
+  cache_ttl_hours: 168  # 7 days
+  parallel_execution: true
+  enable_builtin_checks: true
+
+# Configure built-in checks
+security_best_practices_check:
+  enabled: true
+  severity: high
+
+action_validation_check:
+  enabled: true
+  severity: error
+
+action_condition_enforcement_check:
+  enabled: true
+  severity: critical
+  action_condition_requirements:
+    - actions:
+        - "iam:PassRole"
+      required_conditions:
+        - condition_key: "iam:PassedToService"
+```
+
+**Use in Python:**
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def validate_with_config_file():
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Load and apply configuration from file
+    results = await validate_policies(
+        policies,
+        config_path="./iam-validator.yaml",
+        use_registry=True
+    )
+    return results
+
+asyncio.run(validate_with_config_file())
+```
+
+**Config File Auto-Discovery:**
+
+The validator automatically searches for config files in this order:
+1. Explicit path (if provided)
+2. Current directory
+3. Parent directories (walks up to root)
+4. User home directory
+
+Searched filenames: `iam-validator.yaml`, `iam-validator.yml`, `.iam-validator.yaml`, `.iam-validator.yml`
+
+### 3. Programmatic Configuration
+
+Create configuration dynamically in Python:
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.config_loader import ValidatorConfig, ConfigLoader
+from iam_validator.core.check_registry import create_default_registry
+from iam_validator.core.aws_fetcher import AWSServiceFetcher
+
+async def validate_with_programmatic_config():
+    # Create configuration dictionary
+    config_dict = {
+        "settings": {
+            "fail_on_severity": ["error", "critical"],
+            "cache_enabled": True,
+            "cache_ttl_hours": 24,
+            "parallel_execution": True,
+        },
+        "security_best_practices_check": {
+            "enabled": True,
+            "severity": "high",
+        },
+        "action_validation_check": {
+            "enabled": True,
+            "severity": "error",
+        }
+    }
+
+    # Create config object
+    config = ValidatorConfig(config_dict, use_defaults=True)
+
+    # Create and configure registry
+    registry = create_default_registry(
+        enable_parallel=True,
+        include_builtin_checks=True
+    )
+    ConfigLoader.apply_config_to_registry(config, registry)
+
+    # Load policies
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Get settings
+    cache_enabled = config.get_setting("cache_enabled", True)
+    cache_ttl_hours = config.get_setting("cache_ttl_hours", 168)
+    fail_on_severities = config.get_setting("fail_on_severity", ["error"])
+
+    # Validate with custom configuration
+    async with AWSServiceFetcher(
+        enable_cache=cache_enabled,
+        cache_ttl=cache_ttl_hours * 3600,
+    ) as fetcher:
+        from iam_validator.core.policy_checks import _validate_policy_with_registry
+
+        results = []
+        for file_path, policy in policies:
+            result = await _validate_policy_with_registry(
+                policy, file_path, registry, fetcher, fail_on_severities
+            )
+            results.append(result)
+
+    return results
+
+asyncio.run(validate_with_programmatic_config())
+```
+
+### 4. Custom Checks Integration
+
+Load custom validation checks from a directory:
+
+**Directory structure:**
+```
+my_project/
+├── policies/
+│   └── my-policy.json
+├── custom_checks/
+│   ├── mfa_required_check.py
+│   └── region_restriction_check.py
+└── validate.py
+```
+
+**Create custom check (`custom_checks/mfa_required_check.py`):**
+```python
+from iam_validator.core.check_registry import PolicyCheck, CheckConfig
+from iam_validator.core.models import Statement, ValidationIssue
+from iam_validator.core.aws_fetcher import AWSServiceFetcher
+
+class MFARequiredCheck(PolicyCheck):
+    @property
+    def check_id(self) -> str:
+        return "mfa_required"
+
+    @property
+    def description(self) -> str:
+        return "Ensures sensitive actions require MFA"
+
+    @property
+    def default_severity(self) -> str:
+        return "error"
+
+    async def execute(
+        self,
+        statement: Statement,
+        statement_idx: int,
+        fetcher: AWSServiceFetcher,
+        config: CheckConfig,
+    ) -> list[ValidationIssue]:
+        issues = []
+
+        if statement.effect != "Allow":
+            return issues
+
+        # Get config
+        require_mfa_for = config.config.get("require_mfa_for", [])
+
+        # Check actions
+        actions = statement.get_actions()
+        for action in actions:
+            if action in require_mfa_for:
+                if not self._has_mfa_condition(statement):
+                    issues.append(
+                        ValidationIssue(
+                            severity=self.get_severity(config),
+                            statement_sid=statement.sid,
+                            statement_index=statement_idx,
+                            issue_type="missing_mfa_condition",
+                            message=f"Action '{action}' requires MFA",
+                            action=action,
+                            suggestion="Add: aws:MultiFactorAuthPresent = true",
+                            line_number=statement.line_number,
+                        )
+                    )
+
+        return issues
+
+    def _has_mfa_condition(self, statement: Statement) -> bool:
+        if not statement.condition:
+            return False
+        for operator, conditions in statement.condition.items():
+            if "aws:MultiFactorAuthPresent" in conditions:
+                value = conditions["aws:MultiFactorAuthPresent"]
+                if value is True or str(value).lower() == "true":
+                    return True
+        return False
+```
+
+**Use custom checks in Python:**
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def validate_with_custom_checks():
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Validate with custom checks directory
+    results = await validate_policies(
+        policies,
+        use_registry=True,
+        custom_checks_dir="./custom_checks"  # Auto-discovers checks
+    )
+
+    return results
+
+asyncio.run(validate_with_custom_checks())
+```
+
+**Configure custom checks via YAML:**
+```yaml
+settings:
+  enable_builtin_checks: true
+
+# Specify directory for auto-discovery
+custom_checks_dir: "./custom_checks"
+
+# Configure the custom check
+mfa_required_check:
+  enabled: true
+  severity: critical
+  require_mfa_for:
+    - "iam:DeleteUser"
+    - "iam:DeleteRole"
+    - "s3:DeleteBucket"
+```
+
+## Common Use Cases
+
+### Use Case 1: CI/CD Integration
+
+```python
+#!/usr/bin/env python3
+"""Validate IAM policies in CI/CD pipeline."""
+import asyncio
+import sys
+from pathlib import Path
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.formatters.json import JsonFormatter
+from iam_validator.core.report import ReportGenerator
+
+async def ci_validation():
+    policy_dir = Path("./policies")
+    config_file = Path("./iam-validator.yaml")
+    output_file = Path("./validation-report.json")
+
+    print(f"🔍 Validating policies in: {policy_dir}")
+
+    # Load policies
+    loader = PolicyLoader()
+    try:
+        policies = loader.load_from_path(str(policy_dir))
+        print(f"📄 Found {len(policies)} policies")
+    except Exception as e:
+        print(f"❌ Error loading policies: {e}", file=sys.stderr)
+        return 1
+
+    # Validate
+    results = await validate_policies(
+        policies,
+        config_path=str(config_file) if config_file.exists() else None,
+        use_registry=True
+    )
+
+    # Generate JSON report for CI/CD tools
+    formatter = JsonFormatter()
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+    json_output = formatter.format(report)
+    output_file.write_text(json_output)
+    print(f"📊 Report saved to: {output_file}")
+
+    # Print summary
+    total_issues = sum(len(r.issues) for r in results)
+    valid_count = sum(1 for r in results if r.is_valid)
+
+    print(f"\n📈 Validation Summary:")
+    print(f"  Total Policies: {len(results)}")
+    print(f"  ✅ Valid: {valid_count}")
+    print(f"  ❌ Invalid: {len(results) - valid_count}")
+    print(f"  ⚠️  Total Issues: {total_issues}")
+
+    # Exit with appropriate code for CI/CD
+    if all(r.is_valid for r in results):
+        print("✅ All policies are valid!")
+        return 0
+    else:
+        print("❌ Validation failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(ci_validation()))
+```
+
+### Use Case 2: Batch Processing
+
+```python
+import asyncio
+from pathlib import Path
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def batch_validate_multiple_dirs():
+    """Validate policies from multiple directories."""
+    directories = [
+        "./iam-policies/",
+        "./s3-policies/",
+        "./lambda-policies/",
+    ]
+
+    all_results = []
+
+    loader = PolicyLoader()
+
+    for directory in directories:
+        print(f"Processing {directory}...")
+
+        policies = loader.load_from_path(directory)
+        results = await validate_policies(
+            policies,
+            config_path="./iam-validator.yaml",
+            use_registry=True
+        )
+
+        all_results.extend(results)
+
+        # Print summary for this directory
+        valid = sum(1 for r in results if r.is_valid)
+        print(f"  {directory}: {valid}/{len(results)} valid")
+
+    return all_results
+
+results = asyncio.run(batch_validate_multiple_dirs())
+```
+
+### Use Case 3: Custom Report Generation
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.report import ReportGenerator
+from iam_validator.core.formatters.html import HtmlFormatter
+from iam_validator.core.formatters.markdown import MarkdownFormatter
+from iam_validator.core.formatters.csv import CsvFormatter
+
+async def generate_multiple_reports():
+    """Generate reports in multiple formats."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Validate
+    results = await validate_policies(policies)
+
+    # Generate report
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+
+    # Export in different formats
+    html_formatter = HtmlFormatter()
+    with open("report.html", "w") as f:
+        f.write(html_formatter.format(report))
+    print("✅ HTML report: report.html")
+
+    md_formatter = MarkdownFormatter()
+    with open("report.md", "w") as f:
+        f.write(md_formatter.format(report))
+    print("✅ Markdown report: report.md")
+
+    csv_formatter = CsvFormatter()
+    with open("report.csv", "w") as f:
+        f.write(csv_formatter.format(report))
+    print("✅ CSV report: report.csv")
+
+    return report
+
+asyncio.run(generate_multiple_reports())
+```
+
+### Use Case 4: Filter and Process Issues
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def process_issues_by_severity():
+    """Process validation issues by severity."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    results = await validate_policies(policies)
+
+    # Group issues by severity
+    issues_by_severity = {
+        "critical": [],
+        "error": [],
+        "warning": [],
+        "info": []
+    }
+
+    for result in results:
+        for issue in result.issues:
+            severity = issue.severity.lower()
+            if severity in issues_by_severity:
+                issues_by_severity[severity].append({
+                    "file": result.policy_file,
+                    "issue": issue
+                })
+
+    # Report critical issues
+    if issues_by_severity["critical"]:
+        print("🚨 CRITICAL ISSUES:")
+        for item in issues_by_severity["critical"]:
+            print(f"  {item['file']}: {item['issue'].message}")
+
+    # Report errors
+    if issues_by_severity["error"]:
+        print("\n❌ ERRORS:")
+        for item in issues_by_severity["error"]:
+            print(f"  {item['file']}: {item['issue'].message}")
+
+    # Return only critical and error counts
+    return {
+        "critical": len(issues_by_severity["critical"]),
+        "error": len(issues_by_severity["error"]),
+        "warning": len(issues_by_severity["warning"]),
+    }
+
+summary = asyncio.run(process_issues_by_severity())
+print(f"\nSummary: {summary}")
+```
+
+## Advanced Usage
+
+### Direct Registry Control
+
+For fine-grained control over validation checks:
+
+```python
+import asyncio
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.check_registry import create_default_registry, CheckConfig
+from iam_validator.core.aws_fetcher import AWSServiceFetcher
+from iam_validator.core.models import PolicyValidationResult
+
+async def advanced_validation():
+    # Create custom registry
+    registry = create_default_registry(
+        enable_parallel=True,
+        include_builtin_checks=True
+    )
+
+    # Disable specific checks
+    registry.configure_check(
+        "policy_size",
+        CheckConfig(check_id="policy_size", enabled=False)
+    )
+
+    # Override check severity
+    registry.configure_check(
+        "security_best_practices",
+        CheckConfig(
+            check_id="security_best_practices",
+            enabled=True,
+            severity="critical",
+            config={
+                "wildcard_action_check": {
+                    "enabled": True,
+                    "severity": "high"
+                }
+            }
+        )
+    )
+
+    # Load policies
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Manual validation with full control
+    async with AWSServiceFetcher(
+        enable_cache=True,
+        cache_ttl=3600 * 24  # 24 hours
+    ) as fetcher:
+        results = []
+
+        for file_path, policy in policies:
+            result = PolicyValidationResult(
+                policy_file=file_path,
+                is_valid=True
+            )
+
+            # Run all checks for each statement
+            for idx, statement in enumerate(policy.statement):
+                issues = await registry.execute_checks_parallel(
+                    statement, idx, fetcher
+                )
+                result.issues.extend(issues)
+
+            # Determine if valid (only errors fail)
+            result.is_valid = len([
+                i for i in result.issues
+                if i.severity in ["error", "critical"]
+            ]) == 0
+
+            results.append(result)
+
+    return results
+
+asyncio.run(advanced_validation())
+```
+
+### Streaming Validation
+
+Process large numbers of policies efficiently:
+
+```python
+import asyncio
+from pathlib import Path
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+
+async def streaming_validation():
+    """Validate policies one at a time (memory efficient)."""
+    policy_dir = Path("./policies")
+
+    loader = PolicyLoader()
+
+    # Get all policy files
+    policy_files = list(policy_dir.glob("**/*.json"))
+    policy_files.extend(policy_dir.glob("**/*.yaml"))
+
+    total = len(policy_files)
+    processed = 0
+    all_valid = True
+
+    for policy_file in policy_files:
+        # Load single policy
+        policies = loader.load_from_path(str(policy_file))
+
+        # Validate
+        results = await validate_policies(policies)
+
+        # Process result immediately
+        for result in results:
+            processed += 1
+            status = "✅" if result.is_valid else "❌"
+            print(f"[{processed}/{total}] {status} {policy_file.name}")
+
+            if not result.is_valid:
+                all_valid = False
+                for issue in result.issues:
+                    print(f"  - {issue.severity}: {issue.message}")
+
+    return all_valid
+
+asyncio.run(streaming_validation())
+```
+
+### Custom AWS Service Fetcher Configuration
+
+Configure caching and offline mode:
+
+```python
+import asyncio
+from pathlib import Path
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.aws_fetcher import AWSServiceFetcher
+from iam_validator.core.check_registry import create_default_registry
+from iam_validator.core.policy_checks import _validate_policy_with_registry
+
+async def validate_with_custom_fetcher():
+    # Custom AWS Service Fetcher configuration
+    cache_dir = Path.home() / ".cache" / "iam-validator"
+    aws_services_dir = Path("./aws_services")  # For offline mode
+
+    async with AWSServiceFetcher(
+        enable_cache=True,
+        cache_ttl=7 * 24 * 3600,  # 7 days in seconds
+        cache_dir=str(cache_dir),
+        aws_services_dir=str(aws_services_dir),  # Use offline definitions
+    ) as fetcher:
+        # Load policies
+        loader = PolicyLoader()
+        policies = loader.load_from_path("./policies/")
+
+        # Create registry
+        registry = create_default_registry()
+
+        # Validate
+        results = []
+        for file_path, policy in policies:
+            result = await _validate_policy_with_registry(
+                policy, file_path, registry, fetcher, ["error"]
+            )
+            results.append(result)
+
+    return results
+
+asyncio.run(validate_with_custom_fetcher())
+```
+
+## API Reference
+
+### Core Classes
+
+#### `PolicyLoader`
+Loads IAM policies from files or directories.
+
+```python
+from iam_validator.core.policy_loader import PolicyLoader
+
+loader = PolicyLoader()
+
+# Load from single file
+policies = loader.load_from_path("./policy.json")
+
+# Load from directory (recursive)
+policies = loader.load_from_path("./policies/")
+
+# Returns: list[tuple[str, IAMPolicy]]
+# - str: file path
+# - IAMPolicy: parsed policy object
+```
+
+#### `validate_policies()`
+Main validation function.
+
+```python
+from iam_validator.core.policy_checks import validate_policies
+
+results = await validate_policies(
+    policies,                    # list[tuple[str, IAMPolicy]]
+    config_path=None,           # Optional: path to config file
+    use_registry=True,          # True: new system, False: legacy
+    custom_checks_dir=None,     # Optional: directory for custom checks
+)
+
+# Returns: list[PolicyValidationResult]
+```
+
+#### `ValidatorConfig`
+Configuration object.
+
+```python
+from iam_validator.core.config_loader import ValidatorConfig
+
+# From dictionary
+config = ValidatorConfig(config_dict, use_defaults=True)
+
+# Get check configuration
+check_config = config.get_check_config("action_validation")
+
+# Check if enabled
+enabled = config.is_check_enabled("security_best_practices")
+
+# Get severity
+severity = config.get_check_severity("action_validation")
+
+# Get setting
+cache_enabled = config.get_setting("cache_enabled", True)
+```
+
+#### `ConfigLoader`
+Loads configuration from files.
+
+```python
+from iam_validator.core.config_loader import ConfigLoader
+
+# Load with auto-discovery
+config = ConfigLoader.load_config(
+    explicit_path=None,     # Optional: explicit path
+    search_path=None,       # Optional: start search from path
+    allow_missing=True,     # Return defaults if not found
+)
+
+# Find config file
+config_path = ConfigLoader.find_config_file()
+
+# Load YAML
+config_dict = ConfigLoader.load_yaml(Path("config.yaml"))
+
+# Apply config to registry
+ConfigLoader.apply_config_to_registry(config, registry)
+```
+
+#### `CheckRegistry`
+Manages validation checks.
+
+```python
+from iam_validator.core.check_registry import create_default_registry
+
+# Create registry with built-in checks
+registry = create_default_registry(
+    enable_parallel=True,
+    include_builtin_checks=True
+)
+
+# Register custom check
+registry.register(my_custom_check)
+
+# Configure check
+from iam_validator.core.check_registry import CheckConfig
+registry.configure_check(
+    "security_best_practices",
+    CheckConfig(
+        check_id="security_best_practices",
+        enabled=True,
+        severity="high",
+        config={"wildcard_action_check": {"enabled": True}}
+    )
+)
+
+# Execute checks
+issues = await registry.execute_checks_parallel(
+    statement, statement_idx, fetcher
+)
+```
+
+#### `PolicyValidationResult`
+Validation result object.
+
+```python
+class PolicyValidationResult:
+    policy_file: str                    # Path to policy file
+    is_valid: bool                      # Overall validation status
+    issues: list[ValidationIssue]       # All validation issues
+    actions_checked: int                # Number of actions validated
+    resources_checked: int              # Number of resources validated
+    condition_keys_checked: int         # Number of condition keys validated
+```
+
+#### `ValidationIssue`
+Individual validation issue.
+
+```python
+class ValidationIssue:
+    severity: str                       # "critical", "error", "warning", "info"
+    statement_sid: str | None           # Statement SID
+    statement_index: int                # Statement index in policy
+    issue_type: str                     # Type of issue
+    message: str                        # Human-readable message
+    suggestion: str | None              # Fix suggestion
+    action: str | None                  # Related action
+    resource: str | None                # Related resource
+    condition_key: str | None           # Related condition key
+    line_number: int | None             # Line number in file
+```
+
+#### `ReportGenerator`
+Generates validation reports.
+
+```python
+from iam_validator.core.report import ReportGenerator
+
+generator = ReportGenerator()
+
+# Generate report
+report = generator.generate_report(results)
+
+# Print console report
+generator.print_console_report(report)
+
+# Get statistics
+stats = report.get_statistics()
+# Returns: dict with counts, severities, etc.
+```
+
+### Formatters
+
+All formatters implement the `format(report: ValidationReport) -> str` method.
+
+```python
+from iam_validator.core.formatters.json import JsonFormatter
+from iam_validator.core.formatters.markdown import MarkdownFormatter
+from iam_validator.core.formatters.html import HtmlFormatter
+from iam_validator.core.formatters.csv import CsvFormatter
+from iam_validator.core.formatters.sarif import SarifFormatter
+
+# Generate different formats
+json_output = JsonFormatter().format(report)
+markdown_output = MarkdownFormatter().format(report)
+html_output = HtmlFormatter().format(report)
+csv_output = CsvFormatter().format(report)
+sarif_output = SarifFormatter().format(report)
+```
+
+## Examples
+
+### Complete Validation Script
+
+```python
+#!/usr/bin/env python3
+"""Complete validation script with all features."""
+import asyncio
+import sys
+from pathlib import Path
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.config_loader import ConfigLoader
+from iam_validator.core.report import ReportGenerator
+from iam_validator.core.formatters.json import JsonFormatter
+from iam_validator.core.formatters.html import HtmlFormatter
+
+async def main():
+    # Configuration
+    policy_dir = Path("./policies")
+    config_file = Path("./iam-validator.yaml")
+    custom_checks_dir = Path("./custom_checks")
+    output_dir = Path("./reports")
+    output_dir.mkdir(exist_ok=True)
+
+    # Load configuration
+    config = ConfigLoader.load_config(
+        explicit_path=str(config_file) if config_file.exists() else None,
+        allow_missing=True
+    )
+
+    print(f"🔍 Validating policies in: {policy_dir}")
+    print(f"⚙️  Configuration: {config_file if config_file.exists() else 'defaults'}")
+
+    # Load policies
+    loader = PolicyLoader()
+    try:
+        policies = loader.load_from_path(str(policy_dir))
+        print(f"📄 Found {len(policies)} policies\n")
+    except Exception as e:
+        print(f"❌ Error loading policies: {e}", file=sys.stderr)
+        return 1
+
+    # Validate
+    print("🔄 Running validation...")
+    results = await validate_policies(
+        policies,
+        config_path=str(config_file) if config_file.exists() else None,
+        use_registry=True,
+        custom_checks_dir=str(custom_checks_dir) if custom_checks_dir.exists() else None
+    )
+
+    # Generate report
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+
+    # Console output
+    print("\n" + "="*60)
+    generator.print_console_report(report)
+    print("="*60)
+
+    # Export reports
+    json_formatter = JsonFormatter()
+    json_file = output_dir / "validation-report.json"
+    json_file.write_text(json_formatter.format(report))
+    print(f"\n📊 JSON report: {json_file}")
+
+    html_formatter = HtmlFormatter()
+    html_file = output_dir / "validation-report.html"
+    html_file.write_text(html_formatter.format(report))
+    print(f"📊 HTML report: {html_file}")
+
+    # Summary statistics
+    stats = report.get_statistics()
+    print(f"\n📈 Validation Summary:")
+    print(f"  Total Policies: {len(results)}")
+    print(f"  ✅ Valid: {stats['valid_policies']}")
+    print(f"  ❌ Invalid: {stats['invalid_policies']}")
+    print(f"  ⚠️  Total Issues: {stats['total_issues']}")
+
+    # Issue breakdown by severity
+    if stats.get('issues_by_severity'):
+        print(f"\n  Issues by Severity:")
+        for severity, count in stats['issues_by_severity'].items():
+            print(f"    {severity.upper()}: {count}")
+
+    # Exit with appropriate code
+    if all(r.is_valid for r in results):
+        print("\n✅ All policies are valid!")
+        return 0
+    else:
+        print("\n❌ Validation failed!")
+        return 1
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        print("\n⚠️  Interrupted by user")
+        sys.exit(130)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+```
+
+## Configuration Reference
+
+For detailed configuration options, see:
+- [Configuration Guide](configuration.md)
+- [Custom Checks Guide](custom-checks.md)
+- [Examples](../examples/configs/)
+
+## Related Documentation
+
+- **[Complete Documentation (DOCS.md)](../DOCS.md)** - Full user documentation
+- **[Custom Checks Guide](custom-checks.md)** - Creating custom validation rules
+- **[Configuration Reference](configuration.md)** - YAML configuration options
+- **[GitHub Actions Integration](github-actions-workflows.md)** - Using in CI/CD
+- **[AWS Services Backup](aws-services-backup.md)** - Offline validation setup
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/boogy/iam-policy-validator/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/boogy/iam-policy-validator/discussions)
+- **Examples**: [examples/](../examples/) directory

--- a/examples/iam-test-policies/wrong-s3-condition.json
+++ b/examples/iam-test-policies/wrong-s3-condition.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "WrongS3ConditionWithDeny",
+      "Effect": "Deny",
+      "Action": ["s3:CreateBucket"],
+      "Resource": "arn:aws:s3:::testing-*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/owner": "team-a"
+        }
+      }
+    },
+
+    {
+      "Sid": "WrongS3ConditionWithAllow",
+      "Effect": "Allow",
+      "Action": ["s3:CreateBucket"],
+      "Resource": "arn:aws:s3:::testing-*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/owner": "team-a"
+        }
+      }
+    }
+  ]
+}

--- a/examples/library-usage/README.md
+++ b/examples/library-usage/README.md
@@ -1,0 +1,118 @@
+# Python Library Usage Examples
+
+This directory contains practical examples of using IAM Policy Validator as a Python library.
+
+## Examples Overview
+
+### Quick Reference
+
+**[quick_reference.py](quick_reference.py)** - Copy-paste ready code snippets
+- Basic validation
+- Configuration loading
+- Custom checks
+- Filtering results
+- Multiple output formats
+- Batch processing
+- Statistics extraction
+
+### Basic Examples
+
+1. **[example1_basic_usage.py](example1_basic_usage.py)** - Basic validation with default configuration
+   - Simplest way to get started
+   - Uses default built-in checks
+   - Console output
+
+2. **[example2_config_file.py](example2_config_file.py)** - Using a YAML configuration file
+   - Load configuration from file
+   - Configure checks and settings
+   - Production-ready approach
+
+3. **[example3_programmatic_config.py](example3_programmatic_config.py)** - Programmatic configuration
+   - Create config in Python code
+   - Dynamic configuration
+   - Advanced control
+
+## Running the Examples
+
+### Prerequisites
+
+```bash
+# Install the package
+uv add iam-policy-validator
+
+# Or with pip
+pip install iam-policy-validator
+```
+
+### Setup Test Policies
+
+Create a test policy directory:
+
+```bash
+mkdir -p policies
+cat > policies/test-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowS3Read",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::my-bucket/*"
+    }
+  ]
+}
+EOF
+```
+
+### Run Examples
+
+```bash
+# Example 1: Basic usage
+python example1_basic_usage.py
+
+# Example 2: With config file (create iam-validator.yaml first)
+python example2_config_file.py
+
+# Example 3: Programmatic config
+python example3_programmatic_config.py
+```
+
+## Configuration File Example
+
+Create `iam-validator.yaml`:
+
+```yaml
+settings:
+  fail_on_severity: ["error", "critical"]
+  cache_enabled: true
+  cache_ttl_hours: 168
+  parallel_execution: true
+  enable_builtin_checks: true
+
+# Configure built-in checks
+security_best_practices_check:
+  enabled: true
+  severity: high
+
+action_validation_check:
+  enabled: true
+  severity: error
+```
+
+## Complete Documentation
+
+For comprehensive documentation on using the library, see:
+- **[Python Library Usage Guide](../../docs/python-library-usage.md)** - Complete guide with all use cases
+- **[Configuration Reference](../../docs/configuration.md)** - YAML configuration options
+- **[Custom Checks Guide](../../docs/custom-checks.md)** - Creating custom validation rules
+
+## Additional Examples
+
+For more advanced examples, see the main documentation:
+- Custom checks integration
+- Batch processing
+- CI/CD integration
+- Report generation in multiple formats
+- Direct registry control
+- Streaming validation

--- a/examples/library-usage/example1_basic_usage.py
+++ b/examples/library-usage/example1_basic_usage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Example 1: Basic validation with default configuration."""
+
 import asyncio
 
 from iam_validator.core.policy_checks import validate_policies

--- a/examples/library-usage/example1_basic_usage.py
+++ b/examples/library-usage/example1_basic_usage.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Example 1: Basic validation with default configuration."""
+import asyncio
+from pathlib import Path
+
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.report import ReportGenerator
+
+
+async def validate_basic():
+    """Basic validation with default configuration."""
+
+    # Load policies from a directory or file
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/my-policy.json")
+    # Or: policies = loader.load_from_path("./policies/")  # for directory
+
+    # Validate policies (uses default config)
+    results = await validate_policies(policies)
+
+    # Generate and print report
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+    generator.print_console_report(report)
+
+    # Check if validation passed
+    all_valid = all(r.is_valid for r in results)
+    return 0 if all_valid else 1
+
+
+if __name__ == "__main__":
+    # Run it
+    exit_code = asyncio.run(validate_basic())
+    print(f"Exit code: {exit_code}")

--- a/examples/library-usage/example1_basic_usage.py
+++ b/examples/library-usage/example1_basic_usage.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Example 1: Basic validation with default configuration."""
 import asyncio
-from pathlib import Path
 
-from iam_validator.core.policy_loader import PolicyLoader
 from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.policy_loader import PolicyLoader
 from iam_validator.core.report import ReportGenerator
 
 

--- a/examples/library-usage/example2_config_file.py
+++ b/examples/library-usage/example2_config_file.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Example 2: Validate using an explicit configuration file."""
+
 import asyncio
 
 from iam_validator.core.config_loader import ConfigLoader
@@ -13,7 +14,7 @@ async def validate_with_config():
     # Load configuration from file
     ConfigLoader.load_config(
         explicit_path="./iam-validator.yaml",
-        allow_missing=False  # Fail if config not found
+        allow_missing=False,  # Fail if config not found
     )
 
     # Load policies
@@ -24,7 +25,7 @@ async def validate_with_config():
     results = await validate_policies(
         policies,
         config_path="./iam-validator.yaml",
-        use_registry=True  # Use new check registry system
+        use_registry=True,  # Use new check registry system
     )
 
     return results

--- a/examples/library-usage/example2_config_file.py
+++ b/examples/library-usage/example2_config_file.py
@@ -2,16 +2,16 @@
 """Example 2: Validate using an explicit configuration file."""
 import asyncio
 
-from iam_validator.core.policy_loader import PolicyLoader
-from iam_validator.core.policy_checks import validate_policies
 from iam_validator.core.config_loader import ConfigLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.policy_loader import PolicyLoader
 
 
 async def validate_with_config():
     """Validate using an explicit configuration file."""
 
     # Load configuration from file
-    config = ConfigLoader.load_config(
+    ConfigLoader.load_config(
         explicit_path="./iam-validator.yaml",
         allow_missing=False  # Fail if config not found
     )

--- a/examples/library-usage/example2_config_file.py
+++ b/examples/library-usage/example2_config_file.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Example 2: Validate using an explicit configuration file."""
+import asyncio
+
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.config_loader import ConfigLoader
+
+
+async def validate_with_config():
+    """Validate using an explicit configuration file."""
+
+    # Load configuration from file
+    config = ConfigLoader.load_config(
+        explicit_path="./iam-validator.yaml",
+        allow_missing=False  # Fail if config not found
+    )
+
+    # Load policies
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Validate with config
+    results = await validate_policies(
+        policies,
+        config_path="./iam-validator.yaml",
+        use_registry=True  # Use new check registry system
+    )
+
+    return results
+
+
+if __name__ == "__main__":
+    results = asyncio.run(validate_with_config())
+    print(f"Validated {len(results)} policies")

--- a/examples/library-usage/example3_programmatic_config.py
+++ b/examples/library-usage/example3_programmatic_config.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Example 3: Validate with programmatically created configuration."""
+import asyncio
+
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies, _validate_policy_with_registry
+from iam_validator.core.config_loader import ValidatorConfig, ConfigLoader
+from iam_validator.core.check_registry import create_default_registry
+from iam_validator.core.aws_fetcher import AWSServiceFetcher
+
+
+async def validate_programmatic():
+    """Validate with programmatically created configuration."""
+
+    # Create configuration dictionary
+    config_dict = {
+        "settings": {
+            "fail_on_severity": ["error"],
+            "cache_enabled": True,
+            "cache_ttl_hours": 24,
+            "parallel_execution": True,
+        },
+        "security_best_practices_check": {
+            "enabled": True,
+            "severity": "high",
+        },
+        "action_validation_check": {
+            "enabled": True,
+            "severity": "error",
+        },
+    }
+
+    # Create config object
+    config = ValidatorConfig(config_dict, use_defaults=True)
+
+    # Create registry and apply config
+    registry = create_default_registry(
+        enable_parallel=True, include_builtin_checks=True
+    )
+    ConfigLoader.apply_config_to_registry(config, registry)
+
+    # Load policies
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Get settings from config
+    cache_enabled = config.get_setting("cache_enabled", True)
+    cache_ttl_hours = config.get_setting("cache_ttl_hours", 168)
+    fail_on_severities = config.get_setting("fail_on_severity", ["error"])
+
+    # Validate with AWS Service Fetcher
+    async with AWSServiceFetcher(
+        enable_cache=cache_enabled,
+        cache_ttl=cache_ttl_hours * 3600,
+    ) as fetcher:
+        results = []
+        for file_path, policy in policies:
+            result = await _validate_policy_with_registry(
+                policy, file_path, registry, fetcher, fail_on_severities
+            )
+            results.append(result)
+
+    return results
+
+
+if __name__ == "__main__":
+    results = asyncio.run(validate_programmatic())
+    print(f"Validated {len(results)} policies")

--- a/examples/library-usage/example3_programmatic_config.py
+++ b/examples/library-usage/example3_programmatic_config.py
@@ -2,11 +2,11 @@
 """Example 3: Validate with programmatically created configuration."""
 import asyncio
 
-from iam_validator.core.policy_loader import PolicyLoader
-from iam_validator.core.policy_checks import validate_policies, _validate_policy_with_registry
-from iam_validator.core.config_loader import ValidatorConfig, ConfigLoader
-from iam_validator.core.check_registry import create_default_registry
 from iam_validator.core.aws_fetcher import AWSServiceFetcher
+from iam_validator.core.check_registry import create_default_registry
+from iam_validator.core.config_loader import ConfigLoader, ValidatorConfig
+from iam_validator.core.policy_checks import _validate_policy_with_registry
+from iam_validator.core.policy_loader import PolicyLoader
 
 
 async def validate_programmatic():

--- a/examples/library-usage/example3_programmatic_config.py
+++ b/examples/library-usage/example3_programmatic_config.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Example 3: Validate with programmatically created configuration."""
+
 import asyncio
 
 from iam_validator.core.aws_fetcher import AWSServiceFetcher
@@ -34,9 +35,7 @@ async def validate_programmatic():
     config = ValidatorConfig(config_dict, use_defaults=True)
 
     # Create registry and apply config
-    registry = create_default_registry(
-        enable_parallel=True, include_builtin_checks=True
-    )
+    registry = create_default_registry(enable_parallel=True, include_builtin_checks=True)
     ConfigLoader.apply_config_to_registry(config, registry)
 
     # Load policies

--- a/examples/library-usage/quick_reference.py
+++ b/examples/library-usage/quick_reference.py
@@ -2,11 +2,9 @@
 """Quick reference for common IAM Policy Validator library operations."""
 import asyncio
 
-from iam_validator.core.policy_loader import PolicyLoader
 from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.policy_loader import PolicyLoader
 from iam_validator.core.report import ReportGenerator
-from iam_validator.core.config_loader import ConfigLoader
-
 
 # ============================================================================
 # BASIC USAGE
@@ -99,9 +97,9 @@ async def filter_by_severity():
 
 async def generate_multiple_formats():
     """Generate reports in multiple formats."""
-    from iam_validator.core.formatters.json import JsonFormatter
-    from iam_validator.core.formatters.html import HtmlFormatter
     from iam_validator.core.formatters.csv import CsvFormatter
+    from iam_validator.core.formatters.html import HtmlFormatter
+    from iam_validator.core.formatters.json import JsonFormatter
 
     loader = PolicyLoader()
     policies = loader.load_from_path("./policies/")

--- a/examples/library-usage/quick_reference.py
+++ b/examples/library-usage/quick_reference.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Quick reference for common IAM Policy Validator library operations."""
+
 import asyncio
 
 from iam_validator.core.policy_checks import validate_policies
@@ -9,6 +10,7 @@ from iam_validator.core.report import ReportGenerator
 # ============================================================================
 # BASIC USAGE
 # ============================================================================
+
 
 async def basic_validation():
     """Simplest validation with defaults."""
@@ -27,6 +29,7 @@ async def basic_validation():
 # WITH CONFIGURATION
 # ============================================================================
 
+
 async def validation_with_config():
     """Validation with YAML configuration."""
     loader = PolicyLoader()
@@ -34,9 +37,7 @@ async def validation_with_config():
 
     # Load and apply config from file
     results = await validate_policies(
-        policies,
-        config_path="./iam-validator.yaml",
-        use_registry=True
+        policies, config_path="./iam-validator.yaml", use_registry=True
     )
 
     return results
@@ -45,6 +46,7 @@ async def validation_with_config():
 # ============================================================================
 # CUSTOM CHECKS
 # ============================================================================
+
 
 async def validation_with_custom_checks():
     """Validation with custom checks from directory."""
@@ -55,7 +57,7 @@ async def validation_with_custom_checks():
         policies,
         config_path="./iam-validator.yaml",
         use_registry=True,
-        custom_checks_dir="./custom_checks"
+        custom_checks_dir="./custom_checks",
     )
 
     return results
@@ -64,6 +66,7 @@ async def validation_with_custom_checks():
 # ============================================================================
 # FILTERING RESULTS
 # ============================================================================
+
 
 async def filter_by_severity():
     """Filter validation results by severity."""
@@ -78,11 +81,13 @@ async def filter_by_severity():
         for issue in result.issues:
             severity = issue.severity.lower()
             if severity in by_severity:
-                by_severity[severity].append({
-                    "file": result.policy_file,
-                    "message": issue.message,
-                    "line": issue.line_number
-                })
+                by_severity[severity].append(
+                    {
+                        "file": result.policy_file,
+                        "message": issue.message,
+                        "line": issue.line_number,
+                    }
+                )
 
     # Print critical issues only
     for item in by_severity["critical"]:
@@ -94,6 +99,7 @@ async def filter_by_severity():
 # ============================================================================
 # MULTIPLE OUTPUT FORMATS
 # ============================================================================
+
 
 async def generate_multiple_formats():
     """Generate reports in multiple formats."""
@@ -130,6 +136,7 @@ async def generate_multiple_formats():
 # BATCH PROCESSING
 # ============================================================================
 
+
 async def batch_validate_directories():
     """Validate multiple directories."""
     directories = ["./iam-policies/", "./s3-policies/", "./lambda-policies/"]
@@ -153,6 +160,7 @@ async def batch_validate_directories():
 # GET STATISTICS
 # ============================================================================
 
+
 async def get_validation_stats():
     """Get detailed statistics from validation."""
     loader = PolicyLoader()
@@ -171,9 +179,9 @@ async def get_validation_stats():
     print(f"Total Issues: {stats.get('total_issues', 0)}")
 
     # Issues by severity
-    if 'issues_by_severity' in stats:
+    if "issues_by_severity" in stats:
         print("\nIssues by Severity:")
-        for severity, count in stats['issues_by_severity'].items():
+        for severity, count in stats["issues_by_severity"].items():
             print(f"  {severity}: {count}")
 
     return stats

--- a/examples/library-usage/quick_reference.py
+++ b/examples/library-usage/quick_reference.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Quick reference for common IAM Policy Validator library operations."""
+import asyncio
+
+from iam_validator.core.policy_loader import PolicyLoader
+from iam_validator.core.policy_checks import validate_policies
+from iam_validator.core.report import ReportGenerator
+from iam_validator.core.config_loader import ConfigLoader
+
+
+# ============================================================================
+# BASIC USAGE
+# ============================================================================
+
+async def basic_validation():
+    """Simplest validation with defaults."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+    results = await validate_policies(policies)
+
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+    generator.print_console_report(report)
+
+    return all(r.is_valid for r in results)
+
+
+# ============================================================================
+# WITH CONFIGURATION
+# ============================================================================
+
+async def validation_with_config():
+    """Validation with YAML configuration."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    # Load and apply config from file
+    results = await validate_policies(
+        policies,
+        config_path="./iam-validator.yaml",
+        use_registry=True
+    )
+
+    return results
+
+
+# ============================================================================
+# CUSTOM CHECKS
+# ============================================================================
+
+async def validation_with_custom_checks():
+    """Validation with custom checks from directory."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+
+    results = await validate_policies(
+        policies,
+        config_path="./iam-validator.yaml",
+        use_registry=True,
+        custom_checks_dir="./custom_checks"
+    )
+
+    return results
+
+
+# ============================================================================
+# FILTERING RESULTS
+# ============================================================================
+
+async def filter_by_severity():
+    """Filter validation results by severity."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+    results = await validate_policies(policies)
+
+    # Group by severity
+    by_severity = {"critical": [], "error": [], "warning": [], "info": []}
+
+    for result in results:
+        for issue in result.issues:
+            severity = issue.severity.lower()
+            if severity in by_severity:
+                by_severity[severity].append({
+                    "file": result.policy_file,
+                    "message": issue.message,
+                    "line": issue.line_number
+                })
+
+    # Print critical issues only
+    for item in by_severity["critical"]:
+        print(f"CRITICAL: {item['file']}:{item['line']} - {item['message']}")
+
+    return by_severity
+
+
+# ============================================================================
+# MULTIPLE OUTPUT FORMATS
+# ============================================================================
+
+async def generate_multiple_formats():
+    """Generate reports in multiple formats."""
+    from iam_validator.core.formatters.json import JsonFormatter
+    from iam_validator.core.formatters.html import HtmlFormatter
+    from iam_validator.core.formatters.csv import CsvFormatter
+
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+    results = await validate_policies(policies)
+
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+
+    # JSON
+    json_out = JsonFormatter().format(report)
+    with open("report.json", "w") as f:
+        f.write(json_out)
+
+    # HTML
+    html_out = HtmlFormatter().format(report)
+    with open("report.html", "w") as f:
+        f.write(html_out)
+
+    # CSV
+    csv_out = CsvFormatter().format(report)
+    with open("report.csv", "w") as f:
+        f.write(csv_out)
+
+    return report
+
+
+# ============================================================================
+# BATCH PROCESSING
+# ============================================================================
+
+async def batch_validate_directories():
+    """Validate multiple directories."""
+    directories = ["./iam-policies/", "./s3-policies/", "./lambda-policies/"]
+    all_results = []
+
+    loader = PolicyLoader()
+
+    for directory in directories:
+        policies = loader.load_from_path(directory)
+        results = await validate_policies(policies)
+        all_results.extend(results)
+
+        # Progress
+        valid = sum(1 for r in results if r.is_valid)
+        print(f"{directory}: {valid}/{len(results)} valid")
+
+    return all_results
+
+
+# ============================================================================
+# GET STATISTICS
+# ============================================================================
+
+async def get_validation_stats():
+    """Get detailed statistics from validation."""
+    loader = PolicyLoader()
+    policies = loader.load_from_path("./policies/")
+    results = await validate_policies(policies)
+
+    generator = ReportGenerator()
+    report = generator.generate_report(results)
+
+    # Get stats
+    stats = report.get_statistics()
+
+    print(f"Total Policies: {stats.get('total_policies', 0)}")
+    print(f"Valid: {stats.get('valid_policies', 0)}")
+    print(f"Invalid: {stats.get('invalid_policies', 0)}")
+    print(f"Total Issues: {stats.get('total_issues', 0)}")
+
+    # Issues by severity
+    if 'issues_by_severity' in stats:
+        print("\nIssues by Severity:")
+        for severity, count in stats['issues_by_severity'].items():
+            print(f"  {severity}: {count}")
+
+    return stats
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+if __name__ == "__main__":
+    print("IAM Policy Validator - Quick Reference")
+    print("=" * 60)
+
+    # Run basic validation
+    print("\n1. Basic Validation:")
+    is_valid = asyncio.run(basic_validation())
+    print(f"   Result: {'✅ Valid' if is_valid else '❌ Invalid'}")

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,5 +3,5 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __version_info__ = tuple(int(part) for part in __version__.split("."))

--- a/iam_validator/core/defaults.py
+++ b/iam_validator/core/defaults.py
@@ -300,7 +300,7 @@ With specific values:
                 ],
             },
             {
-                "actions": ["s3:PutObject", "s3:DeleteObject", "s3:CreateBucket"],
+                "actions": ["s3:PutObject"],
                 "severity": "medium",
                 "required_conditions": [
                     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iam-policy-validator"
-version = "1.3.0"
+version = "1.3.1"
 description = "Validate AWS IAM policies for correctness and security using AWS Service Reference API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/sync_defaults_from_yaml.py
+++ b/scripts/sync_defaults_from_yaml.py
@@ -95,7 +95,7 @@ def dict_to_python_literal(obj, indent=0, key_quotes='"'):
             return "[]"
 
         # Check if all items are simple (strings, numbers, bools)
-        all_simple = all(isinstance(item, (str, int, float, bool, type(None))) for item in obj)
+        all_simple = all(isinstance(item, str | int | float | bool | type(None)) for item in obj)
 
         if all_simple and len(obj) <= 3:
             # Inline short simple lists
@@ -121,7 +121,7 @@ def dict_to_python_literal(obj, indent=0, key_quotes='"'):
     elif isinstance(obj, bool):
         return "True" if obj else "False"
 
-    elif isinstance(obj, (int, float)):
+    elif isinstance(obj, int | float):
         return str(obj)
 
     elif obj is None:

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "iam-policy-validator"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "iam-policy-validator"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Fixes condition key validation to properly check if global AWS condition keys (like `aws:RequestTag/*`) are actually supported by specific actions
- Previously, any valid global condition key would pass validation regardless of whether the action supports it
- Added comprehensive Python library documentation and examples

## Problem

The validator was accepting policies like this without error:

```json
{
  "Effect": "Allow",
  "Action": ["s3:CreateBucket"],
  "Condition": {
    "StringEquals": {
      "aws:RequestTag/owner": "team-a"
    }
  }
}
```

However, `s3:CreateBucket` does not support `aws:RequestTag` conditions according to AWS service definitions. This would result in a policy that looks valid but doesn't work as expected in AWS.

## Solution

Modified `validate_condition_key()` in `iam_validator/core/aws_fetcher.py` to:

1. Check if a condition key is a valid global AWS key
2. If the action defines specific supported condition keys (`ActionConditionKeys`), verify the global key is explicitly listed
3. Reject global keys that aren't in the action's supported keys list
4. Maintain backward compatibility for actions without defined condition keys

## Changes

### Core Fix
- **[aws_fetcher.py](iam_validator/core/aws_fetcher.py#L798-L855)**: Enhanced `validate_condition_key()` method to validate global keys against action-specific support

### Test Coverage
- **[wrong-s3-condition.json](examples/iam-test-policies/wrong-s3-condition.json)**: Test case demonstrating the fix

### Documentation & Examples
- **[docs/python-library-usage.md](docs/python-library-usage.md)**: Comprehensive Python library usage guide (1000+ lines)
- **[examples/library-usage/](examples/library-usage/)**: Multiple runnable examples showing library usage
- **[README.md](README.md)**: Updated library usage section with corrected imports

### Configuration & Services
- **[default-config.yaml](default-config.yaml)**: Removed overly restrictive S3 condition requirements
- **AWS service definitions**: Synced latest service definitions for aps, bedrock, cognito-idp, emr-containers, iotmanagedintegrations

## Test Results

Before fix:
```
✓ examples/iam-test-policies/wrong-s3-condition.json
  Valid: 1  Security Findings: 1
  Total Issues: 1 (1 security)
```

After fix:
```
✗ examples/iam-test-policies/wrong-s3-condition.json
  Valid: 0  Invalid: 1  Security Findings: 1
  Total Issues: 3 (2 validity, 1 security)
  
  ERROR: Condition key 'aws:RequestTag/owner' is not supported by action 's3:CreateBucket'
```

All 394 existing tests pass ✅

## Impact

This fix prevents false positives in policy validation and helps catch policies that would fail or behave unexpectedly in AWS due to unsupported condition keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)