### PR TITLE
fix: aggregate condition_key_validation issues to reduce PR noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `condition_key_validation` generating one PR comment per invalid condition key — aggregate keys that share the same action and base pattern (e.g., `aws:RequestTag/owner`, `aws:RequestTag/jira`, `aws:RequestTag/env`) into a single finding listing all affected keys
 - Fix `set_operator_validation` false positive on `aws:ResourceOrgPaths` — classify it as a multivalued condition key (matching `aws:PrincipalOrgPaths`), and update type from `String` to `ArrayOfString` in global condition key metadata ([#87])
 
 [#87]: https://github.com/boogy/iam-policy-validator/pull/87

--- a/iam_validator/checks/condition_key_validation.py
+++ b/iam_validator/checks/condition_key_validation.py
@@ -1,5 +1,6 @@
 """Condition key validation check - validates condition keys against AWS definitions."""
 
+from collections import defaultdict
 from typing import ClassVar
 
 from iam_validator.core.aws_service import AWSServiceFetcher
@@ -121,4 +122,86 @@ class ConditionKeyValidationCheck(PolicyCheck):
                         )
                     )
 
-        return issues
+        return self._aggregate_invalid_key_issues(issues)
+
+    @staticmethod
+    def _condition_key_base(condition_key: str) -> str:
+        """Extract base pattern for grouping (e.g., 'aws:RequestTag/owner' -> 'aws:RequestTag').
+
+        Keys with the same base pattern share the same underlying reason for being
+        invalid, so they can be merged into a single issue.
+        """
+        slash_idx = condition_key.find("/")
+        if slash_idx > 0:
+            return condition_key[:slash_idx]
+        return condition_key
+
+    @staticmethod
+    def _extract_explanation(message: str) -> str:
+        """Extract the explanation part from an error message, after the key-specific prefix.
+
+        Error messages follow the pattern:
+          "Condition key `X` is not supported by action `Y`. <explanation>"
+
+        Returns the explanation part, or empty string if not found.
+        """
+        # Split after the first sentence (which names the specific key)
+        dot_space_idx = message.find(". ")
+        if dot_space_idx > 0:
+            return message[dot_space_idx + 2 :]
+        return ""
+
+    def _aggregate_invalid_key_issues(self, issues: list[ValidationIssue]) -> list[ValidationIssue]:
+        """Aggregate invalid_condition_key issues that share the same action and key pattern.
+
+        Multiple condition keys failing for the same action and same reason (e.g.,
+        aws:RequestTag/owner, aws:RequestTag/jira, aws:RequestTag/env all unsupported
+        by lambda:AddPermission) are merged into a single issue listing all keys.
+        """
+        invalid_key_issues = [i for i in issues if i.issue_type == "invalid_condition_key"]
+        other_issues = [i for i in issues if i.issue_type != "invalid_condition_key"]
+
+        if len(invalid_key_issues) <= 1:
+            return issues
+
+        # Group by (action, condition_key_base_pattern)
+        grouped: dict[tuple[str | None, str], list[ValidationIssue]] = defaultdict(list)
+        for issue in invalid_key_issues:
+            base = self._condition_key_base(issue.condition_key or "")
+            key = (issue.action, base)
+            grouped[key].append(issue)
+
+        aggregated = []
+        for group in grouped.values():
+            if len(group) == 1:
+                aggregated.append(group[0])
+            else:
+                aggregated.append(self._merge_condition_key_issues(group))
+
+        return other_issues + aggregated
+
+    @staticmethod
+    def _merge_condition_key_issues(group: list[ValidationIssue]) -> ValidationIssue:
+        """Merge multiple invalid_condition_key issues into a single aggregated issue."""
+        first = group[0]
+        keys = [i.condition_key for i in group if i.condition_key]
+        keys_formatted = ", ".join(f"`{k}`" for k in keys)
+
+        # Build aggregated message: list all keys, then shared explanation
+        message = f"Condition keys {keys_formatted} are not supported by action `{first.action}`."
+        explanation = ConditionKeyValidationCheck._extract_explanation(first.message or "")
+        if explanation:
+            message += f" {explanation}"
+
+        return ValidationIssue(
+            severity=first.severity,
+            statement_sid=first.statement_sid,
+            statement_index=first.statement_index,
+            issue_type="invalid_condition_key",
+            message=message,
+            action=first.action,
+            condition_key=keys[0] if keys else None,
+            line_number=first.line_number,
+            suggestion=first.suggestion,
+            field_name="condition",
+        )

--- a/tests/checks/test_condition_key_validation_check.py
+++ b/tests/checks/test_condition_key_validation_check.py
@@ -384,3 +384,261 @@ class TestIfExistsFalsePositiveSuppression:
         # Should suppress invalid_condition_key but report warning
         assert not any(i.issue_type == "invalid_condition_key" for i in issues)
         assert any(i.issue_type == "global_condition_key_with_action_specific" for i in issues)
+
+
+class TestConditionKeyIssueAggregation:
+    """Test that multiple invalid condition key issues are aggregated into fewer issues."""
+
+    @pytest.fixture
+    def check(self):
+        return ConditionKeyValidationCheck()
+
+    @pytest.fixture
+    def fetcher(self):
+        mock = MagicMock(spec=AWSServiceFetcher)
+        mock.validate_condition_key = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(check_id="condition_key_validation")
+
+    @pytest.mark.asyncio
+    async def test_aggregates_same_pattern_keys_for_same_action(self, check, fetcher, config):
+        """Multiple RequestTag keys invalid for same action should produce one issue."""
+
+        async def mock_validate(action, key, resources):
+            if key.startswith("aws:RequestTag/"):
+                return ConditionKeyValidationResult(
+                    is_valid=False,
+                    error_message=(
+                        f"Condition key `{key}` is not supported by action `{action}`. "
+                        f"The `aws:RequestTag/${{TagKey}}` condition is only supported by actions "
+                        f"that create or modify resources with tags. This action does not support tag operations."
+                    ),
+                    suggestion="Valid condition keys for this action: `aws:SourceArn`",
+                )
+            return ConditionKeyValidationResult(is_valid=True)
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["lambda:AddPermission"],
+            Resource=["arn:aws:lambda:*:123456789012:function:my-func"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "${aws:PrincipalTag/owner}",
+                    "aws:RequestTag/jira": "${aws:PrincipalTag/jira}",
+                    "aws:RequestTag/env": "${aws:PrincipalTag/env}",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        # Should produce 1 aggregated issue instead of 3
+        assert len(issues) == 1
+        issue = issues[0]
+        assert issue.issue_type == "invalid_condition_key"
+        assert "aws:RequestTag/owner" in issue.message
+        assert "aws:RequestTag/jira" in issue.message
+        assert "aws:RequestTag/env" in issue.message
+        assert "lambda:AddPermission" in issue.message
+        # Should include the shared explanation
+        assert "tag operations" in issue.message
+
+    @pytest.mark.asyncio
+    async def test_does_not_aggregate_different_patterns(self, check, fetcher, config):
+        """Keys with different base patterns should not be merged."""
+
+        async def mock_validate(action, key, resources):
+            return ConditionKeyValidationResult(
+                is_valid=False,
+                error_message=f"Condition key `{key}` is not valid for action `{action}`",
+            )
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["arn:aws:s3:::bucket/*"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "test",
+                    "ec2:InstanceType": "t3.micro",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        # Different patterns → separate issues
+        assert len(issues) == 2
+        condition_keys = {i.condition_key for i in issues}
+        assert "aws:RequestTag/owner" in condition_keys
+        assert "ec2:InstanceType" in condition_keys
+
+    @pytest.mark.asyncio
+    async def test_does_not_aggregate_different_actions(self, check, fetcher, config):
+        """Keys failing for different actions should not be merged."""
+        call_count = 0
+
+        async def mock_validate(action, key, resources):
+            nonlocal call_count
+            call_count += 1
+            # First key invalid for first action, second key invalid for second action
+            if key == "s3:invalidKey1":
+                if action == "s3:GetObject":
+                    return ConditionKeyValidationResult(
+                        is_valid=False,
+                        error_message=f"Condition key `{key}` is not valid for action `{action}`",
+                    )
+                return ConditionKeyValidationResult(is_valid=True)
+            if key == "s3:invalidKey2":
+                if action == "s3:PutObject":
+                    return ConditionKeyValidationResult(
+                        is_valid=False,
+                        error_message=f"Condition key `{key}` is not valid for action `{action}`",
+                    )
+                return ConditionKeyValidationResult(is_valid=True)
+            return ConditionKeyValidationResult(is_valid=True)
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject", "s3:PutObject"],
+            Resource=["arn:aws:s3:::bucket/*"],
+            Condition={
+                "StringEquals": {
+                    "s3:invalidKey1": "value1",
+                    "s3:invalidKey2": "value2",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        # Different actions → separate issues (different grouping keys)
+        assert len(issues) == 2
+
+    @pytest.mark.asyncio
+    async def test_single_invalid_key_not_aggregated(self, check, fetcher, config):
+        """Single invalid key should not be affected by aggregation."""
+        fetcher.validate_condition_key.return_value = ConditionKeyValidationResult(
+            is_valid=False,
+            error_message="Condition key `aws:RequestTag/owner` is not supported by action `lambda:AddPermission`",
+        )
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["lambda:AddPermission"],
+            Resource=["arn:aws:lambda:*:123456789012:function:my-func"],
+            Condition={"StringEquals": {"aws:RequestTag/owner": "test"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        assert len(issues) == 1
+        assert issues[0].condition_key == "aws:RequestTag/owner"
+
+    @pytest.mark.asyncio
+    async def test_aggregation_preserves_suggestion(self, check, fetcher, config):
+        """Aggregated issue should include the suggestion from the first issue."""
+
+        async def mock_validate(action, key, resources):
+            return ConditionKeyValidationResult(
+                is_valid=False,
+                error_message=f"Condition key `{key}` is not supported by action `{action}`. Explanation.",
+                suggestion="Use valid condition keys: `aws:SourceArn`, `aws:SourceAccount`",
+            )
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["lambda:AddPermission"],
+            Resource=["arn:aws:lambda:*:123456789012:function:my-func"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "test",
+                    "aws:RequestTag/env": "prod",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        assert len(issues) == 1
+        assert issues[0].suggestion == "Use valid condition keys: `aws:SourceArn`, `aws:SourceAccount`"
+
+    @pytest.mark.asyncio
+    async def test_aggregation_across_operators(self, check, fetcher, config):
+        """Keys from different operators with same base pattern and action should be aggregated."""
+
+        async def mock_validate(action, key, resources):
+            if key.startswith("aws:RequestTag/"):
+                return ConditionKeyValidationResult(
+                    is_valid=False,
+                    error_message=(
+                        f"Condition key `{key}` is not supported by action `{action}`. "
+                        f"Not supported."
+                    ),
+                )
+            return ConditionKeyValidationResult(is_valid=True)
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["lambda:AddPermission"],
+            Resource=["arn:aws:lambda:*:123456789012:function:my-func"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "test",
+                },
+                "StringLike": {
+                    "aws:RequestTag/env": "prod*",
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        # Both from different operators but same action+pattern → 1 aggregated issue
+        assert len(issues) == 1
+        assert "aws:RequestTag/owner" in issues[0].message
+        assert "aws:RequestTag/env" in issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_aggregation_keeps_warnings_separate(self, check, fetcher, config):
+        """Warning issues should not be affected by aggregation of errors."""
+
+        async def mock_validate(action, key, resources):
+            if key.startswith("aws:RequestTag/"):
+                return ConditionKeyValidationResult(
+                    is_valid=False,
+                    error_message=f"Condition key `{key}` is not supported by action `{action}`. Reason.",
+                )
+            return ConditionKeyValidationResult(
+                is_valid=True,
+                warning_message="Global condition key warning",
+            )
+
+        fetcher.validate_condition_key.side_effect = mock_validate
+
+        statement = Statement(
+            Effect="Allow",
+            Action=["lambda:AddPermission"],
+            Resource=["arn:aws:lambda:*:123456789012:function:my-func"],
+            Condition={
+                "StringEquals": {
+                    "aws:RequestTag/owner": "test",
+                    "aws:RequestTag/env": "prod",
+                    "aws:PrincipalOrgID": "o-123",
+                }
+            },
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+
+        error_issues = [i for i in issues if i.issue_type == "invalid_condition_key"]
+        warning_issues = [i for i in issues if i.issue_type == "global_condition_key_with_action_specific"]
+
+        assert len(error_issues) == 1  # Aggregated
+        assert len(warning_issues) == 1  # Not affected

--- a/tests/checks/test_condition_key_validation_check.py
+++ b/tests/checks/test_condition_key_validation_check.py
@@ -577,10 +577,7 @@ class TestConditionKeyIssueAggregation:
             if key.startswith("aws:RequestTag/"):
                 return ConditionKeyValidationResult(
                     is_valid=False,
-                    error_message=(
-                        f"Condition key `{key}` is not supported by action `{action}`. "
-                        f"Not supported."
-                    ),
+                    error_message=(f"Condition key `{key}` is not supported by action `{action}`. Not supported."),
                 )
             return ConditionKeyValidationResult(is_valid=True)
 


### PR DESCRIPTION
## Summary

- Aggregate `condition_key_validation` issues that share the same action and condition key base pattern into a single finding
- Instead of 3 separate PR comments for `aws:RequestTag/owner`, `aws:RequestTag/team`, `aws:RequestTag/env`, produces 1 comment listing all affected keys
- Keys with different base patterns (e.g., `aws:RequestTag/*` vs `ec2:InstanceType`) or different failing actions remain as separate issues

## Before / After

**Before** (3 comments for the same root cause):
> Condition key `aws:RequestTag/owner` is not supported by action `lambda:AddPermission`...
> Condition key `aws:RequestTag/team` is not supported by action `lambda:AddPermission`...
> Condition key `aws:RequestTag/env` is not supported by action `lambda:AddPermission`...

**After** (1 aggregated comment):
> Condition keys `aws:RequestTag/owner`, `aws:RequestTag/team`, `aws:RequestTag/env` are not supported by action `lambda:AddPermission`. The `aws:RequestTag/${TagKey}` condition is only supported by
actions that create or modify resources with tags.

## Test plan

- [x] All 29 condition key validation tests pass (including 7 new aggregation tests)
- [x] Full test suite passes (1304 passed)
- [x] Ruff lint clean
- [x] End-to-end validation with sample policy confirms 1 issue instead of 3
- [x] Verify PR comment rendering on a real PR with aggregated findings