### PR TITLE
fix: lower service_wildcard severity when ABAC tag conditions restrict access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.18.1] - 2026-03-10
 
+### Added
+
+- Add `"none"` severity level to suppress findings entirely — checks can set severity to `"none"` to filter issues from all output (CLI, PR comments, JSON, SARIF, etc.)
+
 ### Fixed
 
 - Fix `service_wildcard` reporting `high` severity for service wildcards with ABAC tag conditions (`aws:ResourceTag/*` = `${aws:PrincipalTag/*}`) — severity is now reduced to `low` (configurable via `abac_mitigated_severity`) when tag-based ownership constraints restrict the blast radius

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-03-10
+
+### Fixed
+
+- Fix `service_wildcard` reporting `high` severity for service wildcards with ABAC tag conditions (`aws:ResourceTag/*` = `${aws:PrincipalTag/*}`) — severity is now reduced to `low` (configurable via `abac_mitigated_severity`) when tag-based ownership constraints restrict the blast radius
+- Fix `service_wildcard` ABAC detection not recognizing `ForAllValues:`/`ForAnyValue:` set operator prefixes and `IfExists` suffix on condition operators
+- Fix `service_wildcard` ABAC detection not explicitly excluding negated operators (`StringNotEquals`, `StringNotLike`) which do not restrict access
+
+---
+
 ## [1.18.0] - 2026-02-27
 
 ### Added
@@ -488,6 +498,7 @@ _First release._
 
 ---
 
+[1.18.1]: https://github.com/boogy/iam-policy-validator/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/boogy/iam-policy-validator/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/boogy/iam-policy-validator/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/boogy/iam-policy-validator/compare/v1.15.5...v1.16.0

--- a/docs/user-guide/checks/security-checks.md
+++ b/docs/user-guide/checks/security-checks.md
@@ -181,9 +181,9 @@ Or use resource-scoping conditions:
 
 ## service_wildcard
 
-Detects service-level wildcards like `s3:*` or `iam:*`.
+Detects service-level wildcards like `s3:*` or `iam:*` that grant all permissions for a service.
 
-**Severity:** `high`
+**Severity:** `high` (may be lowered to `low` with ABAC tag conditions)
 
 ### Fail Example
 
