### PR TITLE
feat: add IfExists condition validation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.16.0] - 2026-02-05
+
+### Added
+
+- New `ifexists_condition_usage` check validating proper usage of the `IfExists` suffix on condition operators:
+  - Detects `IfExists` on security-sensitive keys in Allow statements (may bypass controls)
+  - Warns about non-negated `IfExists` weakening Deny statements
+  - Flags redundant `IfExists` on always-present keys (e.g., `aws:SecureTransport`)
+  - Optionally suggests `IfExists` for negated operators in Deny statements
+- Security-sensitive and always-present condition key constants in `condition_validators` module
+
+### Improved
+
+- `condition_key_validation`: Suppress false positive errors when `IfExists` is used with keys valid for some but not all actions in the statement
+- `condition_type_mismatch`: Detect `NullIfExists` as invalid syntax (the `Null` operator already checks for key existence)
+- `set_operator_validation`: Compound warning when `ForAllValues` is combined with `IfExists` (doubly permissive pattern)
+
+---
+
 ## [1.15.5] - 2025-01-28
 
 ### Fixed

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.15.6"
+__version__ = "1.16.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/__init__.py
+++ b/iam_validator/checks/__init__.py
@@ -10,6 +10,7 @@ from iam_validator.checks.action_validation import ActionValidationCheck
 from iam_validator.checks.condition_key_validation import ConditionKeyValidationCheck
 from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
 from iam_validator.checks.full_wildcard import FullWildcardCheck
+from iam_validator.checks.ifexists_condition_check import IfExistsConditionCheck
 from iam_validator.checks.mfa_condition_check import MFAConditionCheck
 from iam_validator.checks.not_action_not_resource import NotActionNotResourceCheck
 from iam_validator.checks.policy_size import PolicySizeCheck
