### PR TITLE
feat: add automatic GitHub PR label management based on severity findings

### DIFF
--- a/examples/configs/full-reference-config.yaml
+++ b/examples/configs/full-reference-config.yaml
@@ -154,6 +154,45 @@ settings:
     # - medium  # Uncomment to fail on medium severity
     # - warning  # Uncomment to fail on IAM validity warnings
 
+  # GitHub PR label mapping based on severity findings
+  # When issues with these severities are found, apply the corresponding labels to the PR
+  # If no issues with these severities exist, remove the labels if present
+  # This helps signal to reviewers if the PR is ready for final review
+  #
+  # Supports both single labels and lists of labels per severity:
+  #
+  # Single label per severity:
+  #   severity_labels:
+  #     error: "iam-validity-error"
+  #     critical: "security-critical"
+  #
+  # Multiple labels per severity:
+  #   severity_labels:
+  #     error: ["iam-error", "needs-fix"]
+  #     critical: ["security-critical", "needs-security-review"]
+  #
+  # Mixed (some single, some multiple):
+  #   severity_labels:
+  #     error: "iam-validity-error"
+  #     critical: ["security-critical", "needs-security-review"]
+  #
+  # Example use cases:
+  #   - Apply multiple labels for better categorization
+  #   - Apply "needs-security-review" when critical/high issues are found
+  #   - Apply "needs-fix" for any validation errors
+  #   - Remove all labels when issues are fixed
+  #
+  # Note: Requires GitHub integration (--github-comment or --github-review flags)
+  # Default: [] (empty list = disabled)
+  severity_labels:
+    error: "iam-validity-error"
+    critical: "iam-security-critical"
+    high: "iam-security-high"
+    # medium: "security-medium"  # Uncomment to label medium severity issues
+    # Multiple labels example:
+    # error: ["iam-validity-error", "needs-fix"]
+    # critical: ["security-critical", "needs-security-review"]
+
   # Template Variable Support (applies to all ARN validation checks)
   #
   # When enabled, the validator is POSITION-AWARE and supports ANY variable name

--- a/examples/configs/github-labels-config.yaml
+++ b/examples/configs/github-labels-config.yaml
@@ -1,0 +1,116 @@
+# ============================================================================
+# IAM Policy Validator - GitHub PR Labels Configuration
+# ============================================================================
+# This configuration demonstrates automatic GitHub PR label management based
+# on validation severity findings.
+#
+# When validation finds issues with configured severities, it automatically
+# applies the corresponding labels to the PR. When those issues are fixed,
+# the labels are removed. This helps reviewers quickly understand the status
+# of the PR without reading through all the validation comments.
+# ============================================================================
+
+settings:
+  # Define which severities should cause the build to fail
+  fail_on_severity:
+    - error      # IAM validity errors (invalid actions, malformed ARNs, etc.)
+    - critical   # Critical security risks (e.g., full wildcard policies)
+    - high       # High severity security issues
+
+  # Map severity levels to GitHub PR labels
+  # When validation finds issues with these severities, it will:
+  #   1. Apply the corresponding label(s) to the PR
+  #   2. Remove the label(s) if no issues with that severity exist
+  #
+  # Supports both single labels and lists of labels per severity:
+  #   - Single: error: "iam-validity-error"
+  #   - Multiple: error: ["iam-validity-error", "needs-fix"]
+  #
+  # This provides visual feedback to reviewers about the PR status:
+  #   - Labels present = issues need to be fixed
+  #   - Labels removed = issues resolved, ready for review
+  severity_labels:
+    error: "iam-validity-error"      # Applied when IAM validity errors found
+    critical: "security-critical"    # Applied when critical security issues found
+    high: "security-high"            # Applied when high severity issues found
+
+    # Example with multiple labels per severity:
+    # error: ["iam-validity-error", "needs-fix"]
+    # critical: ["security-critical", "needs-security-review", "high-priority"]
+    # high: ["security-high", "needs-review"]
+
+# ============================================================================
+# Example GitHub Actions Workflow
+# ============================================================================
+# To use this feature in GitHub Actions:
+#
+# name: Validate IAM Policies
+#
+# on:
+#   pull_request:
+#     paths:
+#       - 'policies/**/*.json'
+#
+# permissions:
+#   contents: read
+#   pull-requests: write    # Required for labels
+#   issues: write          # Required for labels
+#
+# jobs:
+#   validate:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#
+#       - name: Validate IAM Policies
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           GITHUB_REPOSITORY: ${{ github.repository }}
+#           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+#         run: |
+#           pip install iam-policy-validator
+#           iam-validator validate \
+#             --path ./policies/ \
+#             --config examples/configs/github-labels-config.yaml \
+#             --github-comment \
+#             --github-review
+# ============================================================================
+
+# ============================================================================
+# Label Behavior Examples
+# ============================================================================
+# Scenario 1: Initial validation finds issues
+#   - Policy has invalid action (severity: error)
+#   - Policy has wildcard resource (severity: high)
+#   → Labels applied: "iam-validity-error", "security-high"
+#   → Reviewer sees: This PR needs fixes before review
+#
+# Scenario 2: Developer fixes the invalid action
+#   - Only wildcard resource remains (severity: high)
+#   → Labels applied: "security-high"
+#   → Labels removed: "iam-validity-error"
+#   → Reviewer sees: IAM validity is good, but security issue remains
+#
+# Scenario 3: Developer fixes all issues
+#   - No issues found
+#   → All labels removed
+#   → Reviewer sees: Clean PR, ready for final review
+# ============================================================================
+
+# ============================================================================
+# Additional Configuration
+# ============================================================================
+# You can customize individual checks below. For a comprehensive list of
+# all available checks and options, see:
+#   - examples/configs/full-reference-config.yaml
+#   - examples/configs/basic-config.yaml
+#   - examples/configs/strict-security.yaml
+# ============================================================================
+
+# Example: Disable specific checks
+# wildcard_resource:
+#   enabled: false
+
+# Example: Adjust severity levels
+# service_wildcard:
+#   severity: medium  # Default is "high"

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -302,12 +302,17 @@ Examples:
             from iam_validator.core.config.config_loader import ConfigLoader
             from iam_validator.core.pr_commenter import PRCommenter
 
