### PR TITLE
fix: use APPROVE review event when validation passes to dismiss REQUEST_CHANGES

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.1"
+__version__ = "1.14.2"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -398,12 +398,15 @@ class PRCommenter:
             logger.info("No inline comments to post (after diff filtering)")
             # Still run cleanup to delete any stale comments from resolved findings
             # (unless skip_cleanup is set for streaming mode)
+            # Use APPROVE event to dismiss any previous REQUEST_CHANGES review
             if validated_files and self.cleanup_old_comments:
-                logger.debug("Running cleanup for stale comments from resolved findings...")
+                logger.debug(
+                    "Running cleanup for stale comments and approving PR (no blocking issues)..."
+                )
                 await self.github.update_or_create_review_comments(
                     comments=[],
                     body="",
-                    event=ReviewEvent.COMMENT,
+                    event=ReviewEvent.APPROVE,
                     identifier=self.REVIEW_IDENTIFIER,
                     validated_files=validated_files,
                     skip_cleanup=False,  # Explicitly run cleanup
@@ -421,7 +424,7 @@ class PRCommenter:
             for issue in result.issues
         )
 
-        event = ReviewEvent.REQUEST_CHANGES if has_blocking_issues else ReviewEvent.COMMENT
+        event = ReviewEvent.REQUEST_CHANGES if has_blocking_issues else ReviewEvent.APPROVE
         logger.info(
             f"Creating PR review with {len(inline_comments)} comments, event: {event.value}"
         )


### PR DESCRIPTION
## Summary

- Fix issue where the "Request Changes" review state wasn't being dismissed when validation issues were fixed
- Change from `ReviewEvent.COMMENT` to `ReviewEvent.APPROVE` when there are no blocking issues
- Bump version to 1.14.2

## Problem

When validation passed (no blocking issues), the GitHub Action was posting a `COMMENT` review instead of an `APPROVE` review. On GitHub:
- `COMMENT` just adds comments but **doesn't change the review state**
- `APPROVE` **dismisses** any previous `REQUEST_CHANGES` review

So when issues were fixed, the bot's previous "Request Changes" would remain.

## Solution

Use `APPROVE` instead of `COMMENT` when there are no blocking issues. This properly clears the previous `REQUEST_CHANGES` state.

## Test plan

- [x] All 848 tests pass
- [ ] Test on a real PR with validation issues, fix them, and verify the "Request Changes" is dismissed