### PR TITLE
perf(mcp): optimize MCP server token usage by 38%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ aws_services/
 
 .mcp.json
 .serena
+agent-sync/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,44 @@ iam_validator/
 - **New Command**: Add to `iam_validator/commands/`
 - **New Formatter**: Add to `iam_validator/core/formatters/`
 
+## MCP Tool Docstring Guidelines
+
+When adding or modifying MCP tools in `iam_validator/mcp/server.py`, follow this template:
+
+```python
+@mcp.tool()
+async def tool_name(
+    param1: str,
+    param2: bool = False,
+) -> dict[str, Any]:
+    """One-sentence description of what the tool does.
+
+    [Optional: One line of critical context]
+
+    Args:
+        param1: Description (e.g., "s3:GetObject")
+        param2: Description
+
+    Returns:
+        {field1, field2, field3}
+    """
+```
+
+### Rules
+
+- **Max 300 tokens** per tool docstring (~1200 characters)
+- **Always include format hints** for IAM actions: `(e.g., "s3:GetObject")`
+- **Use simple field lists** for Returns, not nested structures
+- **Don't repeat** BASE_INSTRUCTIONS content in tool docstrings
+- **Keep first sentence descriptive** - it's crucial for tool discovery
+
+### Token Limits
+
+| Component | Max Tokens |
+|-----------|------------|
+| Tool docstring | 300 |
+| BASE_INSTRUCTIONS | 2500 |
+
 ## Getting Help
 
 - [GitHub Issues](https://github.com/boogy/iam-policy-validator/issues)

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.15.5"
+__version__ = "1.15.6"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary

  - Reduce MCP tool docstring verbosity while preserving IAM action format hints
  - Add `verbose` parameter to 10 tools for response size control
  - Add condition guidance for action and resource-level conditions
  - Update CONTRIBUTING.md with MCP docstring guidelines
  - Bump version to 1.15.6

  ## Token Reduction

  | Metric | Before | After | Change |
  |--------|--------|-------|--------|
  | MCP tools total | 9.1k tokens | 5.6k tokens | **-38%** |
  | Context usage | 4.6% | 2.8% | **-39%** |

  ## Changes

  ### Tools with new `verbose` parameter
  - `generate_policy_from_template`
  - `build_minimal_policy`
  - `check_sensitive_actions`
  - `query_service_actions`
  - `list_sensitive_actions`
  - `fix_policy_issues`
  - `explain_policy`
  - `compare_policies`
  - `check_actions_batch`
  - `check_org_compliance`

  ### Condition Guidance
  Added guidance in BASE_INSTRUCTIONS and tool docstrings to check both:
  1. Action-level conditions (`get_required_conditions`)
  2. Resource-level conditions (`query_condition_keys`)

  ## Test plan

  - [x] Verified MCP server loads correctly
  - [x] Tested token usage with `/context` command
  - [x] Confirmed all 35 tools still available