-            # Load config to get fail_on_severity setting
+            # Load config to get fail_on_severity and severity_labels settings
             config = ConfigLoader.load_config(config_path)
             fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+            severity_labels = config.get_setting("severity_labels", {})
 
             async with GitHubIntegration() as github:
-                commenter = PRCommenter(github, fail_on_severities=fail_on_severities)
+                commenter = PRCommenter(
+                    github,
+                    fail_on_severities=fail_on_severities,
+                    severity_labels=severity_labels,
+                )
                 success = await commenter.post_findings_to_pr(
                     report,
                     create_review=getattr(args, "github_review", False),
@@ -426,12 +431,17 @@ Examples:
             from iam_validator.core.config.config_loader import ConfigLoader
             from iam_validator.core.pr_commenter import PRCommenter
 
-            # Load config to get fail_on_severity setting
+            # Load config to get fail_on_severity and severity_labels settings
             config = ConfigLoader.load_config(config_path)
             fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+            severity_labels = config.get_setting("severity_labels", {})
 
             async with GitHubIntegration() as github:
-                commenter = PRCommenter(github, fail_on_severities=fail_on_severities)
+                commenter = PRCommenter(
+                    github,
+                    fail_on_severities=fail_on_severities,
+                    severity_labels=severity_labels,
+                )
                 success = await commenter.post_findings_to_pr(
                     report,
                     create_review=False,  # Already posted per-file reviews in streaming mode

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -75,6 +75,16 @@ DEFAULT_CONFIG = {
         # IAM Validity: error, warning, info
         # Security: critical, high, medium, low
         "fail_on_severity": list(constants.HIGH_SEVERITY_LEVELS),
+        # GitHub PR label mapping based on severity findings
+        # When issues with these severities are found, apply the corresponding labels
+        # If no issues with these severities exist, remove the labels if present
+        # Supports both single labels and lists of labels per severity
+        # Examples:
+        #   Single label per severity: {"error": "iam-validity-error", "critical": "security-critical"}
+        #   Multiple labels per severity: {"error": ["iam-error", "needs-fix"], "critical": ["security-critical", "needs-review"]}
+        #   Mixed: {"error": "iam-validity-error", "critical": ["security-critical", "needs-review"]}
+        # Default: {} (disabled)
+        "severity_labels": {},
     },
     # ========================================================================
     # AWS IAM Validation Checks (17 checks total)

--- a/iam_validator/core/label_manager.py
+++ b/iam_validator/core/label_manager.py
@@ -1,0 +1,197 @@
+"""Label Manager for GitHub PR Labels based on Severity Findings.
+
+This module manages GitHub PR labels based on IAM policy validation severity findings.
+When validation finds issues with specific severities, it applies corresponding labels.
+When those severities are not found, it removes the labels if present.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from iam_validator.core.models import PolicyValidationResult, ValidationReport
+    from iam_validator.integrations.github_integration import GitHubIntegration
+
+logger = logging.getLogger(__name__)
+
+
+class LabelManager:
+    """Manages GitHub PR labels based on severity findings."""
+
+    def __init__(
+        self,
+        github: "GitHubIntegration",
+        severity_labels: dict[str, str | list[str]] | None = None,
+    ):
+        """Initialize label manager.
+
+        Args:
+            github: GitHubIntegration instance for API calls
+            severity_labels: Mapping of severity levels to label name(s)
+                           Supports both single labels and lists of labels per severity.
+                           Examples:
+                             - Single label per severity:
+                               {"error": "iam-validity-error", "critical": "security-critical"}
+                             - Multiple labels per severity:
+                               {"error": ["iam-error", "needs-fix"], "critical": ["security-critical", "needs-security-review"]}
+                             - Mixed:
+                               {"error": "iam-validity-error", "critical": ["security-critical", "needs-review"]}
+        """
+        self.github = github
+        self.severity_labels = severity_labels or {}
+
+    def is_enabled(self) -> bool:
+        """Check if label management is enabled.
+
+        Returns:
+            True if severity_labels is configured and GitHub is configured
+        """
+        return bool(self.severity_labels) and self.github.is_configured()
+
+    def _get_severities_in_results(self, results: list["PolicyValidationResult"]) -> set[str]:
+        """Extract all severity levels found in validation results.
+
+        Args:
+            results: List of PolicyValidationResult objects
+
+        Returns:
+            Set of severity levels found (e.g., {"error", "critical", "high"})
+        """
+        severities = set()
+        for result in results:
+            for issue in result.issues:
+                severities.add(issue.severity)
+        return severities
+
+    def _get_severities_in_report(self, report: "ValidationReport") -> set[str]:
+        """Extract all severity levels found in validation report.
+
+        Args:
+            report: ValidationReport object
+
+        Returns:
+            Set of severity levels found (e.g., {"error", "critical", "high"})
+        """
+        return self._get_severities_in_results(report.results)
+
+    def _determine_labels_to_apply(self, found_severities: set[str]) -> set[str]:
+        """Determine which labels should be applied based on found severities.
+
+        Args:
+            found_severities: Set of severity levels found in validation
+
+        Returns:
+            Set of label names to apply
+        """
+        labels_to_apply = set()
+        for severity, labels in self.severity_labels.items():
+            if severity in found_severities:
+                # Support both single labels and lists of labels
+                if isinstance(labels, list):
+                    labels_to_apply.update(labels)
+                else:
+                    labels_to_apply.add(labels)
+        return labels_to_apply
+
+    def _determine_labels_to_remove(self, found_severities: set[str]) -> set[str]:
+        """Determine which labels should be removed based on missing severities.
+
+        Args:
+            found_severities: Set of severity levels found in validation
+
+        Returns:
+            Set of label names to remove
+        """
+        labels_to_remove = set()
+        for severity, labels in self.severity_labels.items():
+            if severity not in found_severities:
+                # Support both single labels and lists of labels
+                if isinstance(labels, list):
+                    labels_to_remove.update(labels)
+                else:
+                    labels_to_remove.add(labels)
+        return labels_to_remove
+
+    async def manage_labels_from_results(
+        self, results: list["PolicyValidationResult"]
+    ) -> tuple[bool, int, int]:
+        """Manage PR labels based on validation results.
+
+        This method will:
+        1. Determine which severity levels are present in the results
+        2. Add labels for severities that are found
+        3. Remove labels for severities that are not found
+
+        Args:
+            results: List of PolicyValidationResult objects
+
+        Returns:
+            Tuple of (success, labels_added, labels_removed)
+        """
+        if not self.is_enabled():
+            logger.debug("Label management not enabled (no severity_labels configured)")
+            return (True, 0, 0)
+
+        # Get all severities found in results
+        found_severities = self._get_severities_in_results(results)
+        logger.debug(f"Found severities in results: {found_severities}")
+
+        # Determine which labels to apply/remove
+        labels_to_apply = self._determine_labels_to_apply(found_severities)
+        labels_to_remove = self._determine_labels_to_remove(found_severities)
+
+        logger.debug(f"Labels to apply: {labels_to_apply}")
+        logger.debug(f"Labels to remove: {labels_to_remove}")
+
+        # Get current labels on PR
+        current_labels = set(await self.github.get_labels())
+        logger.debug(f"Current PR labels: {current_labels}")
+
+        # Filter: only add labels that aren't already present
+        labels_to_add = labels_to_apply - current_labels
+
+        # Filter: only remove labels that are currently present
+        labels_to_actually_remove = labels_to_remove & current_labels
+
+        success = True
+        added_count = 0
+        removed_count = 0
+
+        # Add new labels
+        if labels_to_add:
+            logger.info(f"Adding labels to PR: {labels_to_add}")
+            if await self.github.add_labels(list(labels_to_add)):
+                added_count = len(labels_to_add)
+            else:
+                logger.error("Failed to add labels to PR")
+                success = False
+
+        # Remove old labels
+        for label in labels_to_actually_remove:
+            logger.info(f"Removing label from PR: {label}")
+            if await self.github.remove_label(label):
+                removed_count += 1
+            else:
+                logger.error(f"Failed to remove label: {label}")
+                success = False
+
+        if added_count > 0 or removed_count > 0:
+            logger.info(f"Label management complete: added {added_count}, removed {removed_count}")
+        else:
+            logger.debug("No label changes needed")
+
+        return (success, added_count, removed_count)
+
+    async def manage_labels_from_report(self, report: "ValidationReport") -> tuple[bool, int, int]:
+        """Manage PR labels based on validation report.
+
+        This is a convenience method that extracts results from the report
+        and calls manage_labels_from_results().
+
+        Args:
+            report: ValidationReport object
+
+        Returns:
+            Tuple of (success, labels_added, labels_removed)
+        """
+        return await self.manage_labels_from_results(report.results)

--- a/tests/test_label_manager.py
+++ b/tests/test_label_manager.py
@@ -1,0 +1,401 @@
+"""Unit tests for Label Manager."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from iam_validator.core.label_manager import LabelManager
+from iam_validator.core.models import (
+    PolicyValidationResult,
+    ValidationIssue,
+    ValidationReport,
+)
+
+
+class TestLabelManager:
+    """Test the LabelManager class."""
+
+    @pytest.fixture
+    def mock_github(self):
+        """Create a mock GitHubIntegration."""
+        mock = MagicMock()
+        mock.is_configured = MagicMock(return_value=True)
+        mock.get_labels = AsyncMock(return_value=[])
+        mock.add_labels = AsyncMock(return_value=True)
+        mock.remove_label = AsyncMock(return_value=True)
+        return mock
+
+    @pytest.fixture
+    def severity_labels(self):
+        """Create a sample severity_labels configuration."""
+        return {
+            "error": "iam-validity-error",
+            "critical": "security-critical",
+            "high": "security-high",
+            "medium": "security-medium",
+        }
+
+    @pytest.fixture
+    def sample_results(self):
+        """Create sample validation results with various severities."""
+        return [
+            PolicyValidationResult(
+                policy_file="policy1.json",
+                policy_name="TestPolicy1",
+                is_valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="error",
+                        statement_index=0,
+                        issue_type="invalid_action",
+                        message="Invalid action",
+                    ),
+                    ValidationIssue(
+                        severity="critical",
+                        statement_index=0,
+                        issue_type="full_wildcard",
+                        message="Full wildcard detected",
+                    ),
+                ],
+            ),
+            PolicyValidationResult(
+                policy_file="policy2.json",
+                policy_name="TestPolicy2",
+                is_valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="high",
+                        statement_index=0,
+                        issue_type="service_wildcard",
+                        message="Service wildcard detected",
+                    ),
+                ],
+            ),
+        ]
+
+    def test_is_enabled_with_config(self, mock_github, severity_labels):
+        """Test is_enabled returns True when configured."""
+        manager = LabelManager(mock_github, severity_labels)
+        assert manager.is_enabled() is True
+
+    def test_is_enabled_without_config(self, mock_github):
+        """Test is_enabled returns False when not configured."""
+        manager = LabelManager(mock_github, {})
+        assert manager.is_enabled() is False
+
+    def test_is_enabled_github_not_configured(self, severity_labels):
+        """Test is_enabled returns False when GitHub is not configured."""
+        mock_github = MagicMock()
+        mock_github.is_configured = MagicMock(return_value=False)
+        manager = LabelManager(mock_github, severity_labels)
+        assert manager.is_enabled() is False
+
+    def test_get_severities_in_results(self, mock_github, severity_labels, sample_results):
+        """Test extracting severities from results."""
+        manager = LabelManager(mock_github, severity_labels)
+        severities = manager._get_severities_in_results(sample_results)
+        assert severities == {"error", "critical", "high"}
+
+    def test_get_severities_empty_results(self, mock_github, severity_labels):
+        """Test extracting severities from empty results."""
+        manager = LabelManager(mock_github, severity_labels)
+        severities = manager._get_severities_in_results([])
+        assert severities == set()
+
+    def test_determine_labels_to_apply(self, mock_github, severity_labels):
+        """Test determining which labels to apply."""
+        manager = LabelManager(mock_github, severity_labels)
+        found_severities = {"error", "critical"}
+        labels = manager._determine_labels_to_apply(found_severities)
+        assert labels == {"iam-validity-error", "security-critical"}
+
+    def test_determine_labels_to_remove(self, mock_github, severity_labels):
+        """Test determining which labels to remove."""
+        manager = LabelManager(mock_github, severity_labels)
+        found_severities = {"error", "critical"}
+        labels = manager._determine_labels_to_remove(found_severities)
+        assert labels == {"security-high", "security-medium"}
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_add_only(self, mock_github, severity_labels, sample_results):
+        """Test adding labels when none are present."""
+        manager = LabelManager(mock_github, severity_labels)
+        mock_github.get_labels = AsyncMock(return_value=[])
+
+        success, added, removed = await manager.manage_labels_from_results(sample_results)
+
+        assert success is True
+        assert added == 3  # error, critical, high
+        assert removed == 0
+        mock_github.add_labels.assert_called_once()
+        # Check that the correct labels were added
+        added_labels = mock_github.add_labels.call_args[0][0]
+        assert set(added_labels) == {"iam-validity-error", "security-critical", "security-high"}
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_remove_only(self, mock_github, severity_labels):
+        """Test removing labels when severities are not found."""
+        manager = LabelManager(mock_github, severity_labels)
+        # Current labels on PR
+        mock_github.get_labels = AsyncMock(
+            return_value=["security-critical", "security-high", "security-medium"]
+        )
+
+        # No issues in results
+        empty_results = [
+            PolicyValidationResult(
+                policy_file="policy.json",
+                policy_name="TestPolicy",
+                is_valid=True,
+                issues=[],
+            )
+        ]
+
+        success, added, removed = await manager.manage_labels_from_results(empty_results)
+
+        assert success is True
+        assert added == 0
+        assert removed == 3
+        assert mock_github.remove_label.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_add_and_remove(self, mock_github, severity_labels, sample_results):
+        """Test adding and removing labels simultaneously."""
+        manager = LabelManager(mock_github, severity_labels)
+        # Current labels include medium (should be removed) but not error, critical, high
+        mock_github.get_labels = AsyncMock(return_value=["security-medium"])
+
+        success, added, removed = await manager.manage_labels_from_results(sample_results)
+
+        assert success is True
+        assert added == 3  # error, critical, high
+        assert removed == 1  # medium
+        mock_github.add_labels.assert_called_once()
+        mock_github.remove_label.assert_called_once_with("security-medium")
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_no_changes_needed(self, mock_github, severity_labels, sample_results):
+        """Test when labels are already correct."""
+        manager = LabelManager(mock_github, severity_labels)
+        # Current labels match exactly what should be there
+        mock_github.get_labels = AsyncMock(
+            return_value=["iam-validity-error", "security-critical", "security-high"]
+        )
+
+        success, added, removed = await manager.manage_labels_from_results(sample_results)
+
+        assert success is True
+        assert added == 0
+        assert removed == 0
+        # Should not call add or remove
+        mock_github.add_labels.assert_not_called()
+        mock_github.remove_label.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_disabled(self, mock_github):
+        """Test that label management is skipped when disabled."""
+        manager = LabelManager(mock_github, {})  # Empty severity_labels
+
+        results = [
+            PolicyValidationResult(
+                policy_file="policy.json",
+                policy_name="TestPolicy",
+                is_valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="error",
+                        statement_index=0,
+                        issue_type="invalid_action",
+                        message="Invalid action",
+                    ),
+                ],
+            )
+        ]
+
+        success, added, removed = await manager.manage_labels_from_results(results)
+
+        assert success is True
+        assert added == 0
+        assert removed == 0
+        # Should not call any GitHub methods
+        mock_github.get_labels.assert_not_called()
+        mock_github.add_labels.assert_not_called()
+        mock_github.remove_label.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_api_failure_add(self, mock_github, severity_labels, sample_results):
+        """Test handling API failure when adding labels."""
+        manager = LabelManager(mock_github, severity_labels)
+        mock_github.get_labels = AsyncMock(return_value=[])
+        mock_github.add_labels = AsyncMock(return_value=False)  # Simulate failure
+
+        success, added, removed = await manager.manage_labels_from_results(sample_results)
+
+        assert success is False
+        assert added == 0
+        assert removed == 0
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_api_failure_remove(self, mock_github, severity_labels):
+        """Test handling API failure when removing labels."""
+        manager = LabelManager(mock_github, severity_labels)
+        mock_github.get_labels = AsyncMock(return_value=["security-medium"])
+        mock_github.remove_label = AsyncMock(return_value=False)  # Simulate failure
+
+        empty_results = [
+            PolicyValidationResult(
+                policy_file="policy.json",
+                policy_name="TestPolicy",
+                is_valid=True,
+                issues=[],
+            )
+        ]
+
+        success, added, removed = await manager.manage_labels_from_results(empty_results)
+
+        assert success is False
+        assert added == 0
+        assert removed == 0
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_from_report(self, mock_github, severity_labels, sample_results):
+        """Test the convenience method that works with ValidationReport."""
+        manager = LabelManager(mock_github, severity_labels)
+        mock_github.get_labels = AsyncMock(return_value=[])
+
+        report = ValidationReport(
+            results=sample_results,
+            total_policies=2,
+            valid_policies=0,
+            invalid_policies=2,
+            total_issues=3,
+        )
+
+        success, added, removed = await manager.manage_labels_from_report(report)
+
+        assert success is True
+        assert added == 3  # error, critical, high
+        assert removed == 0
+
+    def test_severity_not_in_config(self, mock_github, severity_labels, sample_results):
+        """Test that severities not in config are ignored."""
+        # Add a result with a severity not in the config
+        sample_results.append(
+            PolicyValidationResult(
+                policy_file="policy3.json",
+                policy_name="TestPolicy3",
+                is_valid=True,
+                issues=[
+                    ValidationIssue(
+                        severity="info",  # Not in severity_labels config
+                        statement_index=0,
+                        issue_type="informational",
+                        message="Informational message",
+                    ),
+                ],
+            )
+        )
+
+        manager = LabelManager(mock_github, severity_labels)
+        labels = manager._determine_labels_to_apply({"error", "critical", "info"})
+        # "info" should not create a label since it's not in the config
+        assert labels == {"iam-validity-error", "security-critical"}
+
+    # ========== Tests for list support ==========
+
+    @pytest.fixture
+    def severity_labels_with_lists(self):
+        """Create a severity_labels configuration with lists."""
+        return {
+            "error": ["iam-validity-error", "needs-fix"],
+            "critical": ["security-critical", "needs-security-review"],
+            "high": "security-high",  # Mixed: single label
+        }
+
+    def test_determine_labels_to_apply_with_lists(
+        self, mock_github, severity_labels_with_lists
+    ):
+        """Test determining labels when config uses lists."""
+        manager = LabelManager(mock_github, severity_labels_with_lists)
+        found_severities = {"error", "critical"}
+        labels = manager._determine_labels_to_apply(found_severities)
+        assert labels == {
+            "iam-validity-error",
+            "needs-fix",
+            "security-critical",
+            "needs-security-review",
+        }
+
+    def test_determine_labels_to_remove_with_lists(
+        self, mock_github, severity_labels_with_lists
+    ):
+        """Test determining labels to remove when config uses lists."""
+        manager = LabelManager(mock_github, severity_labels_with_lists)
+        found_severities = {"error"}  # critical and high not found
+        labels = manager._determine_labels_to_remove(found_severities)
+        assert labels == {
+            "security-critical",
+            "needs-security-review",
+            "security-high",
+        }
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_with_lists(
+        self, mock_github, severity_labels_with_lists, sample_results
+    ):
+        """Test managing labels when config uses lists."""
+        manager = LabelManager(mock_github, severity_labels_with_lists)
+        mock_github.get_labels = AsyncMock(return_value=[])
+
+        success, added, removed = await manager.manage_labels_from_results(sample_results)
+
+        assert success is True
+        # error (2 labels) + critical (2 labels) + high (1 label) = 5 labels
+        assert added == 5
+        assert removed == 0
+        mock_github.add_labels.assert_called_once()
+        added_labels = set(mock_github.add_labels.call_args[0][0])
+        assert added_labels == {
+            "iam-validity-error",
+            "needs-fix",
+            "security-critical",
+            "needs-security-review",
+            "security-high",
+        }
+
+    @pytest.mark.asyncio
+    async def test_manage_labels_mixed_lists_and_strings(self, mock_github):
+        """Test managing labels with mixed list and string configuration."""
+        mixed_config = {
+            "error": ["iam-error", "needs-fix"],  # List
+            "critical": "security-critical",  # String
+        }
+        manager = LabelManager(mock_github, mixed_config)
+        # Current PR has the critical label which should be removed
+        mock_github.get_labels = AsyncMock(return_value=["security-critical"])
+
+        results = [
+            PolicyValidationResult(
+                policy_file="policy.json",
+                policy_name="TestPolicy",
+                is_valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="error",
+                        statement_index=0,
+                        issue_type="invalid_action",
+                        message="Invalid action",
+                    ),
+                ],
+            )
+        ]
+
+        success, added, removed = await manager.manage_labels_from_results(results)
+
+        assert success is True
+        assert added == 2  # Two labels for error
+        assert removed == 1  # One label for critical (not found)
+        # Check added labels
+        added_labels = set(mock_github.add_labels.call_args[0][0])
+        assert added_labels == {"iam-error", "needs-fix"}
+        # Check removed label
+        mock_github.remove_label.assert_called_once_with("security-critical")