@@ -31,6 +32,7 @@ __all__ = [
     "ConditionKeyValidationCheck",
     "ConditionTypeMismatchCheck",
     "FullWildcardCheck",
+    "IfExistsConditionCheck",
     "MFAConditionCheck",
     "NotActionNotResourceCheck",
     "PolicySizeCheck",

--- a/iam_validator/checks/ifexists_condition_check.py
+++ b/iam_validator/checks/ifexists_condition_check.py
@@ -1,0 +1,210 @@
+"""IfExists Condition Usage Check.
+
+Validates proper usage of the IfExists suffix on IAM condition operators.
+
+Detects:
+- IfExists on security-sensitive keys in Allow statements (may bypass controls)
+- Non-negated IfExists in Deny statements (weakens the Deny)
+- IfExists on always-present keys (redundant)
+- Suggests IfExists for negated operators in Deny without it
+"""
+
+from typing import ClassVar
+
+from iam_validator.core.aws_service import AWSServiceFetcher
+from iam_validator.core.check_registry import CheckConfig, PolicyCheck
+from iam_validator.core.condition_validators import (
+    ALWAYS_PRESENT_CONDITION_KEYS,
+    SECURITY_SENSITIVE_CONDITION_KEYS,
+    has_if_exists_suffix,
+    is_negated_operator,
+    normalize_operator,
+)
+from iam_validator.core.models import Statement, ValidationIssue
+
+
+class IfExistsConditionCheck(PolicyCheck):
+    """Check for improper or risky usage of IfExists condition operators."""
+
+    check_id: ClassVar[str] = "ifexists_condition_usage"
+    description: ClassVar[str] = "Validates proper usage of IfExists suffix on condition operators"
+    default_severity: ClassVar[str] = "warning"
+
+    async def execute(
+        self,
+        statement: Statement,
+        statement_idx: int,
+        fetcher: AWSServiceFetcher,
+        config: CheckConfig,
+    ) -> list[ValidationIssue]:
+        """Execute IfExists condition usage checks."""
+        issues: list[ValidationIssue] = []
+
+        if not statement.condition:
+            return issues
+
+        statement_sid = statement.sid
+        line_number = statement.line_number
+        effect = statement.effect
+
+        # Config options
+        warn_security_sensitive_allow = config.config.get("warn_security_sensitive_allow", True)
+        suggest_deny_ifexists = config.config.get("suggest_deny_ifexists", False)
+        warn_always_present_keys = config.config.get("warn_always_present_keys", True)
+        additional_security_keys = config.config.get("additional_security_sensitive_keys", [])
+
+        # Build the full set of security-sensitive keys
+        security_keys = SECURITY_SENSITIVE_CONDITION_KEYS | frozenset(additional_security_keys)
+
+        # Collect Null-checked keys for suppression
+        null_checked_keys: set[str] = set()
+        for op, conds in statement.condition.items():
+            base_op, _, _ = normalize_operator(op)
+            if base_op == "Null":
+                for key, value in conds.items():
+                    # Only suppress if Null checks for key presence (value = "false")
+                    values = value if isinstance(value, list) else [value]
+                    if any(str(v).lower() == "false" for v in values):
+                        null_checked_keys.add(key)
+
+        for operator, conditions in statement.condition.items():
+            has_ifexists = has_if_exists_suffix(operator)
+            is_negated = is_negated_operator(operator)
+            base_op, _, _ = normalize_operator(operator)
+
+            for condition_key in conditions:
+                # Normalize condition key for case-insensitive comparison
+                key_lower = condition_key.lower()
+
+                # Skip MFA key - handled by mfa_condition_antipattern check
+                if key_lower == "aws:multifactorauthpresent":
+                    continue
+
+                if has_ifexists:
+                    # IfExists on always-present keys is redundant
+                    if warn_always_present_keys:
+                        always_present_match = any(
+                            k.lower() == key_lower for k in ALWAYS_PRESENT_CONDITION_KEYS
+                        )
+                        if always_present_match:
+                            # Reconstruct the operator without IfExists for the message
+                            raw_base = operator
+                            if ":" in operator:
+                                parts = operator.split(":", 1)
+                                if parts[0] in ("ForAllValues", "ForAnyValue"):
+                                    raw_base = parts[1]
+                            base_without_ifexists = (
+                                raw_base[:-8] if raw_base.endswith("IfExists") else raw_base
+                            )
+                            if ":" in operator:
+                                parts = operator.split(":", 1)
+                                if parts[0] in ("ForAllValues", "ForAnyValue"):
+                                    base_without_ifexists = f"{parts[0]}:{base_without_ifexists}"
+
+                            issues.append(
+                                ValidationIssue(
+                                    severity="info",
+                                    message=(
+                                        f"Redundant `IfExists`: The condition key "
+                                        f"`{condition_key}` is always present in the "
+                                        f"request context. Using `{operator}` has the "
+                                        f"same effect as `{base_without_ifexists}` for "
+                                        f"this key."
+                                    ),
+                                    statement_sid=statement_sid,
+                                    statement_index=statement_idx,
+                                    issue_type="ifexists_on_always_present_key",
+                                    condition_key=condition_key,
+                                    line_number=line_number,
+                                    field_name="condition",
+                                )
+                            )
+
+                    # Check if key is security-sensitive (case-insensitive)
+                    is_security_key = any(k.lower() == key_lower for k in security_keys)
+
+                    if effect == "Allow" and warn_security_sensitive_allow:
+                        # IfExists on security-sensitive keys in Allow may bypass controls
+                        if is_security_key:
+                            # Check for complementary Null check
+                            if condition_key not in null_checked_keys:
+                                issues.append(
+                                    ValidationIssue(
+                                        severity=self.get_severity(config),
+                                        message=(
+                                            f"Security control may be bypassed: "
+                                            f"`{operator}` with `{condition_key}` in "
+                                            f"an Allow statement means the restriction "
+                                            f"is not enforced when the key is missing "
+                                            f"from the request context. Not all API "
+                                            f"calls include `{condition_key}` (e.g., "
+                                            f"calls made by AWS services on your "
+                                            f"behalf). Consider using the operator "
+                                            f"without `IfExists` or adding a `Null` "
+                                            f"condition check."
+                                        ),
+                                        statement_sid=statement_sid,
+                                        statement_index=statement_idx,
+                                        issue_type="ifexists_weakens_security_condition",
+                                        condition_key=condition_key,
+                                        line_number=line_number,
+                                        field_name="condition",
+                                    )
+                                )
+
+                    elif effect == "Deny":
+                        # Non-negated IfExists in Deny weakens the restriction
+                        if not is_negated and is_security_key:
+                            if condition_key not in null_checked_keys:
+                                issues.append(
+                                    ValidationIssue(
+                                        severity=self.get_severity(config),
+                                        message=(
+                                            f"Weakened Deny: `{operator}` with "
+                                            f"`{condition_key}` in a Deny statement "
+                                            f"means the Deny does not apply when "
+                                            f"`{condition_key}` is missing from the "
+                                            f"request context. Consider removing "
+                                            f"`IfExists` or adding a `Null` condition "
+                                            f"check."
+                                        ),
+                                        statement_sid=statement_sid,
+                                        statement_index=statement_idx,
+                                        issue_type="ifexists_weakens_deny",
+                                        condition_key=condition_key,
+                                        line_number=line_number,
+                                        field_name="condition",
+                                    )
+                                )
+
+                elif not has_ifexists and effect == "Deny" and suggest_deny_ifexists:
+                    # Suggest IfExists for negated operator in Deny without it
+                    if is_negated:
+                        # Only suggest for keys that may be absent
+                        is_always_present = any(
+                            k.lower() == key_lower for k in ALWAYS_PRESENT_CONDITION_KEYS
+                        )
+                        is_security_key = any(k.lower() == key_lower for k in security_keys)
+                        if not is_always_present and is_security_key:
+                            issues.append(
+                                ValidationIssue(
+                                    severity="info",
+                                    message=(
+                                        f"Consider using `{base_op}IfExists` instead "
+                                        f"of `{base_op}` in this Deny statement. "
+                                        f"Without `IfExists`, the Deny does not apply "
+                                        f"when `{condition_key}` is missing from the "
+                                        f"request context. With `{base_op}IfExists`, "
+                                        f"the Deny still applies even when the key is "
+                                        f"absent."
+                                    ),
+                                    statement_sid=statement_sid,
+                                    statement_index=statement_idx,
+                                    issue_type="ifexists_deny_suggestion",
+                                    condition_key=condition_key,
+                                    line_number=line_number,
+                                    field_name="condition",
+                                )
+                            )
+
+        return issues

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -706,6 +706,7 @@ def create_default_registry(
         # 3. TYPE VALIDATION (Condition operator type checking)
         registry.register(checks.ConditionTypeMismatchCheck())  # Operator-value type compatibility
         registry.register(checks.SetOperatorValidationCheck())  # ForAllValues/ForAnyValue usage
+        registry.register(checks.IfExistsConditionCheck())  # IfExists usage validation
 
         # 4. RESOURCE MATCHING (Action-resource relationship validation)
         registry.register(

--- a/tests/checks/test_ifexists_condition_check.py
+++ b/tests/checks/test_ifexists_condition_check.py
@@ -1,0 +1,342 @@
+"""Tests for IfExists condition usage check."""
+
+import pytest
+
+from iam_validator.checks.ifexists_condition_check import IfExistsConditionCheck
+from iam_validator.core.check_registry import CheckConfig
+from iam_validator.core.models import Statement
+
+
+class TestIfExistsSecuritySensitiveAllow:
+    """Test IfExists on security-sensitive keys in Allow statements."""
+
+    @pytest.fixture
+    def check(self):
+        return IfExistsConditionCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(check_id="ifexists_condition_usage")
+
+    @pytest.mark.asyncio
+    async def test_ifexists_source_ip_allow_warns(self, check, config):
+        """IfExists on SourceIp in Allow should warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={"IpAddressIfExists": {"aws:SourceIp": "10.0.0.0/8"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "ifexists_weakens_security_condition"
+        assert "aws:SourceIp" in issues[0].message
+        assert "bypassed" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_no_ifexists_source_ip_allow_no_warn(self, check, config):
+        """IpAddress without IfExists on SourceIp in Allow should not warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={"IpAddress": {"aws:SourceIp": "10.0.0.0/8"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert len(issues) == 0
+
+    @pytest.mark.asyncio
+    async def test_ifexists_source_ip_deny_no_security_warn(self, check, config):
+        """IfExists on SourceIp in Deny should not warn about security bypass."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={"IpAddressIfExists": {"aws:SourceIp": "10.0.0.0/8"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        # Should not have Allow-specific warning
+        assert not any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_ifexists_secure_transport_allow_redundant(self, check, config):
+        """IfExists on SecureTransport (always-present) should flag as redundant, not security."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::mybucket/*"],
+            Condition={"BoolIfExists": {"aws:SecureTransport": "true"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        # SecureTransport is always present, so IfExists is redundant (not a security bypass)
+        assert not any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+        assert any(
+            i.issue_type == "ifexists_on_always_present_key" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_ifexists_principal_arn_allow_warns(self, check, config):
+        """IfExists on PrincipalArn (absent for anonymous) in Allow should warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={
+                "ArnLikeIfExists": {
+                    "aws:PrincipalArn": "arn:aws:iam::123:role/*"
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_ifexists_non_security_key_allow_no_warn(self, check, config):
+        """IfExists on non-security key in Allow should not warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["ec2:RunInstances"],
+            Resource=["*"],
+            Condition={"StringLikeIfExists": {"ec2:InstanceType": ["t3.*"]}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_ifexists_with_null_check_suppresses_warning(self, check, config):
+        """IfExists with complementary Null check should not warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={
+                "IpAddressIfExists": {"aws:SourceIp": "10.0.0.0/8"},
+                "Null": {"aws:SourceIp": "false"},
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_ifexists_mfa_key_skipped(self, check, config):
+        """IfExists on MultiFactorAuthPresent should be skipped (handled by mfa check)."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["*"],
+            Resource=["*"],
+            Condition={"BoolIfExists": {"aws:MultiFactorAuthPresent": "false"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_forallvalues_ifexists_security_key_warns(self, check, config):
+        """ForAllValues:StringEqualsIfExists on security key should warn."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={
+                "ForAllValues:StringEqualsIfExists": {
+                    "aws:PrincipalOrgPaths": ["o-123/r-abc/"]
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert any(
+            i.issue_type == "ifexists_weakens_security_condition" for i in issues
+        )
+
+
+class TestIfExistsDenyPatterns:
+    """Test IfExists patterns in Deny statements."""
+
+    @pytest.fixture
+    def check(self):
+        return IfExistsConditionCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(
+            check_id="ifexists_condition_usage",
+            config={"suggest_deny_ifexists": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_negated_ifexists_deny_no_warning(self, check, config):
+        """Negated IfExists in Deny is safe, no warning."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={
+                "StringNotEqualsIfExists": {"aws:PrincipalOrgID": "o-123456"}
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(i.issue_type == "ifexists_weakens_deny" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_non_negated_ifexists_deny_warns(self, check, config):
+        """Non-negated IfExists in Deny weakens the Deny, should warn."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:DeleteBucket"],
+            Resource=["*"],
+            Condition={
+                "StringEqualsIfExists": {"aws:SourceVpc": "vpc-123456"}
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert any(i.issue_type == "ifexists_weakens_deny" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_suggest_ifexists_for_negated_deny_without_it(self, check, config):
+        """Should suggest adding IfExists for negated operator in Deny."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={"StringNotEquals": {"aws:SourceVpc": "vpc-123456"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert any(i.issue_type == "ifexists_deny_suggestion" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_no_suggestion_for_always_present_key(self, check, config):
+        """Should not suggest IfExists for always-present keys."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={
+                "StringNotEquals": {
+                    "aws:PrincipalAccount": "123456789012"
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(i.issue_type == "ifexists_deny_suggestion" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_suggestion_disabled_by_config(self, check):
+        """Deny suggestions disabled when config is off."""
+        config = CheckConfig(
+            check_id="ifexists_condition_usage",
+            config={"suggest_deny_ifexists": False},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={"StringNotEquals": {"aws:SourceVpc": "vpc-123456"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(i.issue_type == "ifexists_deny_suggestion" for i in issues)
+
+
+class TestIfExistsAlwaysPresentKeys:
+    """Test IfExists on always-present condition keys."""
+
+    @pytest.fixture
+    def check(self):
+        return IfExistsConditionCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(check_id="ifexists_condition_usage")
+
+    @pytest.mark.asyncio
+    async def test_ifexists_principal_account_redundant(self, check, config):
+        """IfExists on PrincipalAccount should flag as redundant."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={
+                "StringEqualsIfExists": {
+                    "aws:PrincipalAccount": "123456789012"
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        redundant = [
+            i for i in issues if i.issue_type == "ifexists_on_always_present_key"
+        ]
+        assert len(redundant) == 1
+        assert "always present" in redundant[0].message
+        assert "StringEquals" in redundant[0].message
+
+    @pytest.mark.asyncio
+    async def test_ifexists_on_sometimes_absent_key_no_redundant(self, check, config):
+        """IfExists on sometimes-absent key should not flag as redundant."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["ec2:RunInstances"],
+            Resource=["*"],
+            Condition={
+                "StringLikeIfExists": {"ec2:InstanceType": ["t3.*"]}
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(
+            i.issue_type == "ifexists_on_always_present_key" for i in issues
+        )
+
+    @pytest.mark.asyncio
+    async def test_warn_always_present_disabled(self, check):
+        """Should not warn when config disables it."""
+        config = CheckConfig(
+            check_id="ifexists_condition_usage",
+            config={"warn_always_present_keys": False},
+        )
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={
+                "StringEqualsIfExists": {
+                    "aws:PrincipalAccount": "123456789012"
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert not any(
+            i.issue_type == "ifexists_on_always_present_key" for i in issues
+        )
+
+
+class TestCheckMetadata:
+    """Test check metadata."""
+
+    def test_check_id(self):
+        check = IfExistsConditionCheck()
+        assert check.check_id == "ifexists_condition_usage"
+
+    def test_default_severity(self):
+        check = IfExistsConditionCheck()
+        assert check.default_severity == "warning"
+
+    @pytest.mark.asyncio
+    async def test_no_conditions_returns_empty(self):
+        check = IfExistsConditionCheck()
+        config = CheckConfig(check_id="ifexists_condition_usage")
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert len(issues) == 0


### PR DESCRIPTION
## Summary

- Add new `ifexists_condition_usage` check that validates proper usage of the `IfExists` suffix on IAM condition operators
- Enhance existing condition checks to handle `IfExists` interactions correctly
- Detect `NullIfExists` as invalid syntax and warn about `ForAllValues` + `IfExists` compound risk

## Changes

**New check: `ifexists_condition_check.py`**
- Detects `IfExists` on security-sensitive keys in Allow statements (bypasses controls when key is absent)
- Warns about non-negated `IfExists` weakening Deny statements
- Flags redundant `IfExists` on always-present keys (e.g., `aws:SecureTransport`, `aws:CurrentTime`)
- Optionally suggests `IfExists` for negated operators in Deny statements

**Enhanced existing checks:**
- `condition_key_validation`: Suppress false positive condition key errors when `IfExists` is used with keys valid for some but not all actions
- `condition_type_mismatch`: Detect `NullIfExists` as invalid syntax (Null already checks existence)
- `set_operator_validation`: Compound warning when `ForAllValues` + `IfExists` used without `Null` check (doubly permissive)

**Core additions:**
- `has_if_exists_suffix()` utility in `condition_validators.py`
- `SECURITY_SENSITIVE_CONDITION_KEYS` and `ALWAYS_PRESENT_CONDITION_KEYS` constants

## Testing

- [x] All 927 existing tests pass
- [x] 20 new tests for `IfExistsConditionCheck` covering Allow, Deny, redundant, and config scenarios
- [x] 4 new tests for `NullIfExists` detection in condition type mismatch
- [x] 4 new tests for IfExists false positive suppression in condition key validation
- [x] 3 new tests for ForAllValues + IfExists compound warning
- [x] `ruff format` and `ruff check` pass

## Checklist

- [x] Code follows project style guidelines
- [x] CHANGELOG.md updated
- [x] Version bumped to 1.16.0