### PR TITLE
feat: add off_diff_comment_mode, fix condition key false positives, improve PolicyCheck API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.17.1] - 2026-02-27
+## [1.18.0] - 2026-02-27
 
 ### Added
 
@@ -488,7 +488,7 @@ _First release._
 
 ---
 
-[1.17.1]: https://github.com/boogy/iam-policy-validator/compare/v1.17.0...v1.17.1
+[1.18.0]: https://github.com/boogy/iam-policy-validator/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/boogy/iam-policy-validator/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/boogy/iam-policy-validator/compare/v1.15.5...v1.16.0
 [1.15.5]: https://github.com/boogy/iam-policy-validator/compare/v1.15.4...v1.15.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2026-02-27
+
+### Fixed
+
+- Fix `set_operator_validation` false positive on multivalued service condition keys — look up `Types` metadata from AWS service definitions (`ArrayOfString` etc.) instead of relying solely on hardcoded allowlist
+- Fix `wildcard_resource` false positive when ABAC tag conditions scope `Resource: "*"` — unify detection to cover `aws:ResourceTag/*`, `aws:RequestTag/*`, `aws:TagKeys`, `s3:ExistingObjectTag/*`, and any service-specific tag condition key, validated against AWS service definitions
+- Fix off-diff PR comments posting duplicates on re-runs — deduplicate via fingerprint, skip unchanged comments, update modified ones
+
+---
+
 ## [1.17.0] - 2026-02-08
 
 ### Changed
@@ -463,6 +473,7 @@ _First release._
 
 ---
 
+[1.17.1]: https://github.com/boogy/iam-policy-validator/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/boogy/iam-policy-validator/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/boogy/iam-policy-validator/compare/v1.15.5...v1.16.0
 [1.15.5]: https://github.com/boogy/iam-policy-validator/compare/v1.15.4...v1.15.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.17.1] - 2026-02-27
 
+### Added
+
+- Add `off_diff_comment_mode` setting to control how findings on unchanged lines are surfaced in PRs — supports `summary_only` (default), `individual`, and `modified_statements_only` modes
+- Add `--off-diff-comment-mode` CLI argument for `validate` and `post-to-pr` commands
+- Add `off-diff-comment-mode` input to GitHub Action
+
+### Changed
+
+- Change default off-diff behavior from posting individual review comments to consolidating in the summary table (`summary_only`), reducing PR noise for large policies
+- Change `check_id`, `description`, and `default_severity` annotations in `PolicyCheck` base class from `@property` to `ClassVar[str]` to resolve IDE warnings when subclasses use `ClassVar` overrides
+
 ### Fixed
 
+- Fix `condition_key_in_list` false positive on tag keys containing `/` (e.g., `aws:ResourceTag/team/project-owner`) — use pattern prefix length instead of `rfind("/")` which split at the wrong `/`
+- Fix `condition_type_mismatch` and `set_operator_validation` failing to resolve types for compound tag keys — replace exact `in` lookups on pattern dicts with `find_matching_condition_key()`
 - Fix `set_operator_validation` false positive on multivalued service condition keys — look up `Types` metadata from AWS service definitions (`ArrayOfString` etc.) instead of relying solely on hardcoded allowlist
 - Fix `wildcard_resource` false positive when ABAC tag conditions scope `Resource: "*"` — unify detection to cover `aws:ResourceTag/*`, `aws:RequestTag/*`, `aws:TagKeys`, `s3:ExistingObjectTag/*`, and any service-specific tag condition key, validated against AWS service definitions
 - Fix off-diff PR comments posting duplicates on re-runs — deduplicate via fingerprint, skip unchanged comments, update modified ones
+- Fix off-diff PR comment silently lost when `update_review_comment` fails — fall back to summary table
+- Fix `CheckDocumentation` breaking custom check loading when `short_description` field is missing — make optional with `kw_only=True` to prevent silent positional argument swapping
 
 ---
 

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,11 @@ inputs:
     required: false
     default: "true"
 
+  off-diff-comment-mode:
+    description: "How to handle findings on unchanged lines: 'summary_only' (default), 'individual', or 'modified_statements_only'"
+    required: false
+    default: "summary_only"
+
   allow-owner-ignore:
     description: "Allow CODEOWNERS to ignore findings by replying 'ignore' to review comments"
     required: false
@@ -494,6 +499,11 @@ runs:
         # Add owner-ignore flag (default is enabled, so only add flag when disabled)
         if [ "${{ inputs.allow-owner-ignore }}" = "false" ]; then
           ARGS="$ARGS --no-owner-ignore"
+        fi
+
+        # Add off-diff comment mode (only add flag when not the default)
+        if [ -n "${{ inputs.off-diff-comment-mode }}" ] && [ "${{ inputs.off-diff-comment-mode }}" != "summary_only" ]; then
+          ARGS="$ARGS --off-diff-comment-mode ${{ inputs.off-diff-comment-mode }}"
         fi
 
         # Create temp file for JSON metrics extraction

--- a/examples/configs/full-reference-config.yaml
+++ b/examples/configs/full-reference-config.yaml
@@ -166,6 +166,19 @@ settings:
   # Example: ["low", "info"] - hide low and info severity findings
   hide_severities: None
 
+  # How to handle findings on lines outside the PR diff
+  # Controls whether off-diff issues get individual review comments or are
+  # consolidated in the summary table. Reduces PR noise for large policies
+  # where only a small section changed.
+  #
+  # Available modes:
+  #   summary_only:              Show in summary table only (default, least noise)
+  #   individual:                Post each as an individual review comment
+  #   modified_statements_only:  Individual comments for issues in modified
+  #                              statements only; unchanged statement issues
+  #                              go to summary
+  off_diff_comment_mode: summary_only
+
   # GitHub PR label mapping based on severity findings
   # When issues with these severities are found, apply the corresponding labels to the PR
   # If no issues with these severities exist, remove the labels if present

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.17.1"
+__version__ = "1.18.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/condition_type_mismatch.py
+++ b/iam_validator/checks/condition_type_mismatch.py
@@ -7,6 +7,10 @@ import ipaddress
 from typing import ClassVar
 
 from iam_validator.core.aws_service import AWSServiceFetcher