### PR DESCRIPTION
## Summary

This PR adds automatic GitHub PR label management based on IAM policy validation severity findings. Labels are automatically applied when issues are found and removed when issues are resolved, providing visual feedback to reviewers about the PR status.

## Features

✅ **Automatic Label Management** - Labels are applied/removed based on validation results  
✅ **Flexible Configuration** - Support for both single labels and lists of labels per severity  
✅ **Opt-in by Default** - Disabled unless `severity_labels` is configured  
✅ **Backward Compatible** - No breaking changes to existing functionality  
✅ **Well Tested** - 20 comprehensive tests covering all scenarios  

## Configuration

```yaml
settings:
  fail_on_severity:
    - error
    - critical
    - high
  
  # Single label per severity
  severity_labels:
    error: "iam-validity-error"
    critical: "security-critical"
    high: "security-high"
  
  # Or multiple labels per severity
  severity_labels:
    error: ["iam-validity-error", "needs-fix"]
    critical: ["security-critical", "needs-security-review"]
    high: ["security-high", "needs-review"]
```

## Usage Example

When validation finds issues:
- **IAM validity error** → Apply `iam-validity-error` label
- **Critical security issue** → Apply `security-critical` label  
- **High severity issue** → Apply `security-high` label

When issues are fixed:
- **All labels removed** → PR is ready for review ✅

## Changes

### New Files
- `iam_validator/core/label_manager.py` - New LabelManager component (185 lines)
- `tests/test_label_manager.py` - Comprehensive test suite (396 lines, 20 tests)
- `examples/configs/github-labels-config.yaml` - Example configuration with documentation

### Modified Files
- `iam_validator/core/config/defaults.py` - Add `severity_labels` config option
- `iam_validator/core/pr_commenter.py` - Integrate label management
- `iam_validator/commands/validate.py` - Pass severity_labels to PRCommenter
- `examples/configs/full-reference-config.yaml` - Add documentation

## Testing

All tests pass (20 new tests):
- ✅ Single label configuration
- ✅ Multiple labels per severity
- ✅ Mixed single/list configuration
- ✅ Label add/remove scenarios
- ✅ API failure handling
- ✅ Disabled state handling

```bash
uv run pytest tests/test_label_manager.py -v
# 20 passed in 0.13s ⚡
```

## Version

This should be released as **v1.10.0** (minor version bump - new backward-compatible feature)

## Checklist

- [x] Tests added and passing
- [x] Documentation updated
- [x] Example configurations provided
- [x] Backward compatible (no breaking changes)
- [x] Type hints fixed (PolicyValidationResult import)