### PR TITLE
fix: add pattern matching for service-specific condition keys with tag validation

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.2"
+__version__ = "1.14.3"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/condition_key_validation.py
+++ b/iam_validator/checks/condition_key_validation.py
@@ -37,7 +37,7 @@ class ConditionKeyValidationCheck(PolicyCheck):
         resources = statement.get_resources()
 
         # Extract all condition keys from all condition operators
-        for operator, conditions in statement.condition.items():
+        for _, conditions in statement.condition.items():
             for condition_key in conditions.keys():
                 # Validate this condition key against each action in the statement
                 for action in actions:

--- a/iam_validator/core/config/aws_global_conditions.py
+++ b/iam_validator/core/config/aws_global_conditions.py
@@ -11,6 +11,8 @@ Last updated: 2025-01-17
 import re
 from typing import Any
 
+from iam_validator.core.constants import AWS_TAG_KEY_ALLOWED_CHARS
+
 # AWS Global Condition Keys with Type Information
 # These condition keys are available for use in IAM policies across all AWS services
 # Format: {key: type} where type is one of: String, ARN, Bool, Date, IPAddress, Numeric
@@ -71,17 +73,18 @@ AWS_GLOBAL_CONDITION_KEYS = {
 
 # Patterns that should be recognized (wildcards and tag-based keys)
 # These allow things like aws:RequestTag/Department or aws:PrincipalTag/Environment
+# Uses centralized tag key character class from constants
 AWS_CONDITION_KEY_PATTERNS = [
     {
-        "pattern": r"^aws:RequestTag/[a-zA-Z0-9+\-=._:/@]+$",
+        "pattern": rf"^aws:RequestTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
         "description": "Tag keys in the request (for tag-based access control)",
     },
     {
-        "pattern": r"^aws:ResourceTag/[a-zA-Z0-9+\-=._:/@]+$",
+        "pattern": rf"^aws:ResourceTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
         "description": "Tags on the resource being accessed",
     },
     {
-        "pattern": r"^aws:PrincipalTag/[a-zA-Z0-9+\-=._:/@]+$",
+        "pattern": rf"^aws:PrincipalTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
         "description": "Tags attached to the principal making the request",
     },
 ]
@@ -154,7 +157,8 @@ _global_conditions_instance = None
 
 def get_global_conditions() -> AWSGlobalConditions:
     """Get singleton instance of AWSGlobalConditions."""
-    global _global_conditions_instance
+    global _global_conditions_instance  # pylint: disable=global-statement
+
     if _global_conditions_instance is None:
         _global_conditions_instance = AWSGlobalConditions()
     return _global_conditions_instance

--- a/iam_validator/core/constants.py
+++ b/iam_validator/core/constants.py
@@ -147,3 +147,32 @@ RCP_SUPPORTED_SERVICES = frozenset(
 
 # AWS Service Authorization Reference (for finding valid actions, resources, and condition keys)
 AWS_SERVICE_AUTH_REF_URL = "https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html"
+
+# ============================================================================
+# AWS Tag Constraints
+# ============================================================================
+# Reference: https://docs.aws.amazon.com/tag-editor/latest/userguide/best-practices-and-strats.html
+
+# --- Tag Key Constraints ---
+# Allowed characters in AWS tag keys: letters, numbers, spaces, and + - = . _ : / @
+# This is the character class for use in regex patterns
+AWS_TAG_KEY_ALLOWED_CHARS = r"a-zA-Z0-9 +\-=._:/@"
+
+# Maximum length for AWS tag keys (per AWS documentation)
+AWS_TAG_KEY_MAX_LENGTH = 128
+
+# Tag-key placeholder patterns used in AWS service definitions
+# These patterns indicate where a tag key should be substituted
+AWS_TAG_KEY_PLACEHOLDERS = ("/tag-key", "/${TagKey}", "/${tag-key}")
+
+# --- Tag Value Constraints ---
+# Allowed characters in AWS tag values: letters, numbers, spaces, and + - = . _ : / @
+# Same character set as tag keys
+AWS_TAG_VALUE_ALLOWED_CHARS = r"a-zA-Z0-9 +\-=._:/@"
+
+# Maximum length for AWS tag values (per AWS documentation)
+# Note: Tag values can be empty (minimum 0), unlike keys which must have at least 1 char
+AWS_TAG_VALUE_MAX_LENGTH = 256
+
+# Minimum length for AWS tag values (can be empty)
+AWS_TAG_VALUE_MIN_LENGTH = 0

--- a/iam_validator/integrations/github_integration.py
+++ b/iam_validator/integrations/github_integration.py
@@ -34,7 +34,7 @@ class GitHubRateLimitError(Exception):
 class GitHubRetryableError(Exception):
     """Raised for transient GitHub API errors that should be retried."""
 
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 # Retry configuration

--- a/tests/checks/test_condition_key_validation_check.py
+++ b/tests/checks/test_condition_key_validation_check.py
@@ -517,34 +517,32 @@ class TestConditionKeyPatternMatching:
         """Integration test: ssm:resourceTag/owner should be valid for ssm:PutParameter."""
         from iam_validator.core.aws_service import AWSServiceFetcher
 
-        fetcher = AWSServiceFetcher()
+        async with AWSServiceFetcher() as fetcher:
+            # Test that ssm:resourceTag/owner is now valid for ssm:PutParameter
+            result = await fetcher.validate_condition_key(
+                "ssm:PutParameter",
+                "ssm:resourceTag/owner",
+                ["arn:aws:ssm:us-east-1:123456789012:parameter/test"],
+            )
 
-        # Test that ssm:resourceTag/owner is now valid for ssm:PutParameter
-        result = await fetcher.validate_condition_key(
-            "ssm:PutParameter",
-            "ssm:resourceTag/owner",
-            ["arn:aws:ssm:us-east-1:123456789012:parameter/test"],
-        )
-
-        assert result.is_valid is True
-        assert result.error_message is None
+            assert result.is_valid is True
+            assert result.error_message is None
 
     @pytest.mark.asyncio
     async def test_invalid_ssm_condition_key(self):
         """Integration test: invalid condition keys should still be rejected."""
         from iam_validator.core.aws_service import AWSServiceFetcher
 
-        fetcher = AWSServiceFetcher()
+        async with AWSServiceFetcher() as fetcher:
+            # Test that truly invalid keys are still rejected
+            result = await fetcher.validate_condition_key(
+                "ssm:PutParameter",
+                "ssm:completelyInvalidKey",
+                ["arn:aws:ssm:us-east-1:123456789012:parameter/test"],
+            )
 
-        # Test that truly invalid keys are still rejected
-        result = await fetcher.validate_condition_key(
-            "ssm:PutParameter",
-            "ssm:completelyInvalidKey",
-            ["arn:aws:ssm:us-east-1:123456789012:parameter/test"],
-        )
-
-        assert result.is_valid is False
-        assert result.error_message is not None
+            assert result.is_valid is False
+            assert result.error_message is not None
 
 
 class TestTagKeyValidation:


### PR DESCRIPTION
## Summary

- Fixes validation of condition keys like `ssm:resourceTag/owner` for actions like `ssm:PutParameter`
- Adds pattern matching for tag-key placeholders in AWS service definitions
- Validates tag key format against AWS constraints (characters and length)
- Centralizes AWS tag key/value constants for consistency

## Problem

The IAM Policy Validator was incorrectly flagging valid condition keys like `ssm:resourceTag/owner` as invalid for `ssm:PutParameter`. This happened because:

1. AWS service definitions use patterns like `ssm:resourceTag/tag-key` as placeholders
2. The validator was doing exact string matching, so `ssm:resourceTag/owner` ≠ `ssm:resourceTag/tag-key`

## Solution

Added pattern matching that recognizes tag-key placeholder patterns:
- `/tag-key`
- `/${TagKey}`
- `/${tag-key}`

When a condition key matches a pattern prefix (e.g., `ssm:resourceTag/`), the validator now:
1. Extracts the tag key portion (`owner`)
2. Validates it against AWS tag key constraints

## AWS Tag Key Constraints

Per [AWS documentation](https://docs.aws.amazon.com/tag-editor/latest/userguide/best-practices-and-strats.html):
- **Allowed characters**: letters, numbers, spaces, and `+ - = . _ : / @`
- **Key length**: 1-128 characters
- **Value length**: 0-256 characters

## Test plan

- [x] Run full test suite (857 passed)
- [x] Verify `ssm:resourceTag/owner` is now valid for `ssm:PutParameter`
- [x] Verify invalid tag keys (wrong chars, too long) are rejected
- [x] Verify exact match condition keys still work
- [x] Verify invalid condition keys are still rejected