### PR TITLE
feat: add per-requirement ignore_patterns support in action_condition…

### DIFF
--- a/examples/configs/full-reference-config.yaml
+++ b/examples/configs/full-reference-config.yaml
@@ -38,6 +38,11 @@
 # Every check supports ignore_patterns to filter specific findings while keeping
 # the check enabled. This is more flexible than disabling checks entirely.
 #
+# LEVELS OF IGNORE PATTERNS:
+#   1. Check-level: Applied to ALL requirements/findings in the check
+#   2. Requirement-level: Applied to SPECIFIC requirements only
+#      (Currently supported in: action_condition_enforcement)
+#
 # Pattern Matching Logic:
 #   - Multiple fields in ONE pattern = AND logic (all must match)
 #   - Multiple patterns = OR logic (any pattern matches → ignore)
@@ -861,6 +866,11 @@ action_condition_enforcement:
   #               "iam:PermissionsBoundary": "arn:aws:iam::123456789012:policy/XCompanyBoundaries"
   #             }
   #           }
+  #     # Per-requirement ignore_patterns: Skip this requirement for specific files
+  #     # This allows fine-grained control - other requirements still apply to these files
+  #     ignore_patterns:
+  #       # OpenID roles enforce permission boundary by default, so don't validate it
+  #       - filepath: ".*modules//?iam-openid.*"
   #
   #   # S3 write operations - Require organization ID
   #   - actions:

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.11.1"
+__version__ = "1.12.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
…_enforcement

This feature allows fine-grained control over which requirements are enforced for specific files, while other requirements continue to apply.

Changes:
- Add per-requirement ignore_patterns filtering in action_condition_enforcement
- Support both per-statement and policy-wide (any_of/all_of) checks
- Add _filter_requirement_issues() method for requirement-level filtering
- Update documentation with examples in module docstring
- Update full-reference-config.yaml with per-requirement ignore patterns example
- Add comprehensive tests for per-requirement ignore patterns
- Bump version to 1.12.0

Use Case Example:
  requirements:
    - actions: ["iam:CreateRole", "iam:PutRolePolicy"] required_conditions: - condition_key: "iam:PermissionsBoundary" ignore_patterns: # Skip this requirement for iam-openid modules only - filepath_regex: ".*modules//?iam-openid.*"

    - actions: ["iam:PassRole"] required_conditions:
        - condition_key: "iam:PassedToService" # No ignore patterns - applies to ALL files
