### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-")[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iam-policy-validator"
-version = "1.9.0"
+version = "1.10.0"
 description = "Validate AWS IAM policies for correctness and security using AWS Service Reference API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump version from 1.9.0 to 1.10.0 following the addition of automatic GitHub PR label management feature based on severity findings.