### PR TITLE
fix: correctly validate aws:RequestTag and aws:ResourceTag as action/…

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/core/aws_service/validators.py
+++ b/iam_validator/core/aws_service/validators.py
@@ -262,7 +262,8 @@ class ServiceValidator:
                 if condition_key_in_list(condition_key, list(service_detail.condition_keys.keys())):
                     # If it's RequestTag or ResourceTag, don't return valid here - check action/resource level
                     if not (
-                        condition_key.startswith("aws:RequestTag/") or condition_key.startswith("aws:ResourceTag/")
+                        condition_key.startswith("aws:RequestTag/")
+                        or condition_key.startswith("aws:ResourceTag/")
                     ):
                         return ConditionKeyValidationResult(is_valid=True)
                     # For RequestTag/ResourceTag, continue to check action/resource level
@@ -410,7 +411,9 @@ class ServiceValidator:
                 error_message=f"Failed to validate condition key: {e!s}",
             )
 
-    def get_resources_for_action(self, action: str, service_detail: ServiceDetail) -> list[dict[str, Any]]:
+    def get_resources_for_action(
+        self, action: str, service_detail: ServiceDetail
+    ) -> list[dict[str, Any]]:
         """Get resource types required for a specific action.
 
         Args:

--- a/iam_validator/core/aws_service/validators.py
+++ b/iam_validator/core/aws_service/validators.py
@@ -243,22 +243,29 @@ class ServiceValidator:
             _, action_name = self._parser.parse_action(action)
 
             # Check if it's a global condition key
+            # Note: Some aws: prefixed keys like aws:RequestTag/* and aws:ResourceTag/* are NOT
+            # global keys - they're action-specific or resource-specific. We'll check those later.
             is_global_key = False
             if condition_key.startswith("aws:"):
                 global_conditions = get_global_conditions()
                 if global_conditions.is_valid_global_key(condition_key):
                     is_global_key = True
-                else:
-                    return ConditionKeyValidationResult(
-                        is_valid=False,
-                        error_message=f"Invalid AWS global condition key: `{condition_key}`.",
-                    )
+                # If not a global key, continue to check action/resource-specific keys
+                # Don't return an error yet - aws:RequestTag, aws:ResourceTag are action-specific
 
             # Check service-specific condition keys (with pattern matching for tag keys)
-            if service_detail.condition_keys and condition_key_in_list(
-                condition_key, list(service_detail.condition_keys.keys())
-            ):
-                return ConditionKeyValidationResult(is_valid=True)
+            # IMPORTANT: aws:RequestTag and aws:ResourceTag patterns in service-level keys
+            # are NOT universally valid for all actions. Skip them here - they'll be checked
+            # at action/resource level.
+            if service_detail.condition_keys:
+                # Check if it matches service-level keys, but exclude RequestTag/ResourceTag
+                if condition_key_in_list(condition_key, list(service_detail.condition_keys.keys())):
+                    # If it's RequestTag or ResourceTag, don't return valid here - check action/resource level
+                    if not (
+                        condition_key.startswith("aws:RequestTag/") or condition_key.startswith("aws:ResourceTag/")
+                    ):
+                        return ConditionKeyValidationResult(is_valid=True)
+                    # For RequestTag/ResourceTag, continue to check action/resource level
 
             # Check action-specific condition keys
             if action_name in service_detail.actions:
@@ -298,8 +305,26 @@ class ServiceValidator:
             if is_global_key:
                 return ConditionKeyValidationResult(is_valid=True)
 
-            # Short error message
-            error_msg = f"Condition key `{condition_key}` is not valid for action `{action}`"
+            # If we reach here, the condition key was not found in any valid location
+            # Check if it's an aws: prefixed key that's not global - provide specific error
+            if condition_key.startswith("aws:"):
+                # Special handling for aws:RequestTag and aws:ResourceTag patterns
+                if condition_key.startswith("aws:RequestTag/"):
+                    error_msg = (
+                        f"Condition key `{condition_key}` is not supported by action `{action}`. "
+                        f"The `aws:RequestTag/${{TagKey}}` condition is only supported by actions that "
+                        f"create or modify resources with tags. This action does not support tag operations."
+                    )
+                elif condition_key.startswith("aws:ResourceTag/"):
+                    error_msg = (
+                        f"Condition key `{condition_key}` is not supported by the resources used by action `{action}`. "
+                        f"The `aws:ResourceTag/${{TagKey}}` condition is only supported by resources that have tags."
+                    )
+                else:
+                    error_msg = f"Invalid AWS condition key: `{condition_key}`. This key is not a valid global condition key and is not supported by action `{action}`."
+            else:
+                # Short error message for non-aws: keys
+                error_msg = f"Condition key `{condition_key}` is not valid for action `{action}`"
 
             # Collect valid condition keys for this action
             valid_keys: set[str] = set()
@@ -385,9 +410,7 @@ class ServiceValidator:
                 error_message=f"Failed to validate condition key: {e!s}",
             )
 
-    def get_resources_for_action(
-        self, action: str, service_detail: ServiceDetail
-    ) -> list[dict[str, Any]]:
+    def get_resources_for_action(self, action: str, service_detail: ServiceDetail) -> list[dict[str, Any]]:
         """Get resource types required for a specific action.
 
         Args:

