### PR TITLE
fix: respect ignored findings when managing PR labels and review state

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.4"
+__version__ = "1.14.5"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary

When all findings were ignored by authorized users, the PR labels and review state were not updated to reflect this. This fix ensures:

- **Labels now respect ignored findings**: When all issues are ignored, severity-based labels (like "Rework PR") are removed
- **APPROVE review submitted when all issues are ignored**: When no inline comments exist (all filtered out), an APPROVE review is now submitted to dismiss any previous REQUEST_CHANGES

## Changes

1. **LabelManager** ([label_manager.py](iam_validator/core/label_manager.py))
   - Added `is_issue_ignored` callback parameter to filter out ignored issues
   - Ignored issues are excluded from severity extraction for label determination

2. **PRCommenter** ([pr_commenter.py](iam_validator/core/pr_commenter.py))
   - Pass the ignored findings filter to the label manager

3. **GitHubIntegration** ([github_integration.py](iam_validator/integrations/github_integration.py))
   - Submit APPROVE/REQUEST_CHANGES review even when there are no inline comments
   - This ensures the PR review state is updated when all issues are ignored

4. **Tests** ([test_label_manager.py](tests/integrations/test_label_manager.py))
   - Added 5 new tests for ignored findings filter functionality

## Test plan

- [x] All 871 existing tests pass
- [x] New tests verify:
  - Ignored issues are excluded from label determination
  - When all issues are ignored, corresponding labels are removed
  - Filter correctly receives file paths for matching
  - Filter works through `manage_labels_from_report`