### PR TITLE
fix: show pass status and list ignored findings in summary when all blocking issues ignored

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.3"
+__version__ = "1.14.4"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary

- When all blocking issues are ignored via CODEOWNERS reply, the PR summary comment now correctly shows "Validation Passed" instead of "Validation Failed"
- Ignored findings are now listed in a human-readable table in the summary comment, showing file path, issue type, who ignored it, and the reason

## Changes

- Add `IgnoredFindingInfo` dataclass for display purposes in summary
- Add `_are_all_blocking_issues_ignored()` method to check if all blocking issues have been ignored
- Add `_generate_ignored_findings_section()` for human-readable ignored findings list
- Update `generate_github_comment_parts()` and `generate_github_comment()` with new parameters
- Store full ignored findings (not just IDs) for summary display
- Bump version to 1.14.4

## Test plan

- [x] Run existing tests - all 866 pass
- [x] Added 5 new tests for ignored findings display in summary
- [x] Added 4 new tests for `_are_all_blocking_issues_ignored()` method