+from iam_validator.core.aws_service.validators import (
+    condition_key_in_list,
+    find_matching_condition_key,
+)
 from iam_validator.core.check_registry import CheckConfig, PolicyCheck
 from iam_validator.core.condition_validators import (
     CONDITION_OPERATORS,
@@ -214,9 +218,10 @@ class ConditionTypeMismatchCheck(PolicyCheck):
                 service_prefix, action_name = fetcher.parse_action(action)
                 service_detail = await fetcher.fetch_service_by_name(service_prefix)
 
-                # Check service-level condition keys
-                if condition_key in service_detail.condition_keys:
-                    condition_key_obj = service_detail.condition_keys[condition_key]
+                # Check service-level condition keys (pattern-aware for tag keys with "/")
+                matched_key = find_matching_condition_key(condition_key, service_detail.condition_keys)
+                if matched_key:
+                    condition_key_obj = service_detail.condition_keys[matched_key]
                     if condition_key_obj.types:
                         return condition_key_obj.types[0]
 
@@ -224,10 +229,13 @@ class ConditionTypeMismatchCheck(PolicyCheck):
                 if action_name in service_detail.actions:
                     action_detail = service_detail.actions[action_name]
 
-                    # For action-specific keys, we need to check the service condition keys list
-                    if action_detail.action_condition_keys and condition_key in action_detail.action_condition_keys:
-                        if condition_key in service_detail.condition_keys:
-                            condition_key_obj = service_detail.condition_keys[condition_key]
+                    # For action-specific keys, check with pattern matching then look up type
+                    if action_detail.action_condition_keys and condition_key_in_list(
+                        condition_key, action_detail.action_condition_keys
+                    ):
+                        matched_key = find_matching_condition_key(condition_key, service_detail.condition_keys)
+                        if matched_key:
+                            condition_key_obj = service_detail.condition_keys[matched_key]
                             if condition_key_obj.types:
                                 return condition_key_obj.types[0]
 
@@ -240,10 +248,13 @@ class ConditionTypeMismatchCheck(PolicyCheck):
 
                             resource_type = service_detail.resources.get(resource_name)
                             if resource_type and resource_type.condition_keys:
-                                if condition_key in resource_type.condition_keys:
+                                if condition_key_in_list(condition_key, resource_type.condition_keys):
                                     # Resource condition keys reference service condition keys
-                                    if condition_key in service_detail.condition_keys:
-                                        condition_key_obj = service_detail.condition_keys[condition_key]
+                                    matched_key = find_matching_condition_key(
+                                        condition_key, service_detail.condition_keys
+                                    )
+                                    if matched_key:
+                                        condition_key_obj = service_detail.condition_keys[matched_key]
                                         if condition_key_obj.types:
                                             return condition_key_obj.types[0]
 

--- a/iam_validator/checks/set_operator_validation.py
+++ b/iam_validator/checks/set_operator_validation.py
@@ -25,6 +25,52 @@ class SetOperatorValidationCheck(PolicyCheck):
     description: ClassVar[str] = "Validates proper usage of ForAllValues and ForAnyValue set operators"
     default_severity: ClassVar[str] = "error"
 
+    async def _is_multivalued_key(
+        self,
+        condition_key: str,
+        fetcher: AWSServiceFetcher | None,
+        actions: list[str],
+    ) -> bool:
+        """Check if a condition key is multivalued using hardcoded list and AWS service metadata.
+
+        First checks the hardcoded known multivalued keys, then falls back to
+        looking up the condition key's Types in AWS service data (ArrayOfString etc.).
+        """
+        # Fast path: check hardcoded known multivalued keys
+        if is_multivalued_context_key(condition_key):
+            return True
+
+        if not fetcher:
+            return False
+
+        # Look up condition key type from AWS service data
+        # Try extracting service prefix from the condition key itself (e.g. "route53:KeyName")
+        service_prefixes: set[str] = set()
+        if ":" in condition_key and not condition_key.startswith("aws:"):
+            service_prefixes.add(condition_key.split(":")[0].lower())
+
+        # Also extract service prefixes from the statement's actions
+        for action in actions:
+            if action == "*":
+                continue
+            try:
+                service_prefix, _ = fetcher.parse_action(action)
+                service_prefixes.add(service_prefix.lower())
+            except Exception:
+                continue
+
+        for service_prefix in service_prefixes:
+            try:
+                service_detail = await fetcher.fetch_service_by_name(service_prefix)
+                if condition_key in service_detail.condition_keys:
+                    condition_key_obj = service_detail.condition_keys[condition_key]
+                    if condition_key_obj.types and any(t.startswith("ArrayOf") for t in condition_key_obj.types):
+                        return True
+            except Exception:
+                continue
+
+        return False
+
     async def execute(
         self,
         statement: Statement,
@@ -43,7 +89,7 @@ class SetOperatorValidationCheck(PolicyCheck):
         Args:
             statement: The IAM statement to check
             statement_idx: Index of this statement in the policy
-            fetcher: AWS service fetcher (unused but required by interface)
+            fetcher: AWS service fetcher for looking up condition key metadata
             config: Check configuration
 
         Returns:
@@ -58,6 +104,7 @@ class SetOperatorValidationCheck(PolicyCheck):
         statement_sid = statement.sid
         line_number = statement.line_number
         effect = statement.effect
+        actions = statement.get_actions()
 
         # Track which condition keys have set operators and Null checks
         set_operator_keys: dict[str, str] = {}  # key -> operator prefix
@@ -88,7 +135,7 @@ class SetOperatorValidationCheck(PolicyCheck):
             # Check each condition key used with a set operator
             for condition_key, _condition_values in conditions.items():
                 # Issue 1: Set operator used with single-valued context key (anti-pattern)
-                if not is_multivalued_context_key(condition_key):
+                if not await self._is_multivalued_key(condition_key, fetcher, actions):
                     issues.append(
                         ValidationIssue(
                             severity=self.get_severity(config),

--- a/iam_validator/checks/set_operator_validation.py
+++ b/iam_validator/checks/set_operator_validation.py
@@ -6,9 +6,11 @@ Based on AWS IAM best practices:
 https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html
 """
 
+import logging
 from typing import ClassVar
 
 from iam_validator.core.aws_service import AWSServiceFetcher
+from iam_validator.core.aws_service.validators import find_matching_condition_key
 from iam_validator.core.check_registry import CheckConfig, PolicyCheck
 from iam_validator.core.condition_validators import (
     has_if_exists_suffix,
@@ -16,6 +18,8 @@ from iam_validator.core.condition_validators import (
     normalize_operator,
 )
 from iam_validator.core.models import Statement, ValidationIssue
+
+logger = logging.getLogger(__name__)
 
 
 class SetOperatorValidationCheck(PolicyCheck):
@@ -57,16 +61,19 @@ class SetOperatorValidationCheck(PolicyCheck):
                 service_prefix, _ = fetcher.parse_action(action)
                 service_prefixes.add(service_prefix.lower())
             except Exception:
+                logger.debug("Failed to parse action %s for condition key lookup", action)
                 continue
 
         for service_prefix in service_prefixes:
             try:
                 service_detail = await fetcher.fetch_service_by_name(service_prefix)
-                if condition_key in service_detail.condition_keys:
-                    condition_key_obj = service_detail.condition_keys[condition_key]
+                matched_key = find_matching_condition_key(condition_key, service_detail.condition_keys)
+                if matched_key:
+                    condition_key_obj = service_detail.condition_keys[matched_key]
                     if condition_key_obj.types and any(t.startswith("ArrayOf") for t in condition_key_obj.types):
                         return True
             except Exception:
+                logger.debug("Failed to look up condition key %s in service %s", condition_key, service_prefix)
                 continue
 
         return False

--- a/iam_validator/checks/wildcard_resource.py
+++ b/iam_validator/checks/wildcard_resource.py
@@ -5,8 +5,9 @@ It intelligently adjusts severity based on conditions that restrict resource sco
 
 - Global resource-scoping conditions (aws:ResourceAccount, aws:ResourceOrgID, aws:ResourceOrgPaths)
   always lower severity since they apply to all services.
-- Resource tag conditions (aws:ResourceTag/*) lower severity only if ALL actions in the
-  statement support the condition (validated against AWS service definitions).
+- Tag-based ABAC conditions (aws:ResourceTag/*, aws:RequestTag/*, aws:TagKeys,
+  s3:ExistingObjectTag/*, etc.) lower severity only if ALL actions in the statement
+  support the condition (validated against AWS service definitions).
 """
 
 import asyncio
@@ -103,6 +104,20 @@ def _has_global_resource_scoping(condition_keys: set[str]) -> bool:
         True if any global resource-scoping condition is present
     """
     return bool(condition_keys & GLOBAL_RESOURCE_SCOPING_CONDITION_KEYS)
+
+
+def _is_resource_scoping_tag_condition(key: str) -> bool:
+    """Check if a condition key is a tag-based ABAC condition that scopes resources.
+
+    Matches any condition key containing "Tag/" (e.g., aws:ResourceTag/*,
+    aws:RequestTag/*, s3:ExistingObjectTag/*) or aws:TagKeys.
+
+    Excludes aws:PrincipalTag/* since those scope the principal (WHO), not the resource (WHAT).
+    """
+    key_lower = key.lower()
+    if key_lower.startswith("aws:principaltag/"):
+        return False
+    return "tag/" in key_lower or key_lower == "aws:tagkeys"
 
 
 async def _validate_condition_key_support(
@@ -317,7 +332,8 @@ class WildcardResourceCheck(PolicyCheck):
         This method checks if the statement has conditions that meaningfully restrict
         resource scope:
         1. Global resource-scoping conditions (aws:ResourceAccount, etc.) always lower severity
-        2. Resource tag conditions (aws:ResourceTag/*) lower severity only if ALL actions support them
+        2. Tag-based ABAC conditions (aws:ResourceTag/*, aws:RequestTag/*, aws:TagKeys,
+           s3:ExistingObjectTag/*, etc.) lower severity only if ALL actions support them
 
         Args:
             statement: The policy statement being checked
@@ -340,26 +356,41 @@ class WildcardResourceCheck(PolicyCheck):
                 f"Severity lowered: resource scope restricted by `{', '.join(sorted(global_keys))}`",
             )
 
-        # Check for aws:ResourceTag conditions (must validate per-action support)
-        resource_tag_keys = {k for k in condition_keys if k.startswith("aws:ResourceTag/")}
-        if resource_tag_keys:
-            # Use the first tag key for validation (all should have same support pattern)
-            tag_key = next(iter(resource_tag_keys))
-            all_support, unsupported = await _validate_condition_key_support(actions, tag_key, fetcher)
-            if all_support:
-                return (
-                    "low",
-                    f"Severity lowered: resource scope restricted by `{', '.join(sorted(resource_tag_keys))}`",
-                )
-            else:
-                # Tag condition present but not all actions support it
-                unsupported_display = unsupported[:3]
-                more = f" (+{len(unsupported) - 3} more)" if len(unsupported) > 3 else ""
-                return (
-                    base_severity,
-                    f"Note: `aws:ResourceTag` condition found but these actions don't support "
-                    f"resource tags: `{', '.join(unsupported_display)}`{more}",
-                )
+        # Check for tag-based ABAC conditions that scope resources
+        # Covers: aws:ResourceTag/*, aws:RequestTag/*, aws:TagKeys,
+        # s3:ExistingObjectTag/*, and any other service-specific tag condition keys
+        tag_condition_keys = {k for k in condition_keys if _is_resource_scoping_tag_condition(k)}
+        if tag_condition_keys:
+            # Deduplicate by prefix — actions that support aws:RequestTag/X
+            # also support aws:RequestTag/Y, so validate one per prefix
+            seen_prefixes: set[str] = set()
+            representative_keys: list[str] = []
+            for key in sorted(tag_condition_keys):
+                prefix = key.split("/")[0] if "/" in key else key
+                if prefix not in seen_prefixes:
+                    seen_prefixes.add(prefix)
+                    representative_keys.append(key)
+
+            # Validate that actions support at least one tag condition family
+            last_unsupported: list[str] = []
+            for tag_key in representative_keys:
+                all_support, unsupported = await _validate_condition_key_support(actions, tag_key, fetcher)
+                if all_support:
+                    return (
+                        "low",
+                        f"Severity lowered: ABAC conditions restrict resource scope via "
+                        f"`{', '.join(sorted(tag_condition_keys))}`",
+                    )
+                last_unsupported = unsupported
+
+            # Tag conditions present but no family is fully supported by all actions
+            unsupported_display = last_unsupported[:3]
+            more = f" (+{len(last_unsupported) - 3} more)" if len(last_unsupported) > 3 else ""
+            return (
+                base_severity,
+                f"Note: ABAC tag conditions found but these actions don't support "
+                f"them: `{', '.join(unsupported_display)}`{more}",
+            )
 
         # Has conditions but none that scope resources
         return (base_severity, None)

--- a/iam_validator/commands/analyze.py
+++ b/iam_validator/commands/analyze.py
@@ -220,6 +220,16 @@ Examples:
         )
 
         parser.add_argument(
+            "--off-diff-comment-mode",
+            choices=["summary_only", "individual", "modified_statements_only"],
+            default=None,
+            help="How to handle findings on unchanged lines in PRs: "
+            "'summary_only' (default) shows in summary table only, "
+            "'individual' posts each as a review comment, "
+            "'modified_statements_only' posts only for modified statements",
+        )
+
+        parser.add_argument(
             "--verbose",
             "-v",
             action="store_true",
@@ -397,6 +407,11 @@ Examples:
             enable_ignore = ignore_settings.get("enabled", True)
             allowed_users = ignore_settings.get("allowed_users", [])
 
+            # Get off-diff comment mode (CLI override > config > default)
+            off_diff_mode = getattr(args, "off_diff_comment_mode", None) or config.get_setting(
+                "off_diff_comment_mode", "summary_only"
+            )
+
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
                     github,
@@ -404,6 +419,7 @@ Examples:
                     severity_labels=severity_labels,
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
+                    off_diff_comment_mode=off_diff_mode,
                 )
                 success = await commenter.post_findings_to_pr(
                     validation_report,

--- a/iam_validator/commands/completion.py
+++ b/iam_validator/commands/completion.py
@@ -217,6 +217,10 @@ _iam_validator_completion() {{
             COMPREPLY=( $(compgen -W "stdio sse" -- "$cur") )
             return 0
             ;;
+        --off-diff-comment-mode)
+            COMPREPLY=( $(compgen -W "summary_only individual modified_statements_only" -- "$cur") )
+            return 0
+            ;;
     esac
 
     # Handle cache list --format specifically
@@ -278,17 +282,17 @@ _iam_validator_completion() {{
             return 0
             ;;
         validate)
-            opts="--path -p --stdin --format -f --output -o --no-recursive --fail-on-warnings --policy-type -t --github-comment --github-review --github-summary --verbose -v --config -c --custom-checks-dir --aws-services-dir --stream --batch-size --summary --severity-breakdown --allow-owner-ignore --no-owner-ignore --ci --ci-output"
+            opts="--path -p --stdin --format -f --output -o --no-recursive --fail-on-warnings --policy-type -t --github-comment --github-review --github-summary --verbose -v --config -c --custom-checks-dir --aws-services-dir --stream --batch-size --summary --severity-breakdown --allow-owner-ignore --no-owner-ignore --ci --ci-output --off-diff-comment-mode"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
         post-to-pr)
-            opts="--report -r --create-review --no-review --add-summary --no-summary --config -c"
+            opts="--report -r --create-review --no-review --add-summary --no-summary --config -c --off-diff-comment-mode"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
         analyze)
-            opts="--path -p --policy-type -t --region --profile --format -f --output -o --no-recursive --fail-on-warnings --github-comment --github-review --github-summary --run-all-checks --check-access-not-granted --check-access-resources --check-no-new-access --check-no-public-access --public-access-resource-type --verbose -v"
+            opts="--path -p --policy-type -t --region --profile --format -f --output -o --no-recursive --fail-on-warnings --github-comment --github-review --github-summary --run-all-checks --check-access-not-granted --check-access-resources --check-no-new-access --check-no-public-access --public-access-resource-type --off-diff-comment-mode --verbose -v"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
@@ -436,7 +440,8 @@ _iam_validator() {{
                         '--allow-owner-ignore[Allow CODEOWNERS to ignore findings]' \\
                         '--no-owner-ignore[Disable CODEOWNERS ignore feature]' \\
                         '--ci[CI mode - print enhanced output, write JSON to file]' \\
-                        '--ci-output[Output file for JSON report in CI mode]:file:_files'
+                        '--ci-output[Output file for JSON report in CI mode]:file:_files' \\
+                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)'
                     ;;
                 post-to-pr)
                     _arguments \\
@@ -445,7 +450,8 @@ _iam_validator() {{
                         '--no-review[Do not create line-specific review comments]' \\
                         '--add-summary[Add summary comment]' \\
                         '--no-summary[Do not add summary comment]' \\
-                        '(--config -c)'{{--config,-c}}'[Configuration file]:file:_files'
+                        '(--config -c)'{{--config,-c}}'[Configuration file]:file:_files' \\
+                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)'
                     ;;
                 analyze)
                     _arguments \\
@@ -467,6 +473,7 @@ _iam_validator() {{
                         '--check-no-new-access[Path to existing policy]:file:_files' \\
                         '--check-no-public-access[Check that resource policy does not allow public access]' \\
                         '*--public-access-resource-type[Resource type for public access check]:resource type:' \\
+                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)' \\
                         '(--verbose -v)'{{--verbose,-v}}'[Enable verbose logging]'
                     ;;
                 cache)

--- a/iam_validator/commands/post_to_pr.py
+++ b/iam_validator/commands/post_to_pr.py
@@ -74,6 +74,16 @@ Examples:
             help="Path to configuration file (for fail_on_severity setting)",
         )
 
+        parser.add_argument(
+            "--off-diff-comment-mode",
+            choices=["summary_only", "individual", "modified_statements_only"],
+            default=None,
+            help="How to handle findings on unchanged lines in PRs: "
+            "'summary_only' (default) shows in summary table only, "
+            "'individual' posts each as a review comment, "
+            "'modified_statements_only' posts only for modified statements",
+        )
+
     async def execute(self, args: argparse.Namespace) -> int:
         """Execute the post-to-pr command."""
         success = await post_report_to_pr(
@@ -81,6 +91,7 @@ Examples:
             create_review=args.create_review,
             add_summary=args.add_summary,
             config_path=getattr(args, "config", None),
+            off_diff_comment_mode=getattr(args, "off_diff_comment_mode", None),
         )
 
         return 0 if success else 1

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -13,6 +13,23 @@ from iam_validator.core.report import ReportGenerator
 from iam_validator.integrations.github_integration import GitHubIntegration
 
 
+def _resolve_off_diff_mode(args: argparse.Namespace, config) -> str:
+    """Resolve the off-diff comment mode from CLI args or config.
+
+    Priority: CLI ``--off-diff-comment-mode`` > config setting > default ``"summary_only"``.
+
+    Args:
+        args: Parsed command-line arguments
+        config: Loaded configuration object with ``get_setting()``
+
+    Returns:
+        One of ``"summary_only"``, ``"individual"``, or ``"modified_statements_only"``
+    """
+    return getattr(args, "off_diff_comment_mode", None) or config.get_setting(
+        "off_diff_comment_mode", "summary_only"
+    )
+
+
 class ValidateCommand(Command):
     """Command to validate IAM policies."""
 
@@ -216,6 +233,16 @@ Examples:
         )
 
         parser.add_argument(
+            "--off-diff-comment-mode",
+            choices=["summary_only", "individual", "modified_statements_only"],
+            default=None,
+            help="How to handle findings on unchanged lines in PRs: "
+            "'summary_only' (default) shows in summary table only, "
+            "'individual' posts each as a review comment, "
+            "'modified_statements_only' posts only for modified statements",
+        )
+
+        parser.add_argument(
             "--ci",
             action="store_true",
             help="CI mode: print enhanced console output for visibility in job logs, "
@@ -349,6 +376,9 @@ Examples:
                 enable_ignore = False
             allowed_users = ignore_settings.get("allowed_users", [])
 
+            # Get off-diff comment mode (CLI override > config > default)
+            off_diff_mode = _resolve_off_diff_mode(args, config)
+
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
                     github,
@@ -356,6 +386,7 @@ Examples:
                     severity_labels=severity_labels,
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
+                    off_diff_comment_mode=off_diff_mode,
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -501,6 +532,9 @@ Examples:
                 enable_ignore = False
             allowed_users = ignore_settings.get("allowed_users", [])
 
+            # Get off-diff comment mode (CLI override > config > default)
+            off_diff_mode = _resolve_off_diff_mode(args, config)
+
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
                     github,
@@ -508,6 +542,7 @@ Examples:
                     severity_labels=severity_labels,
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
+                    off_diff_comment_mode=off_diff_mode,
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -567,6 +602,9 @@ Examples:
                     enable_ignore = False
                 allowed_users = ignore_settings.get("allowed_users", [])
 
+                # Get off-diff comment mode (CLI override > config > default)
+                off_diff_mode = _resolve_off_diff_mode(args, config)
+
                 # In streaming mode, don't cleanup comments (we want to keep earlier files)
                 # Cleanup will happen once at the end
                 commenter = PRCommenter(
@@ -575,6 +613,7 @@ Examples:
                     fail_on_severities=fail_on_severities,
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
+                    off_diff_comment_mode=off_diff_mode,
                 )
 
                 # Create a mini-report for just this file
@@ -666,6 +705,9 @@ Examples:
                     enable_ignore = False
                 allowed_users = ignore_settings.get("allowed_users", [])
 
+                # Get off-diff comment mode (CLI override > config > default)
+                off_diff_mode = _resolve_off_diff_mode(args, config)
+
                 # Create commenter WITH cleanup enabled for the final pass
                 commenter = PRCommenter(
                     github,
@@ -673,6 +715,7 @@ Examples:
                     fail_on_severities=fail_on_severities,
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
+                    off_diff_comment_mode=off_diff_mode,
                 )
 
                 # Create a full report with all results

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -25,9 +25,7 @@ def _resolve_off_diff_mode(args: argparse.Namespace, config) -> str:
     Returns:
         One of ``"summary_only"``, ``"individual"``, or ``"modified_statements_only"``
     """
-    return getattr(args, "off_diff_comment_mode", None) or config.get_setting(
-        "off_diff_comment_mode", "summary_only"
-    )
+    return getattr(args, "off_diff_comment_mode", None) or config.get_setting("off_diff_comment_mode", "summary_only")
 
 
 class ValidateCommand(Command):

--- a/iam_validator/core/aws_service/validators.py
+++ b/iam_validator/core/aws_service/validators.py
@@ -45,17 +45,59 @@ def _is_valid_tag_key(tag_key: str) -> bool:
     return bool(_TAG_KEY_PATTERN.match(tag_key))
 
 
+def find_matching_condition_key(condition_key: str, condition_keys: list[str] | dict[str, Any]) -> str | None:
+    """Find the matching pattern key in a collection of condition keys.
+
+    Supports both lists and dicts. Returns the matched key string so the caller
+    can look up associated metadata when working with dicts.
+
+    AWS service definitions use patterns with tag-key placeholders like:
+    - ``ssm:resourceTag/tag-key`` to match ``ssm:resourceTag/owner``
+    - ``aws:ResourceTag/${TagKey}`` to match ``aws:ResourceTag/Environment``
+    - ``s3:RequestObjectTag/<key>`` to match ``s3:RequestObjectTag/Environment``
+
+    Any pattern containing "/" is treated as a potential tag-key pattern where
+    the prefix before the FIRST "/" must match exactly and the suffix after that "/"
+    in the condition_key must be a valid AWS tag key.
+
+    IMPORTANT: Uses the pattern's prefix length (up to the first "/") to split the
+    condition_key. This is critical because AWS tag keys can contain "/" characters
+    (e.g., ``aws:ResourceTag/team/project-owner``). Using ``rfind("/")`` on the
+    condition key would incorrectly split at the last "/" instead of the pattern boundary.
+
+    Args:
+        condition_key: The condition key to look up
+        condition_keys: List or dict of condition keys (may include patterns)
+
+    Returns:
+        The matched key/pattern string, or None if not found
+    """
+    # Fast path: exact match (works for both list and dict via `in`)
+    if condition_key in condition_keys:
+        return condition_key
+
+    # Pattern matching only applies when the condition key contains "/"
+    if "/" not in condition_key:
+        return None
+
+    for pattern in condition_keys:
+        if "/" not in pattern:
+            continue
+        pattern_prefix = pattern[: pattern.find("/")]
+        if not condition_key.startswith(pattern_prefix + "/"):
+            continue
+        tag_key = condition_key[len(pattern_prefix) + 1 :]
+        if tag_key and _is_valid_tag_key(tag_key):
+            return pattern
+
+    return None
+
+
 def condition_key_in_list(condition_key: str, condition_keys: list[str]) -> bool:
     """Check if a condition key matches any key in the list, supporting patterns.
 
-    AWS service definitions use patterns with tag-key placeholders like:
-    - `ssm:resourceTag/tag-key` to match `ssm:resourceTag/owner`
-    - `aws:ResourceTag/${TagKey}` to match `aws:ResourceTag/Environment`
-    - `s3:RequestObjectTag/<key>` to match `s3:RequestObjectTag/Environment`
-
-    Any pattern containing "/" is treated as a potential tag-key pattern where
-    the prefix before "/" must match exactly and the suffix after "/" in the
-    condition_key must be a valid AWS tag key.
+    Convenience wrapper around :func:`find_matching_condition_key` that returns
+    a boolean instead of the matched pattern string.
 
     Args:
         condition_key: The condition key to check
@@ -64,35 +106,7 @@ def condition_key_in_list(condition_key: str, condition_keys: list[str]) -> bool
     Returns:
         True if condition_key matches any entry in the list
     """
-    # Fast path: check for exact match first (most common case)
-    if condition_key in condition_keys:
-        return True
-
-    # Check if condition_key could match a pattern (must contain "/")
-    if "/" not in condition_key:
-        return False
-
-    # Extract prefix and tag key from condition_key
-    cond_slash_idx = condition_key.rfind("/")
-    if cond_slash_idx <= 0:
-        return False
-
-    cond_prefix = condition_key[:cond_slash_idx]
-    tag_key = condition_key[cond_slash_idx + 1 :]
-
-    # Validate tag key format
-    if not _is_valid_tag_key(tag_key):
-        return False
-
-    # Check if any pattern has a matching prefix
-    for pattern in condition_keys:
-        if "/" not in pattern:
-            continue
-        pattern_prefix = pattern[: pattern.rfind("/")]
-        if pattern_prefix == cond_prefix:
-            return True
-
-    return False
+    return find_matching_condition_key(condition_key, condition_keys) is not None
 
 
 @dataclass

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from iam_validator.core.aws_service import AWSServiceFetcher
 from iam_validator.core.config.check_documentation import CheckDocumentationRegistry
@@ -160,7 +160,7 @@ class PolicyCheck(ABC):
 
     Two ways to define check_id and description:
 
-    Option 1 - Class attributes (simpler, recommended for static values):
+    Option 1 - Class attributes (recommended):
         from typing import ClassVar
 
         class MyCheck(PolicyCheck):
@@ -170,9 +170,7 @@ class PolicyCheck(ABC):
             async def execute(self, statement, statement_idx, fetcher, config):
                 return []
 
-        Note: ClassVar annotation is required for Pylance type checker compatibility.
-
-    Option 2 - Property decorators (more flexible, supports dynamic values):
+    Option 2 - Property decorators (supports dynamic values):
         class MyCheck(PolicyCheck):
             @property
             def check_id(self) -> str:
@@ -210,24 +208,28 @@ class PolicyCheck(ABC):
                 return issues
     """
 
-    @property
-    def check_id(self) -> str:
-        """Unique identifier for this check (e.g., 'action_validation')."""
-        raise NotImplementedError("Subclasses must define check_id")
+    #: Unique identifier for this check (e.g., 'action_validation').
+    #: Subclasses must define this as a ClassVar or @property.
+    check_id: ClassVar[str]
 
-    @property
-    def description(self) -> str:
-        """Human-readable description of what this check does."""
-        raise NotImplementedError("Subclasses must define description")
+    #: Human-readable description of what this check does.
+    #: Subclasses must define this as a ClassVar or @property.
+    description: ClassVar[str]
 
-    @property
-    def default_severity(self) -> str:
-        """Default severity level for issues found by this check."""
-        return "warning"
+    #: Default severity level for issues found by this check.
+    #: Subclasses may override. Defaults to "warning".
+    default_severity: ClassVar[str] = "warning"
+
+    def __getattr__(self, name: str) -> Any:
+        """Raise NotImplementedError for required attributes not defined by subclass."""
+        if name in ("check_id", "description"):
+            raise NotImplementedError(f"Subclasses must define {name}")
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def __init_subclass__(cls, **kwargs):
         """
-        Validate that subclasses override at least one execution method.
+        Validate that subclasses define required attributes and override
+        at least one execution method.
 
         This ensures checks implement either execute() OR execute_policy() (or both).
         If neither is overridden, the check would never produce any results.

--- a/iam_validator/core/config/check_documentation.py
+++ b/iam_validator/core/config/check_documentation.py
@@ -22,7 +22,7 @@ RISK_CATEGORY_ICONS = {
 }
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CheckDocumentation:
     """Documentation for a single check.
 
@@ -36,9 +36,9 @@ class CheckDocumentation:
     """
 
     check_id: str
-    short_description: str
     risk_explanation: str
     documentation_url: str
+    short_description: str = ""
     remediation_steps: list[str] = field(default_factory=list)
     risk_category: str | None = None
 
@@ -83,7 +83,7 @@ class CheckDocumentationRegistry:
     def get_short_description(cls, check_id: str) -> str | None:
         """Get short description for a check."""
         doc = cls.get(check_id)
-        return doc.short_description if doc else None
+        return doc.short_description if doc and doc.short_description else None
 
     @classmethod
     def get_remediation_steps(cls, check_id: str) -> list[str] | None:

--- a/iam_validator/core/config/config_loader.py
+++ b/iam_validator/core/config/config_loader.py
@@ -138,6 +138,15 @@ class SettingsSchema(BaseModel):
     ignore_settings: IgnoreSettingsSchema = IgnoreSettingsSchema()
     documentation: DocumentationSettingsSchema = DocumentationSettingsSchema()
     hide_severities: list[str] | None = None  # Global severity filtering
+    off_diff_comment_mode: str = "summary_only"
+
+    @field_validator("off_diff_comment_mode")
+    @classmethod
+    def validate_off_diff_comment_mode(cls, v: str) -> str:
+        valid_modes = {"summary_only", "individual", "modified_statements_only"}
+        if v not in valid_modes:
+            raise ValueError(f"Invalid off_diff_comment_mode: {v}. Must be one of: {sorted(valid_modes)}")
+        return v
 
     @field_validator("fail_on_severity")
     @classmethod

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -118,6 +118,11 @@ DEFAULT_CONFIG = {
         # Valid values: "error", "warning", "info", "critical", "high", "medium", "low"
         # Example: ["low", "info"] - hide low and info severity findings
         "hide_severities": None,
+        # How to handle findings on lines outside the PR diff
+        # summary_only: Show in summary table only (default, least noise)
+        # individual: Post each as an individual review comment
+        # modified_statements_only: Individual comments for modified statements only
+        "off_diff_comment_mode": "summary_only",
     },
     # ========================================================================
     # AWS IAM Validation Checks (17 checks total)

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -492,8 +492,10 @@ class PRCommenter:
     async def _post_off_diff_comments(self, off_diff_issues: list[ContextIssue]) -> tuple[set[str], list[ContextIssue]]:
         """Post comments for issues found outside the PR diff.
 
-        Attempts to post each issue as a line-level review comment first,
-        then falls back to a file-level comment if that fails. Issues that
+        Uses fingerprint-based deduplication to avoid posting duplicate comments
+        on subsequent runs. Existing comments are updated if the body changed,
+        or skipped if unchanged. New issues are posted as line-level review
+        comments first, with a fallback to file-level comments. Issues that
         cannot be posted at all are returned for inclusion in the summary.
 
         Args:
@@ -516,15 +518,38 @@ class PRCommenter:
             return set(), off_diff_issues
 
         commit_id = pr_info["head"]["sha"]
+
+        # Fetch existing bot comments indexed by fingerprint to avoid duplicates
+        existing_by_fingerprint = await self.github._get_bot_comments_by_fingerprint(self.REVIEW_IDENTIFIER)
+
         posted_fingerprints: set[str] = set()
         remaining: list[ContextIssue] = []
+        created_count = 0
+        updated_count = 0
+        skipped_count = 0
 
         for ctx_issue in off_diff_issues:
+            fp_hash = FindingFingerprint.from_issue(ctx_issue.issue, ctx_issue.file_path).to_hash()
             body = ctx_issue.issue.to_pr_comment(file_path=ctx_issue.file_path)
             body += (
                 f"\n\n> **Note:** This finding is on line {ctx_issue.line_number}, which was not modified in this PR."
             )
 
+            # Check if a comment with this fingerprint already exists
+            existing = existing_by_fingerprint.get(fp_hash)
+            if existing:
+                posted_fingerprints.add(fp_hash)
+                if existing["body"] != body:
+                    # Body changed (e.g., message updated) - update existing comment
+                    await self.github.update_review_comment(existing["id"], body)
+                    updated_count += 1
+                    logger.debug(f"Updated off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
+                else:
+                    skipped_count += 1
+                    logger.debug(f"Skipped existing off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
+                continue
+
+            # New finding - post as review comment
             # Try line-level comment first
             posted = await self.github.create_review_comment(
                 commit_id, ctx_issue.file_path, ctx_issue.line_number, body
@@ -535,14 +560,17 @@ class PRCommenter:
                 posted = await self.github.create_file_level_comment(commit_id, ctx_issue.file_path, body)
 
             if posted:
-                fp_hash = FindingFingerprint.from_issue(ctx_issue.issue, ctx_issue.file_path).to_hash()
                 posted_fingerprints.add(fp_hash)
+                created_count += 1
                 logger.debug(f"Posted off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
             else:
                 remaining.append(ctx_issue)
                 logger.debug(f"Failed to post off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
 
-        logger.info(f"Off-diff comments: {len(posted_fingerprints)} posted, {len(remaining)} remaining for summary")
+        logger.info(
+            f"Off-diff comments: {created_count} created, {updated_count} updated, "
+            f"{skipped_count} unchanged, {len(remaining)} remaining for summary"
+        )
         return posted_fingerprints, remaining
 
     def _make_relative_path(self, policy_file: str) -> str | None:

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -36,6 +36,7 @@ class ContextIssue:
         statement_index: int,
         line_number: int,
         issue: ValidationIssue,
+        in_modified_statement: bool = False,
     ):
         """Initialize context issue.
 
@@ -44,11 +45,13 @@ class ContextIssue:
             statement_index: Zero-based statement index
             line_number: Line number where the issue exists
             issue: The validation issue
+            in_modified_statement: Whether the issue is in a statement that was modified in the PR
         """
         self.file_path = file_path
         self.statement_index = statement_index
         self.line_number = line_number
         self.issue = issue
+        self.in_modified_statement = in_modified_statement
 
 
 class PRCommenter:
@@ -67,6 +70,7 @@ class PRCommenter:
         severity_labels: dict[str, str | list[str]] | None = None,
         enable_codeowners_ignore: bool = True,
         allowed_ignore_users: list[str] | None = None,
+        off_diff_comment_mode: str = "summary_only",
     ):
         """Initialize PR commenter.
 
@@ -85,6 +89,10 @@ class PRCommenter:
                              - Mixed: {"error": "iam-validity-error", "critical": ["security-critical", "needs-review"]}
             enable_codeowners_ignore: Whether to enable CODEOWNERS-based ignore feature
             allowed_ignore_users: Fallback users who can ignore findings when no CODEOWNERS
+            off_diff_comment_mode: How to handle findings on unchanged lines.
+                                  "summary_only" (default): All off-diff issues in summary only.
+                                  "individual": Post each as an individual review comment.
+                                  "modified_statements_only": Individual comments for modified statements only.
         """
         self.github = github
         self.cleanup_old_comments = cleanup_old_comments
@@ -92,6 +100,7 @@ class PRCommenter:
         self.severity_labels = severity_labels or {}
         self.enable_codeowners_ignore = enable_codeowners_ignore
         self.allowed_ignore_users = allowed_ignore_users or []
+        self.off_diff_comment_mode = off_diff_comment_mode
         # Track issues in modified statements that are on unchanged lines
         self._context_issues: list[ContextIssue] = []
         # Track ignored finding IDs for the current run
@@ -410,7 +419,11 @@ class PRCommenter:
                     )
                 elif issue.statement_index in modified_statements:
                     # Issue in modified statement but on unchanged line - save for summary
-                    self._context_issues.append(ContextIssue(relative_path, issue.statement_index, line_number, issue))
+                    self._context_issues.append(
+                        ContextIssue(
+                            relative_path, issue.statement_index, line_number, issue, in_modified_statement=True
+                        )
+                    )
                     context_issue_count += 1
                     logger.debug(
                         f"Context issue: {relative_path}:{line_number} (statement {issue.statement_index} modified) - {issue.issue_type}"
@@ -429,10 +442,22 @@ class PRCommenter:
             f"{context_issue_count} context issues for summary"
         )
 
-        # Post off-diff comments for context issues (line-level or file-level fallback)
+        # Post off-diff comments based on off_diff_comment_mode setting
         protected_fingerprints: set[str] = set()
         if self._context_issues:
-            protected_fingerprints, self._context_issues = await self._post_off_diff_comments(self._context_issues)
+            if self.off_diff_comment_mode == "individual":
+                # Post all off-diff issues as individual comments
+                protected_fingerprints, self._context_issues = await self._post_off_diff_comments(self._context_issues)
+            elif self.off_diff_comment_mode == "modified_statements_only":
+                # Only post individual comments for issues in modified statements
+                modified_issues = [ci for ci in self._context_issues if ci.in_modified_statement]
+                unchanged_issues = [ci for ci in self._context_issues if not ci.in_modified_statement]
+                if modified_issues:
+                    protected_fingerprints, remaining = await self._post_off_diff_comments(modified_issues)
+                    self._context_issues = remaining + unchanged_issues
+                else:
+                    self._context_issues = unchanged_issues
+            # else: summary_only (default) - skip individual posting, all go to summary
 
         # Even if no inline comments, we still need to run cleanup to delete stale comments
         # from previous runs where findings have been resolved (unless cleanup is disabled)
@@ -538,13 +563,21 @@ class PRCommenter:
             # Check if a comment with this fingerprint already exists
             existing = existing_by_fingerprint.get(fp_hash)
             if existing:
-                posted_fingerprints.add(fp_hash)
                 if existing["body"] != body:
                     # Body changed (e.g., message updated) - update existing comment
-                    await self.github.update_review_comment(existing["id"], body)
-                    updated_count += 1
-                    logger.debug(f"Updated off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
+                    updated = await self.github.update_review_comment(existing["id"], body)
+                    if updated:
+                        posted_fingerprints.add(fp_hash)
+                        updated_count += 1
+                        logger.debug(f"Updated off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
+                    else:
+                        # Update failed - fall back to remaining for summary
+                        remaining.append(ctx_issue)
+                        logger.warning(
+                            f"Failed to update off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}"
+                        )
                 else:
+                    posted_fingerprints.add(fp_hash)
                     skipped_count += 1
                     logger.debug(f"Skipped existing off-diff comment: {ctx_issue.file_path}:{ctx_issue.line_number}")
                 continue
@@ -873,6 +906,7 @@ async def post_report_to_pr(
     create_review: bool = True,
     add_summary: bool = True,
     config_path: str | None = None,
+    off_diff_comment_mode: str | None = None,
 ) -> bool:
     """Post a JSON report to a PR.
 
@@ -881,6 +915,7 @@ async def post_report_to_pr(
         create_review: Whether to create line-specific review
         add_summary: Whether to add summary comment
         config_path: Optional path to config file (to get fail_on_severity)
+        off_diff_comment_mode: How to handle findings on unchanged lines (overrides config)
 
     Returns:
         True if successful, False otherwise
@@ -906,6 +941,9 @@ async def post_report_to_pr(
         enable_codeowners_ignore = ignore_settings.get("enabled", True)
         allowed_ignore_users = ignore_settings.get("allowed_users", [])
 
+        # Get off-diff comment mode (CLI override > config > default)
+        off_diff_mode = off_diff_comment_mode or config.get_setting("off_diff_comment_mode", "summary_only")
+
         # Post to PR
         async with GitHubIntegration() as github:
             commenter = PRCommenter(
@@ -914,6 +952,7 @@ async def post_report_to_pr(
                 severity_labels=severity_labels,
                 enable_codeowners_ignore=enable_codeowners_ignore,
                 allowed_ignore_users=allowed_ignore_users,
+                off_diff_comment_mode=off_diff_mode,
             )
             return await commenter.post_findings_to_pr(
                 report,

--- a/tests/checks/test_wildcard_resource_check.py
+++ b/tests/checks/test_wildcard_resource_check.py
@@ -162,7 +162,8 @@ class TestConditionAwareSeverity:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "low"
-        assert "aws:ResourceTag" in issues[0].message
+        assert "ABAC" in issues[0].message
+        assert "aws:ResourceTag/nx:component" in issues[0].message
 
     @pytest.mark.asyncio
     async def test_resource_tag_with_resource_level_support_lowers_severity_s3(self, check, fetcher, config):
@@ -176,7 +177,8 @@ class TestConditionAwareSeverity:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "low"
-        assert "aws:ResourceTag" in issues[0].message
+        assert "ABAC" in issues[0].message
+        assert "aws:ResourceTag/Env" in issues[0].message
 
     @pytest.mark.asyncio
     async def test_resource_tag_no_support_keeps_severity_route53(self, check, fetcher, config):
@@ -190,7 +192,7 @@ class TestConditionAwareSeverity:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "medium"
-        assert "don't support resource tags" in issues[0].message
+        assert "don't support them" in issues[0].message
 
     @pytest.mark.asyncio
     async def test_non_resource_scoping_condition_keeps_severity(self, check, fetcher, config):
@@ -229,7 +231,7 @@ class TestConditionAwareSeverity:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "medium"
-        assert "don't support resource tags" in issues[0].message
+        assert "don't support them" in issues[0].message
 
     @pytest.mark.asyncio
     async def test_multiple_global_conditions_lowers_severity(self, check, fetcher, config):
@@ -265,4 +267,67 @@ class TestConditionAwareSeverity:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "low"
-        assert "aws:ResourceTag" in issues[0].message
+        assert "ABAC" in issues[0].message
+        assert "aws:ResourceTag/Env" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_request_tag_abac_lowers_severity(self, check, fetcher, config):
+        """Test: aws:RequestTag/* ABAC conditions lower severity to LOW."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["sqs:CreateQueue"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "${aws:PrincipalTag/owner}",
+                    "aws:RequestTag/env": "${aws:PrincipalTag/env}",
+                },
+                "Null": {
+                    "aws:RequestTag/owner": "false",
+                    "aws:RequestTag/env": "false",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"
+        assert "ABAC" in issues[0].message
+        assert "aws:RequestTag/" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_request_tag_with_tagkeys_includes_both_in_message(self, check, fetcher, config):
+        """Test: aws:RequestTag/* with aws:TagKeys includes both in the message."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["sqs:CreateQueue"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "${aws:PrincipalTag/owner}",
+                },
+                "ForAllValues:StringEquals": {
+                    "aws:TagKeys": ["owner"],
+                },
+                "Null": {
+                    "aws:RequestTag/owner": "false",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"
+        assert "aws:RequestTag/owner" in issues[0].message
+        assert "aws:TagKeys" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_principal_tag_does_not_lower_severity(self, check, fetcher, config):
+        """aws:PrincipalTag/* scopes WHO, not WHAT — should NOT lower severity."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={"StringEquals": {"aws:PrincipalTag/team": "engineering"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "medium"

--- a/tests/core/test_condition_key_pattern_matching.py
+++ b/tests/core/test_condition_key_pattern_matching.py
@@ -1,0 +1,504 @@
+"""Comprehensive tests for condition key pattern matching.
+
+These tests ensure that condition keys with tag-key placeholders (e.g.,
+aws:ResourceTag/${TagKey}) are correctly matched against user-provided condition
+keys, including compound tag keys containing forward slashes (e.g., team/owner).
+
+This test file was created after discovering that multiple checks used exact ``in``
+lookups against service_detail.condition_keys dicts, which only contain pattern
+keys like ``aws:ResourceTag/${TagKey}``. User-provided keys like
+``aws:ResourceTag/team/owner`` would silently fail to match.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from iam_validator.core.aws_service import AWSServiceFetcher
+from iam_validator.core.aws_service.validators import (
+    _is_valid_tag_key,
+    condition_key_in_list,
+    find_matching_condition_key,
+)
+from iam_validator.core.models import ConditionKey
+
+# =============================================================================
+# Unit tests: condition_key_in_list
+# =============================================================================
+
+
+class TestConditionKeyInList:
+    """Tests for condition_key_in_list with focus on compound tag keys."""
+
+    def test_exact_match(self):
+        assert condition_key_in_list("ssm:Overwrite", ["ssm:Overwrite", "ssm:Recursive"])
+
+    def test_exact_match_not_found(self):
+        assert not condition_key_in_list("ssm:Missing", ["ssm:Overwrite"])
+
+    def test_no_slash_never_matches_patterns(self):
+        assert not condition_key_in_list("aws:SourceIp", ["aws:ResourceTag/${TagKey}"])
+
+    # --- Simple tag keys ---
+
+    def test_simple_tag_key_matches_dollar_brace_pattern(self):
+        assert condition_key_in_list("aws:ResourceTag/owner", ["aws:ResourceTag/${TagKey}"])
+
+    def test_simple_tag_key_matches_angle_bracket_pattern(self):
+        assert condition_key_in_list("s3:ExistingObjectTag/Team", ["s3:ExistingObjectTag/<key>"])
+
+    def test_simple_tag_key_matches_literal_placeholder(self):
+        assert condition_key_in_list("ssm:resourceTag/owner", ["ssm:resourceTag/tag-key"])
+
+    # --- Compound tag keys (the critical regression tests) ---
+
+    def test_compound_tag_key_single_slash(self):
+        """aws:ResourceTag/team/owner must match aws:ResourceTag/${TagKey}."""
+        assert condition_key_in_list("aws:ResourceTag/team/owner", ["aws:ResourceTag/${TagKey}"])
+
+    def test_compound_tag_key_multiple_slashes(self):
+        """Tag keys with multiple slashes must still match."""
+        assert condition_key_in_list("aws:RequestTag/dept/env/role", ["aws:RequestTag/${TagKey}"])
+
+    def test_compound_tag_key_service_specific(self):
+        assert condition_key_in_list("ssm:resourceTag/org/team", ["ssm:resourceTag/tag-key"])
+
+    def test_compound_tag_key_s3_existing_object_tag(self):
+        assert condition_key_in_list("s3:ExistingObjectTag/ns/key", ["s3:ExistingObjectTag/<key>"])
+
+    # --- Cross-prefix must NOT match ---
+
+    def test_resource_tag_does_not_match_request_tag(self):
+        assert not condition_key_in_list("aws:ResourceTag/team/owner", ["aws:RequestTag/${TagKey}"])
+
+    def test_request_tag_does_not_match_resource_tag(self):
+        assert not condition_key_in_list("aws:RequestTag/env", ["aws:ResourceTag/${TagKey}"])
+
+    def test_different_service_prefix_no_match(self):
+        assert not condition_key_in_list("ssm:resourceTag/team", ["ec2:ResourceTag/${TagKey}"])
+
+    # --- Edge cases ---
+
+    def test_empty_tag_key_rejected(self):
+        """aws:ResourceTag/ (empty tag key) must NOT match."""
+        assert not condition_key_in_list("aws:ResourceTag/", ["aws:ResourceTag/${TagKey}"])
+
+    def test_invalid_tag_key_chars_rejected(self):
+        """Tag keys with invalid chars must NOT match."""
+        assert not condition_key_in_list("aws:ResourceTag/key<bad>", ["aws:ResourceTag/${TagKey}"])
+        assert not condition_key_in_list("aws:ResourceTag/key*wild", ["aws:ResourceTag/${TagKey}"])
+
+    def test_tag_key_at_max_length(self):
+        """Tag key at exactly 128 chars (max allowed) must match."""
+        long_key = "a" * 128
+        assert condition_key_in_list(f"aws:ResourceTag/{long_key}", ["aws:ResourceTag/${TagKey}"])
+
+    def test_tag_key_over_max_length_rejected(self):
+        """Tag key at 129 chars (over max) must NOT match."""
+        long_key = "a" * 129
+        assert not condition_key_in_list(f"aws:ResourceTag/{long_key}", ["aws:ResourceTag/${TagKey}"])
+
+    def test_tag_key_with_all_special_chars(self):
+        """Tag keys with spaces, +, -, =, ., _, :, /, @ are all valid."""
+        assert condition_key_in_list("aws:ResourceTag/key with spaces", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key+value", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key=value", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key.value", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key_value", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key:value", ["aws:ResourceTag/${TagKey}"])
+        assert condition_key_in_list("aws:ResourceTag/key@value", ["aws:ResourceTag/${TagKey}"])
+
+    def test_empty_pattern_list(self):
+        assert not condition_key_in_list("aws:ResourceTag/owner", [])
+
+    def test_pattern_without_slash_ignored(self):
+        """Patterns without '/' should not match keys with '/'."""
+        assert not condition_key_in_list("aws:ResourceTag/owner", ["aws:SourceIp"])
+
+
+# =============================================================================
+# Unit tests: find_matching_condition_key
+# =============================================================================
+
+
+class TestFindMatchingConditionKey:
+    """Tests for find_matching_condition_key (dict lookup that returns the pattern key)."""
+
+    def test_exact_match_returns_key(self):
+        keys = {"aws:SourceIp": MagicMock(), "aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:SourceIp", keys) == "aws:SourceIp"
+
+    def test_pattern_match_returns_pattern(self):
+        keys = {"aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:ResourceTag/owner", keys) == "aws:ResourceTag/${TagKey}"
+
+    def test_compound_tag_key_returns_pattern(self):
+        keys = {"aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:ResourceTag/team/owner", keys) == "aws:ResourceTag/${TagKey}"
+
+    def test_multiple_slashes_returns_pattern(self):
+        keys = {"aws:RequestTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:RequestTag/a/b/c", keys) == "aws:RequestTag/${TagKey}"
+
+    def test_no_match_returns_none(self):
+        keys = {"aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:SourceIp", keys) is None
+
+    def test_wrong_prefix_returns_none(self):
+        keys = {"aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:RequestTag/owner", keys) is None
+
+    def test_empty_dict_returns_none(self):
+        assert find_matching_condition_key("aws:ResourceTag/owner", {}) is None
+
+    def test_empty_tag_key_returns_none(self):
+        keys = {"aws:ResourceTag/${TagKey}": MagicMock()}
+        assert find_matching_condition_key("aws:ResourceTag/", keys) is None
+
+    def test_service_specific_pattern(self):
+        keys = {"ssm:resourceTag/tag-key": MagicMock(), "ssm:Overwrite": MagicMock()}
+        assert find_matching_condition_key("ssm:resourceTag/ns/key", keys) == "ssm:resourceTag/tag-key"
+
+    def test_caller_can_get_metadata_from_matched_key(self):
+        """Verify the intended usage: look up type info from the matched pattern."""
+        cond_key_obj = ConditionKey(Name="aws:ResourceTag/${TagKey}", Types=["String"])
+        keys = {"aws:ResourceTag/${TagKey}": cond_key_obj}
+        matched = find_matching_condition_key("aws:ResourceTag/team/owner", keys)
+        assert matched is not None
+        assert keys[matched].types == ["String"]
+
+
+# =============================================================================
+# Unit tests: _is_valid_tag_key (allowed characters)
+# =============================================================================
+
+
+class TestIsValidTagKey:
+    """Ensure tag key validation covers the full AWS allowed character set."""
+
+    @pytest.mark.parametrize(
+        "tag_key",
+        [
+            "owner",
+            "Environment",
+            "cost-center",
+            "Cost Center",
+            "key/with/slashes",
+            "key+plus",
+            "key=equals",
+            "key.dot",
+            "key_under",
+            "key:colon",
+            "key@at",
+            "a",
+            "a" * 128,
+        ],
+    )
+    def test_valid_tag_keys(self, tag_key):
+        assert _is_valid_tag_key(tag_key)
+
+    @pytest.mark.parametrize(
+        "tag_key",
+        [
+            "",
+            "a" * 129,
+            "key<angle",
+            "key>angle",
+            "key*star",
+            "key?question",
+            "key#hash",
+            "key$dollar",
+            "key%percent",
+            "key{brace",
+            "key}brace",
+            "key|pipe",
+            "key\\backslash",
+            "key~tilde",
+            "key`backtick",
+        ],
+    )
+    def test_invalid_tag_keys(self, tag_key):
+        assert not _is_valid_tag_key(tag_key)
+
+
+# =============================================================================
+# Integration: condition_type_mismatch with compound tag keys
+# =============================================================================
+
+
+class TestConditionTypeMismatchPatternMatching:
+    """Test that condition_type_mismatch resolves types for compound tag keys."""
+
+    @pytest.mark.asyncio
+    async def test_simple_tag_key_type_resolved(self):
+        """aws:ResourceTag/owner should resolve to String type."""
+        from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
+
+        check = ConditionTypeMismatchCheck()
+        async with AWSServiceFetcher() as fetcher:
+            key_type = await check._get_condition_key_type(
+                fetcher, "aws:ResourceTag/owner", ["events:DeleteEventBus"], ["*"]
+            )
+        assert key_type == "String"
+
+    @pytest.mark.asyncio
+    async def test_compound_tag_key_type_resolved(self):
+        """aws:ResourceTag/team/owner must also resolve to String type."""
+        from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
+
+        check = ConditionTypeMismatchCheck()
+        async with AWSServiceFetcher() as fetcher:
+            key_type = await check._get_condition_key_type(
+                fetcher, "aws:ResourceTag/team/owner", ["events:DeleteEventBus"], ["*"]
+            )
+        assert key_type == "String"
+
+    @pytest.mark.asyncio
+    async def test_request_tag_compound_key_type_resolved(self):
+        """aws:RequestTag/dept/env should resolve to String for actions that support it."""
+        from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
+
+        check = ConditionTypeMismatchCheck()
+        async with AWSServiceFetcher() as fetcher:
+            key_type = await check._get_condition_key_type(
+                fetcher, "aws:RequestTag/dept/env", ["iam:CreateRole"], ["*"]
+            )
+        assert key_type == "String"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_tag_key_returns_none(self):
+        """A condition key with no matching pattern in any service should return None."""
+        from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
+
+        check = ConditionTypeMismatchCheck()
+        async with AWSServiceFetcher() as fetcher:
+            # Use a completely fabricated condition key that no service defines
+            key_type = await check._get_condition_key_type(
+                fetcher, "custom:NonExistentTag/team/owner", ["sts:GetCallerIdentity"], ["*"]
+            )
+        assert key_type is None
+
+    @pytest.mark.asyncio
+    async def test_type_resolution_with_mock_service_detail(self):
+        """Test with mock to verify find_matching_condition_key is called correctly."""
+        from iam_validator.checks.condition_type_mismatch import ConditionTypeMismatchCheck
+
+        check = ConditionTypeMismatchCheck()
+
+        fetcher = MagicMock()
+        fetcher.parse_action = MagicMock(return_value=("events", "DeleteEventBus"))
+
+        action_detail = MagicMock()
+        action_detail.action_condition_keys = []
+        action_detail.resources = [{"Name": "event-bus"}]
+
+        resource_type = MagicMock()
+        resource_type.condition_keys = ["aws:ResourceTag/${TagKey}"]
+
+        service_detail = MagicMock()
+        service_detail.condition_keys = {
+            "aws:ResourceTag/${TagKey}": ConditionKey(
+                Name="aws:ResourceTag/${TagKey}", Types=["String"]
+            ),
+        }
+        service_detail.actions = {"DeleteEventBus": action_detail}
+        service_detail.resources = {"event-bus": resource_type}
+        fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
+
+        key_type = await check._get_condition_key_type(
+            fetcher, "aws:ResourceTag/team/owner", ["events:DeleteEventBus"], ["*"]
+        )
+        assert key_type == "String"
+
+
+# =============================================================================
+# Integration: set_operator_validation with compound tag keys
+# =============================================================================
+
+
+class TestSetOperatorValidationPatternMatching:
+    """Test that set_operator_validation resolves types for compound tag keys."""
+
+    @pytest.mark.asyncio
+    async def test_arrayofstring_compound_tag_key_with_mock(self):
+        """Mock service with ArrayOfString tag pattern — compound key must resolve."""
+        from iam_validator.checks.set_operator_validation import SetOperatorValidationCheck
+
+        check = SetOperatorValidationCheck()
+
+        fetcher = MagicMock()
+        fetcher.parse_action = MagicMock(return_value=("svc", "DoThing"))
+        service_detail = MagicMock()
+        service_detail.condition_keys = {
+            "svc:tag/${TagKey}": ConditionKey(
+                Name="svc:tag/${TagKey}", Types=["ArrayOfString"]
+            ),
+        }
+        fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
+
+        result = await check._is_multivalued_key(
+            "svc:tag/team/owner", fetcher, ["svc:DoThing"]
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_string_type_compound_tag_key_is_single_valued(self):
+        """Compound tag key with String type (not ArrayOfString) is still single-valued."""
+        from iam_validator.checks.set_operator_validation import SetOperatorValidationCheck
+
+        check = SetOperatorValidationCheck()
+
+        fetcher = MagicMock()
+        fetcher.parse_action = MagicMock(return_value=("events", "DeleteEventBus"))
+        service_detail = MagicMock()
+        service_detail.condition_keys = {
+            "aws:ResourceTag/${TagKey}": ConditionKey(
+                Name="aws:ResourceTag/${TagKey}", Types=["String"]
+            ),
+        }
+        fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
+
+        result = await check._is_multivalued_key(
+            "aws:ResourceTag/team/owner", fetcher, ["events:DeleteEventBus"]
+        )
+        assert result is False
+
+
+# =============================================================================
+# Integration: wildcard_resource ABAC with compound tag keys
+# =============================================================================
+
+
+class TestWildcardResourceCompoundTagKeys:
+    """Test wildcard_resource ABAC detection with compound tag keys."""
+
+    @pytest.fixture
+    def check(self):
+        from iam_validator.checks.wildcard_resource import WildcardResourceCheck
+
+        return WildcardResourceCheck()
+
+    @pytest.fixture
+    def config(self):
+        from iam_validator.core.check_registry import CheckConfig
+
+        return CheckConfig(check_id="wildcard_resource", enabled=True, config={})
+
+    @pytest.fixture
+    async def fetcher(self):
+        async with AWSServiceFetcher(prefetch_common=False) as f:
+            yield f
+
+    @pytest.mark.asyncio
+    async def test_compound_resource_tag_lowers_severity(self, check, fetcher, config):
+        """aws:ResourceTag/team/owner with events:DeleteEventBus should lower severity."""
+        from iam_validator.core.models import Statement
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["events:DeleteEventBus"],
+            Resource=["*"],
+            Condition={"StringEquals": {"aws:ResourceTag/team/owner": "my-team"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"
+        assert "ABAC" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_compound_request_tag_lowers_severity(self, check, fetcher, config):
+        """aws:RequestTag/org/team with sqs:CreateQueue should lower severity."""
+        from iam_validator.core.models import Statement
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["sqs:CreateQueue"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {"aws:RequestTag/org/team": "${aws:PrincipalTag/org/team}"},
+                "Null": {"aws:RequestTag/org/team": "false"},
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"
+        assert "ABAC" in issues[0].message
+
+
+# =============================================================================
+# Backward compatibility: CheckDocumentation
+# =============================================================================
+
+
+class TestCheckDocumentationBackwardCompatibility:
+    """Ensure CheckDocumentation works with and without short_description."""
+
+    def test_with_all_fields(self):
+        from iam_validator.core.config.check_documentation import CheckDocumentation
+
+        doc = CheckDocumentation(
+            check_id="test",
+            short_description="Test Check",
+            risk_explanation="Risk",
+            documentation_url="https://example.com",
+            remediation_steps=["Step 1"],
+            risk_category="validation",
+        )
+        assert doc.short_description == "Test Check"
+
+    def test_without_short_description(self):
+        """Custom checks written against older API must still work."""
+        from iam_validator.core.config.check_documentation import CheckDocumentation
+
+        doc = CheckDocumentation(
+            check_id="custom_check",
+            risk_explanation="Some risk",
+            documentation_url="https://example.com",
+        )
+        assert doc.short_description == ""
+        assert doc.check_id == "custom_check"
+
+    def test_without_optional_fields(self):
+        """Minimal construction with only required fields."""
+        from iam_validator.core.config.check_documentation import CheckDocumentation
+
+        doc = CheckDocumentation(
+            check_id="minimal",
+            risk_explanation="Risk",
+            documentation_url="https://example.com",
+        )
+        assert doc.remediation_steps == []
+        assert doc.risk_category is None
+        assert doc.short_description == ""
+
+    def test_registry_get_short_description_returns_none_for_empty(self):
+        """get_short_description should return None when short_description is empty."""
+        from iam_validator.core.config.check_documentation import (
+            CheckDocumentation,
+            CheckDocumentationRegistry,
+        )
+
+        CheckDocumentationRegistry.register(
+            CheckDocumentation(
+                check_id="_test_empty_desc",
+                risk_explanation="Risk",
+                documentation_url="https://example.com",
+            )
+        )
+        assert CheckDocumentationRegistry.get_short_description("_test_empty_desc") is None
+
+    def test_registry_get_short_description_returns_value_when_set(self):
+        from iam_validator.core.config.check_documentation import (
+            CheckDocumentation,
+            CheckDocumentationRegistry,
+        )
+
+        CheckDocumentationRegistry.register(
+            CheckDocumentation(
+                check_id="_test_with_desc",
+                risk_explanation="Risk",
+                documentation_url="https://example.com",
+                short_description="My Check",
+            )
+        )
+        assert CheckDocumentationRegistry.get_short_description("_test_with_desc") == "My Check"

--- a/tests/core/test_condition_key_pattern_matching.py
+++ b/tests/core/test_condition_key_pattern_matching.py
@@ -297,9 +297,7 @@ class TestConditionTypeMismatchPatternMatching:
 
         service_detail = MagicMock()
         service_detail.condition_keys = {
-            "aws:ResourceTag/${TagKey}": ConditionKey(
-                Name="aws:ResourceTag/${TagKey}", Types=["String"]
-            ),
+            "aws:ResourceTag/${TagKey}": ConditionKey(Name="aws:ResourceTag/${TagKey}", Types=["String"]),
         }
         service_detail.actions = {"DeleteEventBus": action_detail}
         service_detail.resources = {"event-bus": resource_type}
@@ -330,15 +328,11 @@ class TestSetOperatorValidationPatternMatching:
         fetcher.parse_action = MagicMock(return_value=("svc", "DoThing"))
         service_detail = MagicMock()
         service_detail.condition_keys = {
-            "svc:tag/${TagKey}": ConditionKey(
-                Name="svc:tag/${TagKey}", Types=["ArrayOfString"]
-            ),
+            "svc:tag/${TagKey}": ConditionKey(Name="svc:tag/${TagKey}", Types=["ArrayOfString"]),
         }
         fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
 
-        result = await check._is_multivalued_key(
-            "svc:tag/team/owner", fetcher, ["svc:DoThing"]
-        )
+        result = await check._is_multivalued_key("svc:tag/team/owner", fetcher, ["svc:DoThing"])
         assert result is True
 
     @pytest.mark.asyncio
@@ -352,15 +346,11 @@ class TestSetOperatorValidationPatternMatching:
         fetcher.parse_action = MagicMock(return_value=("events", "DeleteEventBus"))
         service_detail = MagicMock()
         service_detail.condition_keys = {
-            "aws:ResourceTag/${TagKey}": ConditionKey(
-                Name="aws:ResourceTag/${TagKey}", Types=["String"]
-            ),
+            "aws:ResourceTag/${TagKey}": ConditionKey(Name="aws:ResourceTag/${TagKey}", Types=["String"]),
         }
         fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
 
-        result = await check._is_multivalued_key(
-            "aws:ResourceTag/team/owner", fetcher, ["events:DeleteEventBus"]
-        )
+        result = await check._is_multivalued_key("aws:ResourceTag/team/owner", fetcher, ["events:DeleteEventBus"])
         assert result is False
 
 

--- a/tests/core/test_pr_commenter_diff_filtering.py
+++ b/tests/core/test_pr_commenter_diff_filtering.py
@@ -28,6 +28,8 @@ class TestPRCommenterDiffFiltering:
         github.create_review_comment = AsyncMock(return_value=False)
         github.create_file_level_comment = AsyncMock(return_value=False)
         github.get_pr_info = AsyncMock(return_value={"head": {"sha": "abc123"}})
+        github._get_bot_comments_by_fingerprint = AsyncMock(return_value={})
+        github.update_review_comment = AsyncMock(return_value=True)
         return github
 
     @pytest.fixture
@@ -379,6 +381,8 @@ class TestPRCommenterOffDiffPipeline:
         github.create_review_comment = AsyncMock(return_value=False)
         github.create_file_level_comment = AsyncMock(return_value=False)
         github.get_pr_info = AsyncMock(return_value={"head": {"sha": "abc123"}})
+        github._get_bot_comments_by_fingerprint = AsyncMock(return_value={})
+        github.update_review_comment = AsyncMock(return_value=True)
         return github
 
     @pytest.fixture
@@ -573,6 +577,136 @@ class TestPRCommenterOffDiffPipeline:
         assert ctx.line_number == 14
         assert ctx.issue.severity == "critical"
         assert ctx.issue.issue_type == "wildcard_action"
+
+    @pytest.mark.asyncio
+    async def test_off_diff_skips_existing_unchanged_comment(self, mock_github, sample_policy_file):
+        """Test that off-diff pipeline skips posting when identical comment already exists."""
+        from iam_validator.core.finding_fingerprint import FindingFingerprint
+
+        issue = ValidationIssue(
+            policy_file=sample_policy_file,
+            statement_index=1,
+            severity="critical",
+            issue_type="wildcard_action",
+            message="Action uses dangerous wildcard",
+            action="dynamodb:*",
+            line_number=14,
+        )
+
+        relative_path = Path(sample_policy_file).name
+        fp_hash = FindingFingerprint.from_issue(issue, relative_path).to_hash()
+
+        # Build the expected body (same as what _post_off_diff_comments would generate)
+        expected_body = issue.to_pr_comment(file_path=relative_path)
+        expected_body += "\n\n> **Note:** This finding is on line 14, which was not modified in this PR."
+
+        # Mock existing comment with same fingerprint and same body
+        mock_github._get_bot_comments_by_fingerprint.return_value = {
+            fp_hash: {
+                "id": 42,
+                "body": expected_body,
+                "path": relative_path,
+                "line": 14,
+            }
+        }
+
+        report = ValidationReport(
+            results=[
+                PolicyValidationResult(
+                    policy_file=sample_policy_file,
+                    is_valid=False,
+                    issues=[issue],
+                    policy_type="IDENTITY_POLICY",
+                )
+            ],
+            total_policies=1,
+            valid_policies=0,
+            invalid_policies=1,
+            total_issues=1,
+        )
+
+        mock_github.get_pr_files.return_value = [
+            {
+                "filename": relative_path,
+                "status": "modified",
+                "patch": '@@ -4,7 +4,7 @@\n     {\n       "Sid": "AllowS3Read",\n       "Effect": "Allow",\n-      "Action": "s3:GetObject",\n+      "Action": "s3:*",\n       "Resource": "*"\n     },\n     {',
+            }
+        ]
+
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False)
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            await commenter._post_review_comments(report)
+
+        # Should NOT create a new comment (dedup skipped it)
+        mock_github.create_review_comment.assert_not_called()
+        mock_github.create_file_level_comment.assert_not_called()
+        # Should NOT update (body unchanged)
+        mock_github.update_review_comment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_off_diff_updates_existing_changed_comment(self, mock_github, sample_policy_file):
+        """Test that off-diff pipeline updates comment when body has changed."""
+        from iam_validator.core.finding_fingerprint import FindingFingerprint
+
+        issue = ValidationIssue(
+            policy_file=sample_policy_file,
+            statement_index=1,
+            severity="critical",
+            issue_type="wildcard_action",
+            message="Action uses dangerous wildcard",
+            action="dynamodb:*",
+            line_number=14,
+        )
+
+        relative_path = Path(sample_policy_file).name
+        fp_hash = FindingFingerprint.from_issue(issue, relative_path).to_hash()
+
+        # Mock existing comment with same fingerprint but DIFFERENT body (stale)
+        mock_github._get_bot_comments_by_fingerprint.return_value = {
+            fp_hash: {
+                "id": 42,
+                "body": "old stale body content",
+                "path": relative_path,
+                "line": 14,
+            }
+        }
+
+        report = ValidationReport(
+            results=[
+                PolicyValidationResult(
+                    policy_file=sample_policy_file,
+                    is_valid=False,
+                    issues=[issue],
+                    policy_type="IDENTITY_POLICY",
+                )
+            ],
+            total_policies=1,
+            valid_policies=0,
+            invalid_policies=1,
+            total_issues=1,
+        )
+
+        mock_github.get_pr_files.return_value = [
+            {
+                "filename": relative_path,
+                "status": "modified",
+                "patch": '@@ -4,7 +4,7 @@\n     {\n       "Sid": "AllowS3Read",\n       "Effect": "Allow",\n-      "Action": "s3:GetObject",\n+      "Action": "s3:*",\n       "Resource": "*"\n     },\n     {',
+            }
+        ]
+
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False)
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            await commenter._post_review_comments(report)
+
+        # Should NOT create a new comment
+        mock_github.create_review_comment.assert_not_called()
+        mock_github.create_file_level_comment.assert_not_called()
+        # Should UPDATE existing comment with new body
+        mock_github.update_review_comment.assert_called_once()
+        call_args = mock_github.update_review_comment.call_args
+        assert call_args[0][0] == 42  # comment ID
 
 
 class TestPRCommenterBlockingIssuesIgnored:

--- a/tests/core/test_pr_commenter_diff_filtering.py
+++ b/tests/core/test_pr_commenter_diff_filtering.py
@@ -454,9 +454,7 @@ class TestPRCommenterOffDiffPipeline:
             }
         ]
 
-        commenter = PRCommenter(
-            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual"
-        )
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             await commenter._post_review_comments(report)
@@ -956,15 +954,15 @@ class TestOffDiffCommentMode:
     def diff_patch(self):
         """Diff patch that only changes line 7 in statement 0."""
         return (
-            '@@ -4,7 +4,7 @@\n'
-            '     {\n'
+            "@@ -4,7 +4,7 @@\n"
+            "     {\n"
             '       "Sid": "AllowS3Read",\n'
             '       "Effect": "Allow",\n'
             '-      "Action": "s3:GetObject",\n'
             '+      "Action": "s3:*",\n'
             '       "Resource": "*"\n'
-            '     },\n'
-            '     {'
+            "     },\n"
+            "     {"
         )
 
     @pytest.mark.asyncio
@@ -976,9 +974,7 @@ class TestOffDiffCommentMode:
             {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
         ]
 
-        commenter = PRCommenter(
-            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only"
-        )
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             with mock.patch.object(commenter, "_post_off_diff_comments", new_callable=AsyncMock) as mock_post:
@@ -997,9 +993,7 @@ class TestOffDiffCommentMode:
             {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
         ]
 
-        commenter = PRCommenter(
-            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual"
-        )
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             with mock.patch.object(
@@ -1045,9 +1039,7 @@ class TestOffDiffCommentMode:
             {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
         ]
 
-        commenter = PRCommenter(
-            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only"
-        )
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             await commenter._post_review_comments(report_with_off_diff_issues)

--- a/tests/core/test_pr_commenter_diff_filtering.py
+++ b/tests/core/test_pr_commenter_diff_filtering.py
@@ -454,7 +454,9 @@ class TestPRCommenterOffDiffPipeline:
             }
         ]
 
-        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False)
+        commenter = PRCommenter(
+            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual"
+        )
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             await commenter._post_review_comments(report)
@@ -633,7 +635,7 @@ class TestPRCommenterOffDiffPipeline:
             }
         ]
 
-        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False)
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             await commenter._post_review_comments(report)
@@ -695,7 +697,7 @@ class TestPRCommenterOffDiffPipeline:
             }
         ]
 
-        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False)
+        commenter = PRCommenter(github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual")
 
         with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
             await commenter._post_review_comments(report)
@@ -867,6 +869,229 @@ class TestPRCommenterBlockingIssuesIgnored:
 
         result = commenter._are_all_blocking_issues_ignored(report)
         assert result is False
+
+
+class TestOffDiffCommentMode:
+    """Tests for the off_diff_comment_mode setting."""
+
+    @pytest.fixture
+    def sample_policy_file(self):
+        """Create a temporary policy file for testing."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(
+                """{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowS3Read",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowDynamoDB",
+      "Effect": "Allow",
+      "Action": "dynamodb:*",
+      "Resource": "arn:aws:dynamodb:*:*:table/*"
+    }
+  ]
+}"""
+            )
+            policy_file = f.name
+
+        yield policy_file
+        Path(policy_file).unlink()
+
+    @pytest.fixture
+    def mock_github(self):
+        """Create a mock GitHub integration."""
+        github = MagicMock(spec=GitHubIntegration)
+        github.is_configured = MagicMock(return_value=True)
+        github.get_pr_files = AsyncMock(return_value=[])
+        github.update_or_create_review_comments = AsyncMock(return_value=True)
+        github.post_multipart_comments = AsyncMock(return_value=True)
+        github.create_review_comment = AsyncMock(return_value=False)
+        github.create_file_level_comment = AsyncMock(return_value=False)
+        github.get_pr_info = AsyncMock(return_value={"head": {"sha": "abc123"}})
+        github.get_existing_review_comments = AsyncMock(return_value=[])
+        github.update_review_comment = AsyncMock(return_value=True)
+        return github
+
+    @pytest.fixture
+    def report_with_off_diff_issues(self, sample_policy_file):
+        """Report with issues on lines that won't match the diff (off-diff)."""
+        return ValidationReport(
+            total_policies=1,
+            valid_policies=0,
+            invalid_policies=1,
+            total_issues=2,
+            results=[
+                PolicyValidationResult(
+                    policy_file=sample_policy_file,
+                    is_valid=False,
+                    issues=[
+                        # Issue on line 8 (Resource in statement 0, modified statement but unchanged line)
+                        ValidationIssue(
+                            severity="medium",
+                            issue_type="wildcard_resource",
+                            message="Wildcard resource",
+                            statement_index=0,
+                            line_number=8,
+                        ),
+                        # Issue on line 14 (unchanged statement 1)
+                        ValidationIssue(
+                            severity="high",
+                            issue_type="service_wildcard",
+                            message="Service wildcard",
+                            statement_index=1,
+                            line_number=14,
+                        ),
+                    ],
+                    policy_type="IDENTITY_POLICY",
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def diff_patch(self):
+        """Diff patch that only changes line 7 in statement 0."""
+        return (
+            '@@ -4,7 +4,7 @@\n'
+            '     {\n'
+            '       "Sid": "AllowS3Read",\n'
+            '       "Effect": "Allow",\n'
+            '-      "Action": "s3:GetObject",\n'
+            '+      "Action": "s3:*",\n'
+            '       "Resource": "*"\n'
+            '     },\n'
+            '     {'
+        )
+
+    @pytest.mark.asyncio
+    async def test_summary_only_skips_off_diff_posting(
+        self, mock_github, sample_policy_file, report_with_off_diff_issues, diff_patch
+    ):
+        """summary_only mode should not call _post_off_diff_comments."""
+        mock_github.get_pr_files.return_value = [
+            {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
+        ]
+
+        commenter = PRCommenter(
+            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only"
+        )
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            with mock.patch.object(commenter, "_post_off_diff_comments", new_callable=AsyncMock) as mock_post:
+                await commenter._post_review_comments(report_with_off_diff_issues)
+                mock_post.assert_not_called()
+
+        # Context issues should remain for summary (both off-diff issues)
+        assert len(commenter._context_issues) >= 1
+
+    @pytest.mark.asyncio
+    async def test_individual_posts_all_off_diff(
+        self, mock_github, sample_policy_file, report_with_off_diff_issues, diff_patch
+    ):
+        """individual mode should pass all context issues to _post_off_diff_comments."""
+        mock_github.get_pr_files.return_value = [
+            {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
+        ]
+
+        commenter = PRCommenter(
+            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="individual"
+        )
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            with mock.patch.object(
+                commenter, "_post_off_diff_comments", new_callable=AsyncMock, return_value=(set(), [])
+            ) as mock_post:
+                await commenter._post_review_comments(report_with_off_diff_issues)
+                mock_post.assert_called_once()
+                # Should pass all context issues (both modified-statement and unchanged-statement)
+                assert len(mock_post.call_args[0][0]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_modified_statements_only_splits_correctly(
+        self, mock_github, sample_policy_file, report_with_off_diff_issues, diff_patch
+    ):
+        """modified_statements_only should only post issues from modified statements."""
+        mock_github.get_pr_files.return_value = [
+            {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
+        ]
+
+        commenter = PRCommenter(
+            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="modified_statements_only"
+        )
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            with mock.patch.object(
+                commenter, "_post_off_diff_comments", new_callable=AsyncMock, return_value=(set(), [])
+            ) as mock_post:
+                await commenter._post_review_comments(report_with_off_diff_issues)
+                mock_post.assert_called_once()
+                # Should only pass modified-statement issues (in_modified_statement=True)
+                posted_issues = mock_post.call_args[0][0]
+                assert all(ci.in_modified_statement for ci in posted_issues)
+
+        # Unchanged-statement issues should remain in _context_issues for summary
+        assert any(not ci.in_modified_statement for ci in commenter._context_issues)
+
+    @pytest.mark.asyncio
+    async def test_in_modified_statement_flag_set_correctly(
+        self, mock_github, sample_policy_file, report_with_off_diff_issues, diff_patch
+    ):
+        """Verify in_modified_statement flag is set correctly on ContextIssue during diff filtering."""
+        mock_github.get_pr_files.return_value = [
+            {"filename": Path(sample_policy_file).name, "status": "modified", "patch": diff_patch}
+        ]
+
+        commenter = PRCommenter(
+            github=mock_github, cleanup_old_comments=False, off_diff_comment_mode="summary_only"
+        )
+
+        with mock.patch.dict(os.environ, {"GITHUB_WORKSPACE": Path(sample_policy_file).parent.as_posix()}):
+            await commenter._post_review_comments(report_with_off_diff_issues)
+
+        # Should have context issues with both in_modified_statement=True and False
+        modified = [ci for ci in commenter._context_issues if ci.in_modified_statement]
+        unchanged = [ci for ci in commenter._context_issues if not ci.in_modified_statement]
+        # Statement 0 was modified (line 7 changed), so its off-diff issue (line 8) is in_modified_statement=True
+        assert len(modified) >= 1
+        # Statement 1 was NOT modified, so its issue (line 14) is in_modified_statement=False
+        assert len(unchanged) >= 1
+
+    def test_default_mode_is_summary_only(self, mock_github):
+        """PRCommenter should default to summary_only mode."""
+        commenter = PRCommenter(github=mock_github)
+        assert commenter.off_diff_comment_mode == "summary_only"
+
+
+class TestOffDiffCommentModeConfigValidation:
+    """Tests for off_diff_comment_mode config validation."""
+
+    def test_valid_modes_accepted(self):
+        """All valid modes should be accepted by schema validation."""
+        from iam_validator.core.config.config_loader import SettingsSchema
+
+        for mode in ["summary_only", "individual", "modified_statements_only"]:
+            schema = SettingsSchema(off_diff_comment_mode=mode)
+            assert schema.off_diff_comment_mode == mode
+
+    def test_invalid_mode_rejected(self):
+        """Invalid modes should raise ValidationError."""
+        from pydantic import ValidationError
+
+        from iam_validator.core.config.config_loader import SettingsSchema
+
+        with pytest.raises(ValidationError, match="Invalid off_diff_comment_mode"):
+            SettingsSchema(off_diff_comment_mode="invalid_mode")
+
+    def test_default_is_summary_only(self):
+        """Default mode in schema should be summary_only."""
+        from iam_validator.core.config.config_loader import SettingsSchema
+
+        schema = SettingsSchema()
+        assert schema.off_diff_comment_mode == "summary_only"
 
 
 if __name__ == "__main__":

--- a/tests/core/test_set_operator_validation.py
+++ b/tests/core/test_set_operator_validation.py
@@ -1,10 +1,12 @@
 """Tests for Set Operator Validation Check."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from iam_validator.checks.set_operator_validation import SetOperatorValidationCheck
 from iam_validator.core.check_registry import CheckConfig
-from iam_validator.core.models import Statement
+from iam_validator.core.models import ConditionKey, Statement
 
 
 class TestSetOperatorValidationCheck:
@@ -438,3 +440,111 @@ class TestForAllValuesIfExistsCompound:
         )
         issues = await check.execute(statement, 0, None, config)
         assert not any(i.issue_type == "forallvalues_allow_without_null_check" for i in issues)
+
+
+class TestAWSServiceMetadataLookup:
+    """Test multivalued key detection via AWS service metadata (ArrayOfString types)."""
+
+    @pytest.fixture
+    def check(self):
+        return SetOperatorValidationCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(check_id="set_operator_validation", enabled=True)
+
+    @pytest.fixture
+    def mock_fetcher_with_route53(self):
+        """Mock fetcher that returns route53 service data with ArrayOfString condition key."""
+        fetcher = MagicMock()
+        fetcher.parse_action = MagicMock(return_value=("route53", "ChangeResourceRecordSets"))
+
+        service_detail = MagicMock()
+        service_detail.condition_keys = {
+            "route53:ChangeResourceRecordSetsNormalizedRecordNames": ConditionKey(
+                Name="route53:ChangeResourceRecordSetsNormalizedRecordNames",
+                Description="DNS record names",
+                Types=["ArrayOfString"],
+            ),
+            "route53:ChangeResourceRecordSetsTTL": ConditionKey(
+                Name="route53:ChangeResourceRecordSetsTTL",
+                Description="TTL value",
+                Types=["Numeric"],
+            ),
+        }
+        fetcher.fetch_service_by_name = AsyncMock(return_value=service_detail)
+        return fetcher
+
+    @pytest.mark.asyncio
+    async def test_arrayofstring_key_recognized_as_multivalued(self, check, config, mock_fetcher_with_route53):
+        """Test that a condition key with ArrayOfString type is recognized as multivalued."""
+        statement = Statement(
+            effect="Allow",
+            action=["route53:ChangeResourceRecordSets"],
+            resource=["*"],
+            condition={
+                "ForAllValues:StringLike": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": ["*.example.com"],
+                },
+                "Null": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": "false",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, mock_fetcher_with_route53, config)
+        # Should NOT flag as single-valued key since AWS metadata says ArrayOfString
+        assert not any(i.issue_type == "set_operator_on_single_valued_key" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_numeric_key_still_flagged_as_single_valued(self, check, config, mock_fetcher_with_route53):
+        """Test that a condition key with Numeric type is still flagged as single-valued."""
+        statement = Statement(
+            effect="Allow",
+            action=["route53:ChangeResourceRecordSets"],
+            resource=["*"],
+            condition={
+                "ForAllValues:NumericEquals": {
+                    "route53:ChangeResourceRecordSetsTTL": ["300"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, mock_fetcher_with_route53, config)
+        assert any(i.issue_type == "set_operator_on_single_valued_key" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_fetcher_lookup_falls_back_when_fetcher_is_none(self, check, config):
+        """Test that when fetcher is None, unknown service keys are treated as single-valued."""
+        statement = Statement(
+            effect="Allow",
+            action=["route53:ChangeResourceRecordSets"],
+            resource=["*"],
+            condition={
+                "ForAllValues:StringLike": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": ["*.example.com"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        # Without fetcher, falls back to hardcoded list — key is unknown, so flagged
+        assert any(i.issue_type == "set_operator_on_single_valued_key" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_fetcher_exception_handled_gracefully(self, check, config):
+        """Test that fetcher exceptions don't break the check."""
+        fetcher = MagicMock()
+        fetcher.parse_action = MagicMock(return_value=("route53", "ChangeResourceRecordSets"))
+        fetcher.fetch_service_by_name = AsyncMock(side_effect=Exception("Network error"))
+
+        statement = Statement(
+            effect="Allow",
+            action=["route53:ChangeResourceRecordSets"],
+            resource=["*"],
+            condition={
+                "ForAllValues:StringLike": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": ["*.example.com"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        # Falls back to single-valued when fetcher fails
+        assert any(i.issue_type == "set_operator_on_single_valued_key" for i in issues)


### PR DESCRIPTION
## Summary

- Add `off_diff_comment_mode` setting (`summary_only`, `individual`, `modified_statements_only`) to control how findings on unchanged PR lines are surfaced — reduces review noise by consolidating off-diff
issues into the summary table by default
- Fix false positives in `condition_key_in_list`, `condition_type_mismatch`, `set_operator_validation`, and `wildcard_resource` caused by compound tag keys containing `/` (e.g.,
`aws:ResourceTag/team/project-owner`) and missing pattern-aware lookups
- Change `PolicyCheck` base class from `@property` to `ClassVar[str]` for `check_id`, `description`, and `default_severity` to resolve IDE warnings
- Fix `CheckDocumentation` breaking custom check loading when `short_description` field is missing

## Changes

### New feature: `off_diff_comment_mode`
- New config setting, CLI argument (`--off-diff-comment-mode`), and GitHub Action input
- Three modes: `summary_only` (new default), `individual` (previous behavior), `modified_statements_only`
- Wired through all 6 `PRCommenter` instantiation sites
- Schema validation via Pydantic field validator
- Shell completions (bash + zsh) updated
- Full reference config and `action.yaml` updated

### Bug fixes
- Replace `rfind("/")` with pattern prefix length in `condition_key_in_list` — compound tag keys like `team/owner` no longer split at wrong `/`
- Add `find_matching_condition_key()` for dict-based pattern lookups with metadata access
- Replace exact `in` lookups with pattern-aware matching in `condition_type_mismatch` and `set_operator_validation`
- Look up `Types` metadata from AWS service definitions instead of hardcoded allowlist in `set_operator_validation`
- Unify ABAC tag condition detection in `wildcard_resource` to cover all tag-based keys
- Add fingerprint-based deduplication for off-diff PR comments
- Make `CheckDocumentation.short_description` optional with `kw_only=True`

## Test plan

- [x] 1203 tests pass, 26 skipped (pre-existing)
- [x] `uv run ruff check` passes
- [x] New `TestOffDiffCommentMode` class (5 tests) + `TestOffDiffCommentModeConfigValidation` (3 tests)
- [x] New `test_condition_key_pattern_matching.py` with comprehensive unit + integration tests
- [x] Backward compatibility verified: `ClassVar`, `@property`, and bare attribute approaches all work for `PolicyCheck`