### PR TITLE
chore: bump version to 1.14.7

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.14.6"
+__version__ = "1.14.7"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary
- Bump version from 1.14.6 to 1.14.7
- This release updates PyPI metadata with correct links:
  - Documentation: https://boogy.github.io/iam-policy-validator
  - Changelog: https://github.com/boogy/iam-policy-validator/blob/main/CHANGELOG.md

## Changes
- Version bump in `iam_validator/__version__.py`

## Test plan
- [x] CI passes