### PR TITLE
fix: separate security findings from validity errors in PR comments

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.4"
+__version__ = "1.14.5"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary
- Display security findings (critical, high) separately from validity errors in Issue Breakdown table and Detailed Findings section
- Remove redundant "Validation complete." message from review body
- Fix malformed HTML comment in review submission (`<!-- <!-- identifier --> -->`)

## Changes

**Before:** All high-severity issues grouped as "🔴 Errors"

**After:**
- 🔴 Errors - validity issues (`error` severity)
- 🟣 Critical - security findings (`critical` severity)
- 🔶 High - security findings (`high` severity)
- 🟡 Warnings - warnings/medium
- 🔵 Info - info/low

## Test plan
- [x] Run existing tests (`uv run pytest tests/ -k "report"`)
- [x] Verify PR comment display with security findings shows correct severity labels