### PR TITLE
fix: separate security findings from validity errors in PR comments

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.5"
+__version__ = "1.14.6"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/integrations/github_integration.py
+++ b/iam_validator/integrations/github_integration.py
@@ -1278,7 +1278,7 @@ class GitHubIntegration:
             logger.info(f"Submitting {event.value} review (no inline comments)")
             success = await self.create_review_with_comments(
                 comments=[],
-                body=body or f"<!-- {identifier} -->\nValidation complete.",
+                body=body,
                 event=event,
             )
             if not success:


### PR DESCRIPTION
- Display security findings (critical, high) separately from validity errors in Issue Breakdown table and Detailed Findings section
- Remove redundant "Validation complete." message from review body
- Fix malformed HTML comment in review submission

Before: All high-severity issues grouped as "🔴 Errors" After:
- 🔴 Errors - validity issues (error)
- 🟣 Critical - security findings (critical)
- 🔶 High - security findings (high)
- 🟡 Warnings - warnings/medium
- 🔵 Info - info/low