### PR TITLE
fix: classify aws:ResourceOrgPaths as multivalued condition key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.2] - 2026-03-24
+
+### Fixed
+
+- Fix `set_operator_validation` false positive on `aws:ResourceOrgPaths` — classify it as a multivalued condition key (matching `aws:PrincipalOrgPaths`), and update type from `String` to `ArrayOfString` in global condition key metadata ([#87])
+
+[#87]: https://github.com/boogy/iam-policy-validator/pull/87
+
+---
+
 ## [1.18.1] - 2026-03-10
 
 ### Added

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.18.1"
+__version__ = "1.18.2"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/core/condition_validators.py
+++ b/iam_validator/core/condition_validators.py
@@ -845,6 +845,7 @@ def is_multivalued_context_key(condition_key: str) -> bool:
     multivalued_keys = {
         "aws:tagkeys",  # List of tag keys being applied/modified
         "aws:principalorgpaths",  # Organization paths for the principal
+        "aws:resourceorgpaths",  # Organization paths for the resource
     }
 
     # Check exact matches

--- a/iam_validator/core/config/aws_global_conditions.py
+++ b/iam_validator/core/config/aws_global_conditions.py
@@ -51,7 +51,7 @@ AWS_GLOBAL_CONDITION_KEYS = {
     # Resource Properties
     "aws:ResourceAccount": "String",  # Resource owner's AWS account ID
     "aws:ResourceOrgID": "String",  # Organization ID of resource owner
-    "aws:ResourceOrgPaths": "String",  # AWS Organizations path of resource
+    "aws:ResourceOrgPaths": "ArrayOfString",  # AWS Organizations paths of resource (multivalued)
     # Request Properties
     "aws:CurrentTime": "Date",  # Current date and time
     "aws:EpochTime": "Date",  # Request timestamp in epoch format (also accepts Numeric)

--- a/tests/core/test_set_operator_validation.py
+++ b/tests/core/test_set_operator_validation.py
@@ -260,6 +260,22 @@ class TestSetOperatorValidationCheck:
         assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
 
     @pytest.mark.asyncio
+    async def test_resource_org_paths_is_multivalued(self, check, config):
+        """Test aws:ResourceOrgPaths is recognized as multivalued (like aws:PrincipalOrgPaths)."""
+        statement = Statement(
+            effect="Allow",
+            action=["sts:AssumeRole"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringEquals": {
+                    "aws:ResourceOrgPaths": "${aws:PrincipalOrgPaths}",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
+
+    @pytest.mark.asyncio
     async def test_statement_with_sid(self, check, config):
         """Test issue includes statement SID when present."""
         statement = Statement(


### PR DESCRIPTION
## Summary

`aws:ResourceOrgPaths` is a [multivalued condition key](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html) (returns a list of organization paths), just like `aws:PrincipalOrgPaths`. However, the `set_operator_validation` check incorrectly flags `ForAnyValue:StringEquals` on this key as an error.

Three inconsistencies fixed:

- **`condition_validators.py`**: Add `aws:resourceorgpaths` to `multivalued_keys` set in `is_multivalued_context_key()` (only `aws:principalorgpaths` was listed)
- **`aws_global_conditions.py`**: Change type from `"String"` to `"ArrayOfString"` in `AWS_GLOBAL_CONDITION_KEYS`
- **`test_set_operator_validation.py`**: Add test for `aws:ResourceOrgPaths` with `ForAnyValue` operator

Note: the library's own `condition_requirements.py` already uses `ForAnyValue:StringLike` for this key, confirming it's multivalued.

## Test plan

- [x] New test `test_resource_org_paths_is_multivalued` passes
- [x] Full test suite: 1298 passed, 0 failed