--- a/iam_validator/core/config/aws_global_conditions.py
+++ b/iam_validator/core/config/aws_global_conditions.py
@@ -85,17 +85,13 @@ GLOBAL_RESOURCE_SCOPING_CONDITION_KEYS = frozenset(
 )
 
 # Patterns that should be recognized (wildcards and tag-based keys)
-# These allow things like aws:RequestTag/Department or aws:PrincipalTag/Environment
+# IMPORTANT: aws:RequestTag and aws:ResourceTag are NOT global condition keys!
+# They are action-specific or resource-specific and must be explicitly listed in
+# the action's ActionConditionKeys or the resource's ConditionKeys.
+# Only aws:PrincipalTag is a true global condition key.
+#
 # Uses centralized tag key character class from constants
 AWS_CONDITION_KEY_PATTERNS = [
-    {
-        "pattern": rf"^aws:RequestTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
-        "description": "Tag keys in the request (for tag-based access control)",
-    },
-    {
-        "pattern": rf"^aws:ResourceTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
-        "description": "Tags on the resource being accessed",
-    },
     {
         "pattern": rf"^aws:PrincipalTag/[{AWS_TAG_KEY_ALLOWED_CHARS}]+$",
         "description": "Tags attached to the principal making the request",


### PR DESCRIPTION
## Summary

Fixes a validation bug where `aws:RequestTag/${TagKey}` and `aws:ResourceTag/${TagKey}` were incorrectly accepted for all actions, when they should only be valid for specific actions and resources that support tagging.

## Problem

`iam:SetDefaultPolicyVersion` with `aws:RequestTag/owner` condition was not being flagged as invalid, even though this action doesn't support the `aws:RequestTag` condition key. Only actions that create or modify tagged resources (like `iam:CreatePolicy`, `iam:CreateRole`, etc.) support `aws:RequestTag`.

## Root Cause

1. **Incorrect classification**: `aws:RequestTag` and `aws:ResourceTag` were listed as "global condition keys" when they are actually action-specific and resource-specific keys
2. **Service-level bypass**: The IAM service lists these keys at the service level, but the validator was treating service-level keys as universally valid for all actions

## Changes

### Core Logic
- **`aws_global_conditions.py`**: Removed `aws:RequestTag` and `aws:ResourceTag` patterns from global condition keys (only `aws:PrincipalTag` remains as a true global pattern)
- **`validators.py`**: Updated validation logic to skip service-level `RequestTag/ResourceTag` patterns and require them to be explicitly listed in action's `ActionConditionKeys` or resource's `ConditionKeys`
- **Error messages**: Added descriptive error messages explaining that these keys are only for tagging operations

### Tests
- Added test for `iam:SetDefaultPolicyVersion` with `aws:RequestTag` (should fail)
- Added test for `iam:CreatePolicy` with `aws:RequestTag` (should pass)
- Updated 5 existing tests in `test_aws_global_conditions.py` to reflect corrected behavior

## Validation

**Before:** iam:SetDefaultPolicyVersion with aws:RequestTag/owner incorrectly passed validation

**After:** Now correctly fails with error: "Condition key `aws:RequestTag/owner` is not supported by action `iam:SetDefaultPolicyVersion`. The `aws:RequestTag/${TagKey}` condition is only supported by actions that create or modify resources with tags."

**Still works correctly:** iam:CreatePolicy with aws:RequestTag/owner correctly passes (CreatePolicy supports tagging)

## Test Results

- All 873 tests pass
- No regressions
- New tests cover both supported and unsupported scenarios

## Version

Bumped to v1.15.1

## References

- AWS IAM Condition Keys Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html
- IAM Actions Reference: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html
