### PR TITLE
fix: enhance security checks for NotAction/NotResource and MFA conditions

### DIFF
--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.15.2"
+__version__ = "1.15.3"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/mfa_condition_check.py
+++ b/iam_validator/checks/mfa_condition_check.py
@@ -75,7 +75,36 @@ class MFAConditionCheck(PolicyCheck):
                         )
                     )
 
-        # Check for anti-pattern #2: Null with aws:MultiFactorAuthPresent = false
+        # Check for anti-pattern #2: BoolIfExists with aws:MultiFactorAuthPresent = false
+        # This is MORE dangerous than Bool because it also matches when the key is missing
+        bool_if_exists_conditions = statement.condition.get("BoolIfExists", {})
+        for key, value in bool_if_exists_conditions.items():
+            if key.lower() == "aws:multifactorauthpresent":
+                # Normalize value to list
+                values = value if isinstance(value, list) else [value]
+                # Convert to lowercase strings for comparison
+                values_lower = [str(v).lower() for v in values]
+
+                if "false" in values_lower or False in values:
+                    issues.append(
+                        ValidationIssue(
+                            severity="high",  # Higher than default - this is worse than Bool
+                            message=(
+                                "**DANGEROUS MFA condition pattern detected.** "
+                                'Using `{"BoolIfExists": {"aws:MultiFactorAuthPresent": "false"}}` '
+                                "is MORE dangerous than using `Bool` because it also matches when "
+                                "the key is missing entirely (no MFA context in the request). "
+                                "This effectively allows access without any MFA verification."
+                            ),
+                            statement_sid=statement_sid,
+                            statement_index=statement_idx,
+                            issue_type="mfa_antipattern_boolif_exists_false",
+                            line_number=line_number,
+                            field_name="condition",
+                        )
+                    )
+
+        # Check for anti-pattern #3: Null with aws:MultiFactorAuthPresent = false
         null_conditions = statement.condition.get("Null", {})
         for key, value in null_conditions.items():
             if key.lower() == "aws:multifactorauthpresent":
@@ -97,6 +126,26 @@ class MFAConditionCheck(PolicyCheck):
                             statement_sid=statement_sid,
                             statement_index=statement_idx,
                             issue_type="mfa_antipattern_null_false",
+                            line_number=line_number,
+                            field_name="condition",
+                        )
+                    )
+
+                # Check for anti-pattern #4: Null with aws:MultiFactorAuthPresent = true
+                # This means "key does NOT exist" = no MFA was used
+                if "true" in values_lower or True in values:
+                    issues.append(
+                        ValidationIssue(
+                            severity=self.get_severity(config),
+                            message=(
+                                "**Dangerous MFA condition pattern detected.** "
+                                'Using `{"Null": {"aws:MultiFactorAuthPresent": "true"}}` checks if the key '
+                                "does NOT exist, which means no MFA was provided in the request context. "
+                                "This condition allows access when MFA is absent."
+                            ),
+                            statement_sid=statement_sid,
+                            statement_index=statement_idx,
+                            issue_type="mfa_antipattern_null_true",
                             line_number=line_number,
                             field_name="condition",
                         )

--- a/tests/checks/test_not_action_not_resource.py
+++ b/tests/checks/test_not_action_not_resource.py
@@ -102,7 +102,13 @@ class TestNotActionNotResourceCheck:
             resource="*",
         )
         issues = await check.execute(statement, 0, mock_fetcher, config)
-        assert len(issues) == 2
+        # Expect 3 issues: NotAction alone, NotResource alone, AND combined critical
+        assert len(issues) == 3
         issue_types = {i.issue_type for i in issues}
         assert "not_action_allow_no_condition" in issue_types
         assert "not_resource_broad" in issue_types
+        assert "combined_not_action_not_resource" in issue_types
+
+        # The combined check should be critical severity
+        combined_issue = next(i for i in issues if i.issue_type == "combined_not_action_not_resource")
+        assert combined_issue.severity == "critical"


### PR DESCRIPTION
## Summary

- Add **critical** severity check when both `NotAction` AND `NotResource` are used together with `Allow` effect (near-administrator access pattern)
- Add detection for `BoolIfExists` with `aws:MultiFactorAuthPresent=false` (more dangerous than `Bool` - matches when key is missing)
- Add detection for `Null` with `aws:MultiFactorAuthPresent=true` (checks if key doesn't exist = no MFA context)
- Update tests to cover new anti-pattern detection
- Improve message formatting with markdown backticks for better GitHub rendering

## Details

### Fix #2: Combined NotAction + NotResource Check

When both `NotAction` AND `NotResource` are used together with `Allow`, it creates near-administrator access:

```json
{
  "Effect": "Allow",
  "NotAction": ["iam:DeleteUser"],
  "NotResource": ["arn:aws:s3:::sensitive-bucket/*"]
}
```

This grants ALL actions (except DeleteUser) on ALL resources (except the sensitive bucket). Now detected with **critical** severity.

### Fix #6: MFA Anti-Pattern Detection

Added two new MFA anti-patterns:

| Pattern | What it means | Severity |
|---------|---------------|----------|
| `BoolIfExists: false` | Matches if MFA=false OR key missing | **high** |
| `Null: true` | Matches if key doesn't exist (no MFA context) | warning |

## Test plan

- [x] All 13 tests for modified checks pass
- [x] Full test suite passes (896 passed)
- [x] Ruff linting passes

## Version

Bumps version to **1.15.3**