@@ -206,6 +206,55 @@ Use specific actions or action patterns:
   "Resource": "*"
 }
 ```
+
+### ABAC-Aware Severity
+
+When a statement uses a service wildcard but restricts access via ABAC tag conditions —
+where `aws:ResourceTag/*` is compared against `${aws:PrincipalTag/*}` — the finding is
+still reported but at a reduced severity (`low` by default). The wildcard remains an
+auditable finding, but the tag-based ownership constraint meaningfully limits its blast radius.
+
+**Detected pattern:**
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["secretsmanager:*"],
+  "Resource": "arn:aws:secretsmanager:*:123456789012:secret:*",
+  "Condition": {
+    "StringLike": {
+      "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+      "aws:ResourceTag/env": "${aws:PrincipalTag/env}"
+    }
+  }
+}
+```
+
+This applies to any service, not only `secretsmanager`.
+
+### Configuration Options
+
+```yaml
+service_wildcard:
+  enabled: true
+
+  # Severity for wildcards without ABAC mitigation (default: high)
+  severity: high
+
+  # Severity when ABAC ResourceTag/PrincipalTag conditions are present (default: low)
+  abac_mitigated_severity: low
+
+  # Services exempt from this check entirely
+  allowed_services:
+    - logs
+    - cloudwatch
+```
+
+| Option                    | Type           | Default | Description                                                                    |
+| ------------------------- | -------------- | ------- | ------------------------------------------------------------------------------ |
+| `severity`                | string         | `high`  | Severity for service wildcards without ABAC conditions                         |
+| `abac_mitigated_severity` | string         | `low`   | Severity when `aws:ResourceTag/*` = `${aws:PrincipalTag/*}` conditions present |
+| `allowed_services`        | list of string | `[]`    | Service prefixes (e.g. `logs`, `s3`) that are exempt from this check           |
 
 ---
 

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.18.0"
+__version__ = "1.18.1"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/service_wildcard.py
+++ b/iam_validator/checks/service_wildcard.py
@@ -1,11 +1,25 @@
 """Service wildcard check - detects service-level wildcards like 'iam:*', 's3:*'."""
 
+import re
 from typing import ClassVar
 
 from iam_validator.checks.utils.action_parser import parse_action
 from iam_validator.core.aws_service import AWSServiceFetcher
 from iam_validator.core.check_registry import CheckConfig, PolicyCheck
 from iam_validator.core.models import Statement, ValidationIssue
+
+# Matches ${aws:PrincipalTag/...} references used in ABAC conditions
+_PRINCIPAL_TAG_REF = re.compile(r"\$\{aws:PrincipalTag/", re.IGNORECASE)
+
+# ABAC-aware condition operators (base forms, lowercased) that can enforce tag-based access.
+# IfExists and set-operator prefixes (ForAllValues:/ForAnyValue:) are stripped before lookup.
+_ABAC_BASE_OPERATORS = frozenset(
+    [
+        "stringequals",
+        "stringlike",
+        "stringequalsignorecase",
+    ]
+)
 
 
 class ServiceWildcardCheck(PolicyCheck):
@@ -32,6 +46,8 @@ class ServiceWildcardCheck(PolicyCheck):
         actions = statement.get_actions()
         allowed_services = self._get_allowed_service_wildcards(config)
 
+        abac_mitigated = self._has_abac_resource_tag_condition(statement)
+
         for action in actions:
             # Skip full wildcard (covered by wildcard_action check)
             if action == "*":
@@ -43,38 +59,96 @@ class ServiceWildcardCheck(PolicyCheck):
                 service = parsed.service.lower()
 
                 # Check if this service is in the allowed list
-                if service not in allowed_services:
-                    # Get message template and replace placeholders
+                if service in allowed_services:
+                    continue
+
+                if abac_mitigated:
+                    severity = config.config.get("abac_mitigated_severity", "low")
+                    message_template = config.config.get(
+                        "abac_mitigated_message",
+                        "Service-level wildcard `{action}` grants all permissions for `{service}` service, but ABAC tag conditions restrict access to owned resources",
+                    )
+                else:
+                    severity = self.get_severity(config)
                     message_template = config.config.get(
                         "message",
                         "Service-level wildcard `{action}` grants all permissions for `{service}` service",
                     )
-                    suggestion_template = config.config.get(
-                        "suggestion",
-                        "Consider specifying explicit actions instead of `{action}`. If you need multiple actions, list them individually or use more specific wildcards like `{service}:Get*` or `{service}:List*`.",
-                    )
-                    example_template = config.config.get("example", "")
 
-                    message = message_template.format(action=action, service=service)
-                    suggestion = suggestion_template.format(action=action, service=service)
-                    example = example_template.format(action=action, service=service) if example_template else ""
+                suggestion_template = config.config.get(
+                    "suggestion",
+                    "Consider specifying explicit actions instead of `{action}`. If you need multiple actions, list them individually or use more specific wildcards like `{service}:Get*` or `{service}:List*`.",
+                )
 
-                    issues.append(
-                        ValidationIssue(
-                            severity=self.get_severity(config),
-                            statement_sid=statement.sid,
-                            statement_index=statement_idx,
-                            issue_type="overly_permissive",
-                            message=message,
-                            action=action,
-                            suggestion=suggestion,
-                            example=example if example else None,
-                            line_number=statement.line_number,
-                            field_name="action",
-                        )
+                example_template = config.config.get("example", "")
+                message = message_template.format(action=action, service=service)
+                suggestion = suggestion_template.format(action=action, service=service)
+                example = example_template.format(action=action, service=service) if example_template else ""
+
+                issues.append(
+                    ValidationIssue(
+                        severity=severity,
+                        statement_sid=statement.sid,
+                        statement_index=statement_idx,
+                        issue_type="overly_permissive",
+                        message=message,
+                        action=action,
+                        suggestion=suggestion,
+                        example=example if example else None,
+                        line_number=statement.line_number,
+                        field_name="action",
                     )
+                )
 
         return issues
+
+    @staticmethod
+    def _is_abac_operator(operator: str) -> bool:
+        """Check if a condition operator is a non-negated string comparison usable for ABAC.
+
+        Strips ForAllValues:/ForAnyValue: prefixes and IfExists suffix before
+        matching against base operators like StringEquals, StringLike, etc.
+        Negated operators (StringNotEquals, StringNotLike) are excluded because
+        they do not restrict access to matching resources.
+        """
+        cleaned = operator
+        # Strip set-operator prefix (ForAllValues:/ForAnyValue:)
+        if ":" in cleaned:
+            prefix, rest = cleaned.split(":", 1)
+            if prefix.lower() in ("forallvalues", "foranyvalue"):
+                cleaned = rest
+        # Strip IfExists suffix
+        if cleaned.lower().endswith("ifexists"):
+            cleaned = cleaned[: -len("IfExists")]
+        return cleaned.lower() in _ABAC_BASE_OPERATORS
+
+    def _has_abac_resource_tag_condition(self, statement: Statement) -> bool:
+        """Return True if the statement uses ABAC conditions restricting by resource tags.
+
+        Detects patterns like:
+          "StringEquals": {"aws:ResourceTag/owner": "${aws:PrincipalTag/owner}"}
+
+        This indicates the wildcard is scoped to resources the principal owns via
+        attribute-based access control (ABAC), making the wildcard intentional.
+        """
+        if not statement.condition:
+            return False
+
+        for operator, conditions in statement.condition.items():
+            if not self._is_abac_operator(operator):
+                continue
+            if not isinstance(conditions, dict):
+                continue
+            for key, value in conditions.items():
+                if not key.lower().startswith("aws:resourcetag/"):
+                    continue
+                # Value can be a string or list of strings
+                values = [value] if isinstance(value, str) else (value if isinstance(value, list) else [])
+                for v in values:
+                    if isinstance(v, str) and _PRINCIPAL_TAG_REF.search(v):
+                        return True
+
+        return False
 
     def _get_allowed_service_wildcards(self, config: CheckConfig) -> set[str]:
         """

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -472,7 +472,9 @@ class CheckRegistry:
         return [
             issue
             for issue in issues
-            if not config.should_ignore(issue, filepath) and config.should_show_severity(issue.severity)
+            if issue.severity != "none"
+            and not config.should_ignore(issue, filepath)
+            and config.should_show_severity(issue.severity)
         ]
 
     async def execute_checks_parallel(

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -45,6 +45,11 @@ from iam_validator.core.config.wildcards import (
 #    - medium:   Medium security risk (e.g., overly permissive wildcards)
 #    - low:      Low security risk (e.g., minor best practice violations)
 #
+# 3. SPECIAL SEVERITIES:
+#    - none:     Suppressed — issue is filtered out and never shown in any output
+#               (useful for checks that conditionally suppress findings, e.g.,
+#                ABAC-mitigated service wildcards)
+#
 # Use 'error' for policy validity issues, and 'critical/high/medium/low' for
 # security best practices. This distinction helps separate "broken policies"
 # from "insecure but valid policies".

--- a/iam_validator/core/models.py
+++ b/iam_validator/core/models.py
@@ -162,14 +162,16 @@ class ValidationIssue(BaseModel):
       (for issues that make the policy invalid according to AWS IAM rules)
     - Security: "critical", "high", "medium", "low"
       (for security best practices and configuration issues)
+    - Special: "none"
+      (issue is suppressed — never shown in any output)
     """
 
-    severity: str  # "error", "warning", "info" OR "critical", "high", "medium", "low"
+    severity: str  # "error", "warning", "info" OR "critical", "high", "medium", "low" OR "none"
 
     @field_validator("severity")
     @classmethod
     def validate_severity(cls, v: str) -> str:
-        valid = {"error", "warning", "info", "critical", "high", "medium", "low"}
+        valid = {"error", "warning", "info", "critical", "high", "medium", "low", "none"}
         if v not in valid:
             raise ValueError(f"Invalid severity '{v}'. Must be one of: {', '.join(sorted(valid))}")
         return v
@@ -209,6 +211,7 @@ class ValidationIssue(BaseModel):
             "high",
             "medium",
             "low",  # Security severities
+            "none",  # Suppressed — filtered out before output
         ]
     )
 

--- a/tests/checks/test_service_wildcard_check.py
+++ b/tests/checks/test_service_wildcard_check.py
@@ -142,6 +142,30 @@ class TestServiceWildcardCheck:
         assert issues[0].severity == "medium"
 
     @pytest.mark.asyncio
+    async def test_abac_mitigated_severity_none_suppresses_issue(self, check, fetcher):
+        """abac_mitigated_severity set to 'none' produces an issue that the framework will filter out."""
+        config = CheckConfig(
+            check_id="service_wildcard",
+            enabled=True,
+            config={"abac_mitigated_severity": "none"},
+        )
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        # The check still emits the issue with severity "none";
+        # the framework's _process_issues will filter it out
+        assert len(issues) == 1
+        assert issues[0].severity == "none"
+
+    @pytest.mark.asyncio
     async def test_abac_without_principal_tag_ref_uses_normal_severity(self, check, fetcher, config):
         """Condition with ResourceTag but a static value (not PrincipalTag) uses normal severity."""
         statement = Statement(

--- a/tests/checks/test_service_wildcard_check.py
+++ b/tests/checks/test_service_wildcard_check.py
@@ -80,3 +80,218 @@ class TestServiceWildcardCheck:
         # Only iam:* should be flagged
         assert len(issues) == 1
         assert issues[0].action == "iam:*"
+
+    @pytest.mark.asyncio
+    async def test_abac_resource_tag_condition_lowers_severity(self, check, fetcher, config):
+        """Service wildcard with ABAC ResourceTag/PrincipalTag condition should be flagged at 'low' severity."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["secretsmanager:*"],
+            Resource=["arn:aws:secretsmanager:*:123456789012:secret:*"],
+            Condition={
+                "StringLike": {
+                    "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+                    "aws:ResourceTag/env": "${aws:PrincipalTag/env}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].action == "secretsmanager:*"
+        assert issues[0].severity == "low"
+        assert "ABAC" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_abac_applies_to_any_service_wildcard(self, check, fetcher, config):
+        """ABAC severity reduction is not limited to secretsmanager — applies to any service."""
+        for action in ["s3:*", "ec2:*", "iam:*", "lambda:*"]:
+            statement = Statement(
+                Effect="Allow",
+                Action=[action],
+                Resource=["*"],
+                Condition={
+                    "StringEquals": {
+                        "aws:ResourceTag/team": "${aws:PrincipalTag/team}",
+                    }
+                },
+            )
+            issues = await check.execute(statement, 0, fetcher, config)
+            assert len(issues) == 1, f"Expected issue for {action}"
+            assert issues[0].severity == "low", f"Expected low severity for {action}"
+
+    @pytest.mark.asyncio
+    async def test_abac_mitigated_severity_configurable(self, check, fetcher):
+        """abac_mitigated_severity config option overrides the default 'low'."""
+        config = CheckConfig(
+            check_id="service_wildcard",
+            enabled=True,
+            config={"abac_mitigated_severity": "medium"},
+        )
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "medium"
+
+    @pytest.mark.asyncio
+    async def test_abac_without_principal_tag_ref_uses_normal_severity(self, check, fetcher, config):
+        """Condition with ResourceTag but a static value (not PrincipalTag) uses normal severity."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["iam:*"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:ResourceTag/env": "production",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].action == "iam:*"
+        assert issues[0].severity == "high"
+
+    @pytest.mark.asyncio
+    async def test_non_resource_tag_condition_uses_normal_severity(self, check, fetcher, config):
+        """Condition that doesn't use aws:ResourceTag/ does not lower severity."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["ec2:*"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestedRegion": "us-east-1",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].action == "ec2:*"
+        assert issues[0].severity == "high"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            "ForAllValues:StringEquals",
+            "ForAnyValue:StringEquals",
+            "StringEqualsIfExists",
+            "ForAllValues:StringEqualsIfExists",
+            "StringEqualsIgnoreCaseIfExists",
+            "StringLikeIfExists",
+            "ForAnyValue:StringLikeIfExists",
+        ],
+    )
+    async def test_abac_with_set_operators_and_ifexists(self, check, fetcher, config, operator):
+        """ABAC detection handles ForAllValues:/ForAnyValue: prefixes and IfExists suffix."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                operator: {
+                    "aws:ResourceTag/team": "${aws:PrincipalTag/team}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1, f"Expected issue for operator {operator}"
+        assert issues[0].severity == "low", f"Expected low severity for operator {operator}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            "StringNotEquals",
+            "StringNotLike",
+            "StringNotEqualsIgnoreCase",
+            "ForAllValues:StringNotEquals",
+        ],
+    )
+    async def test_negated_operators_not_treated_as_abac(self, check, fetcher, config, operator):
+        """Negated string operators (StringNotEquals, etc.) should NOT be treated as ABAC mitigation."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                operator: {
+                    "aws:ResourceTag/team": "${aws:PrincipalTag/team}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1, f"Expected issue for operator {operator}"
+        assert issues[0].severity == "high", f"Expected high severity for negated operator {operator}"
+
+    @pytest.mark.asyncio
+    async def test_abac_and_plain_wildcard_in_same_policy(self, check, fetcher, config):
+        """ABAC statement gets 'low' severity; plain wildcard gets full 'high' severity."""
+        abac_statement = Statement(
+            Effect="Allow",
+            Action=["secretsmanager:*"],
+            Resource=["arn:aws:secretsmanager:*:123456789012:secret:*"],
+            Condition={
+                "StringLike": {
+                    "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+                }
+            },
+        )
+        plain_wildcard_statement = Statement(
+            Effect="Allow",
+            Action=["iam:*"],
+            Resource=["*"],
+        )
+
+        abac_issues = await check.execute(abac_statement, 0, fetcher, config)
+        plain_issues = await check.execute(plain_wildcard_statement, 1, fetcher, config)
+
+        assert len(abac_issues) == 1
+        assert abac_issues[0].severity == "low"
+        assert len(plain_issues) == 1
+        assert plain_issues[0].severity == "high"
+
+    @pytest.mark.asyncio
+    async def test_abac_condition_value_as_list(self, check, fetcher, config):
+        """ABAC detection works when condition value is a list (OR semantics in AWS)."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                "StringEquals": {
+                    "aws:ResourceTag/team": ["${aws:PrincipalTag/team}", "shared"],
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"
+
+    @pytest.mark.asyncio
+    async def test_mixed_abac_and_non_abac_conditions(self, check, fetcher, config):
+        """ABAC is detected even when mixed with non-ABAC conditions in the same block."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Condition={
+                "IpAddress": {
+                    "aws:SourceIp": "10.0.0.0/8",
+                },
+                "StringEquals": {
+                    "aws:ResourceTag/owner": "${aws:PrincipalTag/owner}",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].severity == "low"

--- a/tests/core/test_check_registry.py
+++ b/tests/core/test_check_registry.py
@@ -105,6 +105,38 @@ class MultiSeverityCheck(PolicyCheck):
         ]
 
 
+class NoneSeverityCheck(PolicyCheck):
+    """Mock check that generates a mix of 'none' and normal severity issues."""
+
+    def __init__(self, check_id="none_severity_check"):
+        self._check_id = check_id
+
+    @property
+    def check_id(self) -> str:
+        return self._check_id
+
+    @property
+    def description(self) -> str:
+        return "Generates issues including none severity"
+
+    async def execute(self, statement, statement_idx, fetcher, config):
+        """Generate issues with none and normal severities."""
+        return [
+            ValidationIssue(
+                severity="none",
+                statement_index=statement_idx,
+                issue_type="suppressed_issue",
+                message="This should be suppressed",
+            ),
+            ValidationIssue(
+                severity="high",
+                statement_index=statement_idx,
+                issue_type="real_issue",
+                message="This should be visible",
+            ),
+        ]
+
+
 class TestCheckConfig:
     """Test the CheckConfig dataclass."""
 
@@ -601,6 +633,32 @@ class TestCheckRegistry:
         # Should get 3 issues (medium, high, critical)
         assert len(issues) == 3
         assert all(issue.severity != "low" for issue in issues)
+
+    @pytest.mark.asyncio
+    async def test_none_severity_filtered_out_parallel(self, mock_statement, mock_fetcher):
+        """Test that 'none' severity issues are always filtered out in parallel execution."""
+        registry = CheckRegistry(enable_parallel=True)
+        check = NoneSeverityCheck()
+        registry.register(check)
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert len(issues) == 1
+        assert issues[0].severity == "high"
+        assert issues[0].issue_type == "real_issue"
+
+    @pytest.mark.asyncio
+    async def test_none_severity_filtered_out_sequential(self, mock_statement, mock_fetcher):
+        """Test that 'none' severity issues are always filtered out in sequential execution."""
+        registry = CheckRegistry(enable_parallel=False)
+        check = NoneSeverityCheck()
+        registry.register(check)
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert len(issues) == 1
+        assert issues[0].severity == "high"
+        assert issues[0].issue_type == "real_issue"
 
 
 class TestCreateDefaultRegistry:


### PR DESCRIPTION
Body:

## Summary

- Lower `service_wildcard` severity from `high` to `low` when ABAC tag conditions (`aws:ResourceTag/*` = `${aws:PrincipalTag/*}`) restrict the blast radius of service-level wildcards
- Add configurable `abac_mitigated_severity` option (default: `low`)
- Handle `ForAllValues:`/`ForAnyValue:` set operator prefixes and `IfExists` suffix in ABAC detection
- Exclude negated operators (`StringNotEquals`, `StringNotLike`) from ABAC mitigation since they don't restrict access
- Document ABAC-aware severity and configuration options in check docs
- Bump version to `1.18.1`

## Test plan

- [x] 23 tests pass for `service_wildcard` check (17 new tests)
- [x] 1292 total tests pass, no regressions
- [x] E2E validation of ABAC policy produces `LOW` severity finding
- [x] Lint clean (`ruff check`)
- [x] Docs build clean (`mkdocs build --strict`)