### PR TITLE
feat(mcp): v1.20.0 — accuracy, CLI parity, token-efficient profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,154 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - Unreleased
+
+### Added
+
+- `suppress_superseded_findings` setting (default `true`): when a bare
+  `Allow Action:* Resource:*` statement is detected, a single `critical` finding from
+  `full_wildcard` is surfaced and all redundant statement-level and policy-level
+  findings for that statement are suppressed — including custom checks. Sibling
+  statements are unaffected. Set to `false` to restore the previous behaviour.
+- `Statement.is_full_wildcard_allow()` predicate and `PolicyCheck.supersedes` /
+  `PolicyCheck.matches()` extension points (zero-cost defaults for existing checks).
+- Centralized `IAM_POLICY_VERSION_CURRENT` / `IAM_POLICY_VERSION_LEGACY` /
+  `IAM_POLICY_VERSIONS_VALID` in `iam_validator/core/constants.py` so MCP, fix tools,
+  and templates source the IAM policy language version from one place.
+- `iam_validator/mcp/check_metadata.py` — curated examples and fix steps for 12
+  built-in checks. MCP `get_issue_guidance` and `get_check_details` now return
+  registry-driven defaults for any registered check (previously hardcoded for
+  5–6 checks).
+- MCP `--custom-checks-dir` and `--aws-services-dir` flags (CLI parity). Paths
+  are stored on `SessionConfigManager` and forwarded to `validate_policies()`
+  by the validation tools.
+- MCP `aws_access_analyzer_validate` tool — wraps AWS Access Analyzer
+  ValidatePolicy in `asyncio.to_thread`. Lifespan caches `boto3.Session`
+  instances per `(region, profile)` to amortise the ~50 ms session-construction
+  cost across calls.
+- `AccessAnalyzerValidator(session=...)` keyword argument so MCP can pass a
+  shared boto3 session instead of reconstructing one per call.
+- MCP `--profile {full,validate-only,validate-and-query,no-generation,read-only}`
+  flag for token-efficient sessions (FastMCP tag-based gating). `--list-profiles`
+  prints the taxonomy and exits.
+- MCP `get_active_profile` tool — introspect the active profile and the tools
+  it currently exposes.
+- MCP `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
+  `openWorldHint`) on every registered tool so MCP clients can reason about
+  side-effects without parsing names.
+- Parameterised resources `iam://sensitive-actions/{category}` and
+  `iam://checks/{check_id}` (replace the demoted tools — see Compatibility).
+- FastMCP in-process `Client` transport tests (`tests/mcp/test_transport.py`)
+  for protocol-level coverage of tool registration, annotations, profiles,
+  and tool errors.
+
+### Changed
+
+- MCP `build_arn` validates the `partition` argument against `ARN_PARTITION_REGEX`
+  and rejects unknown partitions instead of silently accepting them. Supported
+  partitions: `aws`, `aws-cn`, `aws-us-gov`, `aws-eusc`, `aws-iso`, `aws-iso-b`,
+  `aws-iso-e`, `aws-iso-f`.
+- MCP `get_issue_guidance` / `get_check_details` now source description and
+  default severity from the check registry. Curated examples / fix steps live in
+  `iam_validator/mcp/check_metadata.py`. The `related_tools` field has been
+  renamed to `related` (covers both tools and resource URIs).
+- MCP `build_arn` now consults the live AWS service reference (cached) instead
+  of a hardcoded 9-service map. Supports all partitions in `ARN_PARTITION_REGEX`
+  (incl. `aws-eusc`, `aws-iso*`) and multi-placeholder ARN templates via a new
+  `placeholders` dict argument. Returns `{arn, valid, notes, format_template,
+  unfilled_placeholders}`. The `resource_name` argument is deprecated (removal
+  target v1.21.0) — pass `placeholders={...}` instead.
+- Single-call MCP query tools (`query_service_actions`, `query_action_details`,
+  `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`) now
+  reuse the lifespan-managed `AWSServiceFetcher` instead of constructing a new
+  one per call. Fewer HTTP connections, warmer cache. `validate_policy` /
+  `validate_policies_batch` continue to construct their fetcher inside
+  `validate_policies()` — see follow-up issue for fetcher reuse there.
+- `validate_policies_batch` accepts a `max_concurrency` parameter (default 10)
+  and uses an `asyncio.Semaphore` to cap parallel validations.
+- `get_shared_fetcher` log noise demoted from WARNING to DEBUG.
+- FastMCP minimum bumped from `>=2.14.1` to `>=3.2,<4` — we now rely on v3
+  `enable(only=True)` semantics for tag-based gating.
+- MCP `BASE_INSTRUCTIONS` slimmed from ~2.6 KB to ~700 chars: per-tool
+  guardrails relocated to individual tool docstrings; the server-level
+  instructions retain only Core Principles, Absolute Rules, the Validation
+  Loop Prevention guardrail, and resource pointers.
+- MCP `explain_policy` now sources access-level classification from the live
+  AWS service reference (Read/Write/List/Tagging/Permissions management)
+  instead of a name-prefix heuristic. Surfaces `NotAction`/`NotResource`/
+  `Principal:*`/`NotPrincipal` as explicit security concerns. Effect comparison
+  is case-insensitive.
+- MCP `compare_policies` now uses canonical statement signatures (effect +
+  sorted actions/resources/principals + canonical-JSON conditions) instead of
+  positional indexing. Reports added/removed `NotAction`, `NotResource`,
+  `Principal`, `NotPrincipal`, and condition keys independently. No more
+  phantom diffs from re-ordering Sid-less statements.
+- MCP `aws_access_analyzer_validate` adds a `partition` argument and defaults
+  `region` to the canonical region per partition (e.g. `aws-cn` → `cn-north-1`,
+  `aws-us-gov` → `us-gov-west-1`). Adds `timeout_seconds` (default 30s) so a
+  hung AWS endpoint cannot block the MCP server. Centralized in
+  `core/constants.PARTITION_DEFAULT_REGION`.
+- MCP `fix_policy_issues` action-case normalization now also handles
+  `NotAction` (previously only `Action`). `unfixed_issues` always returns a
+  list; `unfixed_count` is exposed separately for clients that want the count.
+- MCP `quick_validate` `wildcards_detected` now correctly fires for
+  `full_wildcard` issues (previously missed; only the three lower-severity
+  wildcard checks were in the set).
+- MCP DRY: extracted `issue_to_dict()` helper in `mcp/tools/validation.py`.
+  `validate_policy`, `validate_policies_batch`, `generate_policy_from_template`,
+  `build_minimal_policy`, and `fix_policy_issues` all use it — single source of
+  truth for the verbose-vs-lean issue projection.
+
+### Fixed (P0 — accuracy)
+
+- MCP `validate_policy` (and every wrapper that calls it) now wraps malformed
+  input in a clean `ToolError` instead of letting Pydantic's `ValidationError`
+  stack trace leak through the MCP protocol.
+- MCP `--instructions` and `--instructions-file` are now in an argparse
+  mutually-exclusive group. Previously `--instructions` was silently ignored
+  if both were supplied.
+
+### Removed (demoted to resources)
+
+- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details`
+  are no longer registered as MCP tools. Fetch them via the resource URIs:
+  - `iam://templates`
+  - `iam://checks`
+  - `iam://sensitive-actions/{category}`
+  - `iam://checks/{check_id}`
+
+### Token cost (per profile, instructions + tool descriptions, characters)
+
+| Profile              | Tools | Instr | Tool descs | Total | % full |
+| -------------------- | ----- | ----- | ---------- | ----- | ------ |
+| `full`               | 33    | 1128  | 3900       | 5028  | 100%   |
+| `validate-only`      | 5     | 1128  | 481        | 1609  | 32%    |
+| `validate-and-query` | 13    | 1128  | 1045       | 2173  | 43%    |
+| `no-generation`      | 28    | 1128  | 3306       | 4434  | 88%    |
+| `read-only`          | 28    | 1128  | 3444       | 4572  | 90%    |
+
+### Compatibility
+
+- Default MCP profile is `full` — existing Claude Desktop / Cursor configs see
+  no behavioural change unless they explicitly pass `--profile`.
+- `--profile` requires a server restart to take effect — MCP clients cache
+  tool catalogs per session.
+- `build_arn(resource_name=...)` is **deprecated** and emits a warning. Prefer
+  `placeholders={...}`. Removal target: v1.21.0.
+- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details`
+  are **demoted from tools to resources**. MCP clients that previously called
+  these tools must switch to fetching the corresponding resource URI.
+- FastMCP minimum bumped to `>=3.2,<4`. Users on `fastmcp<3` must upgrade
+  via `uv sync --extra mcp`.
+
+### Notes
+
+- **Breaking (noise reduction):** existing PR comments anchored to the suppressed
+  check IDs become orphans on the next run and are cleaned up automatically. Set
+  `suppress_superseded_findings: false` to restore all findings.
+
+---
+
 ## [1.19.1] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ For the full configuration reference including how `action_condition_enforcement
 
 ## MCP Server
 
-Use the IAM Policy Validator as an [MCP](https://modelcontextprotocol.io/) server for AI assistants like Claude Desktop. Provides 36 tools across validation, policy generation, AWS service querying, analysis, and organization config management.
+Use the IAM Policy Validator as an [MCP](https://modelcontextprotocol.io/) server for AI assistants like Claude Desktop. Provides 33 tools across validation, generation, AWS service querying, analysis, AWS Access Analyzer, and organization config management — plus tag-based `--profile` gating to slim the per-turn token cost.
 
 ```bash
 # Quick start with uvx (no installation needed)
@@ -491,10 +491,13 @@ uvx --from "iam-policy-validator[mcp]" iam-validator-mcp
 
 # Or install with MCP extras
 pip install "iam-policy-validator[mcp]"
-iam-validator-mcp
+iam-validator-mcp                                      # all 33 tools (default)
+iam-validator-mcp --profile validate-only              # 5 validation tools only
+iam-validator-mcp --custom-checks-dir ./my-checks      # CLI parity: custom checks
+iam-validator-mcp --aws-services-dir ./aws-services    # CLI parity: offline AWS data
 ```
 
-See the [MCP Server Documentation](https://boogy.github.io/iam-policy-validator/integrations/mcp-server/) for Claude Desktop configuration and tool reference.
+See the [MCP Server Documentation](https://boogy.github.io/iam-policy-validator/integrations/mcp-server/) for Claude Desktop configuration, tool reference, and the profile taxonomy.
 
 ---
 

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -376,18 +376,21 @@ principal_validation:
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `generate_policy_from_template` | Generate a policy from a built-in secure template                                                                                                                            |
 | `build_minimal_policy`          | Build a least-privilege policy from actions and resources. Automatically applies required conditions for sensitive actions (e.g., `iam:PassedToService` for `iam:PassRole`). |
-| `build_arn`                     | Build a valid ARN from components (service, resource type, resource name, region, account) with format validation                                                            |
-| `list_templates`                | List all available policy templates                                                                                                                                          |
+| `build_arn`                     | Build a valid ARN from the live AWS service reference. Pass `placeholders={...}` for resource-specific tokens. (`resource_name=` is deprecated.)                             |
 | `suggest_actions`               | Suggest AWS actions based on natural language description                                                                                                                    |
 | `get_required_conditions`       | Get recommended conditions for sensitive actions                                                                                                                             |
 | `check_sensitive_actions`       | Check if actions are in the sensitive actions catalog                                                                                                                        |
 
+!!! info "list_templates is now a resource"
+    Fetch `iam://templates` instead of calling `list_templates` (demoted in v1.20.0).
+
 ### Analysis Tools
 
-| Tool               | Description                                                                                                            |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `explain_policy`   | Generate a human-readable explanation of what a policy allows or denies, including security concerns and services used |
-| `compare_policies` | Compare two IAM policies and highlight differences in permissions, actions added/removed, and resource scope changes   |
+| Tool                            | Description                                                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `explain_policy`                | Generate a human-readable explanation of what a policy allows or denies, including security concerns and services used |
+| `compare_policies`              | Compare two IAM policies and highlight differences in permissions, actions added/removed, and resource scope changes   |
+| `aws_access_analyzer_validate`  | Run AWS Access Analyzer ValidatePolicy (live AWS API — needs credentials). Surfaces AWS-only checks beyond the local validator. |
 
 ### Query Tools
 
@@ -399,12 +402,13 @@ principal_validation:
 | `expand_wildcard_action`                | Expand patterns like `s3:Get*` to specific actions                                       |
 | `query_condition_keys`                  | Get condition keys for a service                                                         |
 | `query_arn_formats`                     | Get ARN format patterns for a service                                                    |
-| `list_checks`                           | List all available validation checks                                                     |
-| `get_check_details`                     | Get full documentation for a specific check including examples and configuration options |
 | `get_policy_summary`                    | Analyze a policy's structure                                                             |
-| `list_sensitive_actions`                | List sensitive actions by category                                                       |
 | `check_actions_batch`                   | Validate and check sensitivity for multiple actions in one call                          |
 | `get_condition_requirements_for_action` | Get required conditions for a specific action based on sensitivity and best practices    |
+
+!!! info "list_checks, get_check_details, list_sensitive_actions are now resources"
+    Fetch via the resource URI instead of calling these tools (demoted in v1.20.0):
+    `iam://checks`, `iam://checks/{check_id}`, `iam://sensitive-actions/{category}`.
 
 ### Fix and Help Tools
 
@@ -431,6 +435,59 @@ principal_validation:
 | `set_custom_instructions`   | Set custom organization-specific instructions for policy generation |
 | `get_custom_instructions`   | Get the current custom instructions                                 |
 | `clear_custom_instructions` | Clear custom instructions, reverting to defaults                    |
+
+## Profiles (`--profile`)
+
+Tag-based gating restricts which tools the MCP server advertises. Smaller
+catalog = fewer tokens spent on tool descriptions per turn. The CLI flag
+applies the profile at startup; clients see a server with that subset of tools.
+
+| Profile              | Tools | When to use                                                     |
+| -------------------- | ----- | --------------------------------------------------------------- |
+| `full` (default)     | 33    | Dev assistant, exploratory work — full surface area             |
+| `validate-only`      | 5     | CI / audit scripts that only need to check policies pass        |
+| `validate-and-query` | 13    | Validation + AWS reference lookups, but no live AWS API         |
+| `no-generation`      | 28    | Exclude template/build tools when policies come from elsewhere  |
+| `read-only`          | 28    | Block tools that mutate session state — sandbox/CI integrations |
+
+```bash
+iam-validator-mcp --list-profiles            # print taxonomy and exit
+iam-validator-mcp --profile validate-only    # CI-friendly minimal set
+```
+
+Claude Desktop config example for a CI-style read-only profile with offline AWS data:
+
+```json
+{
+  "mcpServers": {
+    "iam-policy-validator": {
+      "command": "iam-validator-mcp",
+      "args": [
+        "--profile",
+        "read-only",
+        "--aws-services-dir",
+        "/var/cache/iam-validator/services"
+      ]
+    }
+  }
+}
+```
+
+!!! note "Profiles take effect on server start"
+    MCP clients cache the tool catalog per session. Switch profiles by
+    restarting the server.
+
+## CLI Parity Flags
+
+| Flag                  | Purpose                                                                        |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `--config`            | Load YAML config (settings + check overrides + custom_instructions)            |
+| `--instructions`      | Inline custom LLM instructions                                                 |
+| `--instructions-file` | File path containing custom instructions (markdown/text)                       |
+| `--custom-checks-dir` | Directory with custom Python `PolicyCheck` modules to auto-discover            |
+| `--aws-services-dir`  | Pre-downloaded AWS service definitions for offline mode (`sync-services`)      |
+| `--profile`           | Tool visibility profile (see above)                                            |
+| `--list-profiles`     | Print profile taxonomy and exit                                                |
 
 ## Usage Examples
 

--- a/docs/user-guide/checks/security-checks.md
+++ b/docs/user-guide/checks/security-checks.md
@@ -39,6 +39,39 @@ Replace with specific actions and resources:
 }
 ```
 
+### Noise Reduction (suppress_superseded_findings)
+
+A bare `Allow */*` statement would normally trigger many redundant checks —
+`wildcard_action`, `wildcard_resource`, `service_wildcard`, `sensitive_action`,
+`action_condition_enforcement`, and any custom checks you have loaded. All of those
+findings say the same thing: the statement is too permissive. The fix is always
+identical: scope the wildcard.
+
+By default (`suppress_superseded_findings: true`), the validator short-circuits this:
+when `full_wildcard` fires on a statement, **all other findings for that statement are
+suppressed** and a note is appended to the `full_wildcard` finding listing every check
+that was silenced. Sibling statements still receive the full check set.
+
+```
+CRITICAL — Statement allows all actions on all resources - CRITICAL SECURITY RISK
+
+**20 checks suppressed** for this statement (abac_enforcement,
+action_condition_enforcement, action_resource_matching, …).
+Scope the statement and re-run to see remaining findings.
+```
+
+!!! note "Conditions do not prevent suppression"
+    `Allow Action:* Resource:* + Condition: {...}` still triggers suppression. The
+    presence of a condition (ABAC tag, MFA, IP) does not change the root cause or
+    the fix: the wildcard needs to be scoped down.
+
+To restore the full finding list, set:
+
+```yaml
+settings:
+  suppress_superseded_findings: false
+```
+
 ---
 
 ## wildcard_action

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -90,6 +90,65 @@ wildcard_resource:
   hide_severities: [low]
 ```
 
+### suppress_superseded_findings
+
+When a statement contains `Action: "*"` and `Resource: "*"` with no conditions, every
+other check produces a redundant finding — the root cause and the fix are always the
+same: scope down the wildcard. This setting collapses all of that noise into one
+`critical` finding from `full_wildcard`.
+
+```yaml
+settings:
+  suppress_superseded_findings: true # default: true
+```
+
+**What gets suppressed**
+
+When `full_wildcard` fires on a statement, all other findings for **that statement
+only** are dropped — both statement-level checks (built-in and custom) and policy-level
+check findings that reference that statement index. The suppressed check IDs are listed
+inside the `full_wildcard` finding message so nothing is lost silently:
+
+```
+Statement allows all actions on all resources - CRITICAL SECURITY RISK
+
+**20 checks suppressed** for this statement (abac_enforcement,
+action_condition_enforcement, action_resource_matching, …).
+Scope the statement and re-run to see remaining findings.
+```
+
+**What is never suppressed**
+
+| Statement                             | Suppression                                      |
+| ------------------------------------- | ------------------------------------------------ |
+| `Deny */*`                            | No — `full_wildcard` only fires on `Allow`       |
+| `Allow NotAction: "*"`                | No — inverted semantics require full analysis    |
+| Sibling statements in the same policy | No — only the `*/*` statement is short-circuited |
+| `full_wildcard` itself                | Never suppressed                                 |
+
+!!! note "Conditions do not prevent suppression"
+    `Allow */* + Condition: {...}` is still treated as a full-wildcard statement.
+    The condition does not change the root cause or the fix, so suppression still
+    applies. The `full_wildcard` finding lists all suppressed checks so nothing is
+    lost silently.
+
+**Custom checks**
+
+Custom checks loaded via `--custom-checks-dir` are suppressed automatically — no
+changes to the check code required.
+
+**Opt out**
+
+```yaml
+settings:
+  suppress_superseded_findings: false
+```
+
+!!! warning "PR comment fingerprint churn"
+Switching from `false` to `true` (or vice versa) causes a one-time churn of
+existing PR comments anchored to the now-suppressed (or now-visible) check IDs.
+Re-run the validator once after changing this setting to refresh comment state.
+
 ## Check Configuration
 
 ### Disable a Check
@@ -272,6 +331,9 @@ settings:
   hide_severities:
     null # Hide these severities from output
     # Example: [low, info]
+
+  # Noise reduction
+  suppress_superseded_findings: true # Collapse */* noise into one finding (default: true)
 
   # AWS service definitions
   aws_services_dir: null # Path to offline service definitions

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.19.1"
+__version__ = "1.20.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/full_wildcard.py
+++ b/iam_validator/checks/full_wildcard.py
@@ -14,6 +14,21 @@ class FullWildcardCheck(PolicyCheck):
     description: ClassVar[str] = "Checks for both action and resource wildcards together (critical risk)"
     default_severity: ClassVar[str] = "critical"
 
+    supersedes: ClassVar[frozenset[str]] = frozenset(
+        {
+            "wildcard_action",
+            "wildcard_resource",
+            "service_wildcard",
+            "action_resource_matching",
+            "sensitive_action",
+            "action_condition_enforcement",
+            "mfa_condition_antipattern",
+        }
+    )
+
+    def matches(self, statement: Statement) -> bool:
+        return statement.is_full_wildcard_allow()
+
     async def execute(
         self,
         statement: Statement,

--- a/iam_validator/core/access_analyzer.py
+++ b/iam_validator/core/access_analyzer.py
@@ -207,6 +207,8 @@ class AccessAnalyzerValidator:
         region: str = "us-east-1",
         policy_type: PolicyType = PolicyType.IDENTITY_POLICY,
         profile: str | None = None,
+        *,
+        session: "boto3.Session | None" = None,
     ):
         """Initialize the Access Analyzer validator.
 
@@ -214,6 +216,10 @@ class AccessAnalyzerValidator:
             region: AWS region to use for Access Analyzer API calls
             policy_type: Type of policy to validate
             profile: AWS profile name to use (optional)
+            session: Optional pre-built boto3.Session. When supplied, the
+                region/profile arguments are ignored for session construction
+                (the client is created from the supplied session). The MCP
+                lifespan caches sessions per (region, profile) key for reuse.
         """
         self.region = region
         self.policy_type = policy_type
@@ -221,11 +227,11 @@ class AccessAnalyzerValidator:
         self.logger = logging.getLogger(__name__)
 
         try:
-            session_kwargs: dict[str, Any] = {"region_name": region}
-            if profile:
-                session_kwargs["profile_name"] = profile
-
-            session = boto3.Session(**session_kwargs)
+            if session is None:
+                session_kwargs: dict[str, Any] = {"region_name": region}
+                if profile:
+                    session_kwargs["profile_name"] = profile
+                session = boto3.Session(**session_kwargs)
             self.client = session.client("accessanalyzer")
             self.logger.info(f"Initialized Access Analyzer client in region {region}")
         except NoCredentialsError:

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -220,6 +220,14 @@ class PolicyCheck(ABC):
     #: Subclasses may override. Defaults to "warning".
     default_severity: ClassVar[str] = "warning"
 
+    #: Check IDs whose findings this check supersedes when matches() returns True.
+    supersedes: ClassVar[frozenset[str]] = frozenset()
+
+    def matches(self, statement: Statement) -> bool:
+        """True if this check dominates the statement (enables suppression of supersedes set).
+        Only relevant when supersedes is non-empty."""
+        return True
+
     def __getattr__(self, name: str) -> Any:
         """Raise NotImplementedError for required attributes not defined by subclass."""
         if name in ("check_id", "description"):
@@ -347,16 +355,19 @@ class CheckRegistry:
         issues = await registry.execute_checks_parallel(statement, idx, fetcher)
     """
 
-    def __init__(self, enable_parallel: bool = True):
+    def __init__(self, enable_parallel: bool = True, suppress_superseded: bool = False):
         """
         Initialize the registry.
 
         Args:
             enable_parallel: If True, execute checks in parallel (default: True)
+            suppress_superseded: If True, suppress redundant findings when a superseding
+                check fires (default: False here; config layer enables it by default)
         """
         self._checks: dict[str, PolicyCheck] = {}
         self._configs: dict[str, CheckConfig] = {}
         self.enable_parallel = enable_parallel
+        self.suppress_superseded = suppress_superseded
 
     def register(self, check: PolicyCheck) -> None:
         """
@@ -477,6 +488,37 @@ class CheckRegistry:
             and config.should_show_severity(issue.severity)
         ]
 
+    def _apply_supersedes(
+        self,
+        statement: Statement,
+        enabled_checks: list[PolicyCheck],
+        issues_map: dict[str, list[ValidationIssue]],
+    ) -> dict[str, list[ValidationIssue]]:
+        """Post-process issues to suppress redundant findings when a superseding check fired.
+
+        Suppresses ALL other checks that produced issues for this statement — not just
+        the hardcoded supersedes set — so custom checks are automatically covered.
+        """
+        superseding = [
+            (check, issues_map.get(check.check_id, []))
+            for check in enabled_checks
+            if check.supersedes and check.matches(statement) and issues_map.get(check.check_id)
+        ]
+        if not superseding:
+            return issues_map
+        superseder_ids = {check.check_id for check, _ in superseding}
+        suppressed_ids = set(issues_map.keys()) - superseder_ids
+        if not suppressed_ids:
+            return issues_map
+        for _, s_issues in superseding:
+            for issue in s_issues:
+                issue.message = (
+                    issue.message + f"\n\n**{len(suppressed_ids)} checks suppressed** for this statement "
+                    f"({', '.join(sorted(suppressed_ids))}). "
+                    "Scope the statement and re-run to see remaining findings."
+                )
+        return {check_id: issues for check_id, issues in issues_map.items() if check_id not in suppressed_ids}
+
     async def execute_checks_parallel(
         self,
         statement: Statement,
@@ -506,13 +548,15 @@ class CheckRegistry:
 
         if not self.enable_parallel or len(enabled_checks) == 1:
             # Run sequentially if parallel disabled or only one check
-            all_issues = []
+            issues_map: dict[str, list[ValidationIssue]] = {}
             for check in enabled_checks:
                 config = self.get_config(check.check_id)
                 if config:
                     issues = await check.execute(statement, statement_idx, fetcher, config)
-                    all_issues.extend(self._process_issues(issues, check, config, filepath))
-            return all_issues
+                    issues_map[check.check_id] = self._process_issues(issues, check, config, filepath)
+            if self.suppress_superseded:
+                issues_map = self._apply_supersedes(statement, enabled_checks, issues_map)
+            return [issue for issues in issues_map.values() for issue in issues]
 
         # Execute all checks in parallel
         tasks = []
@@ -529,16 +573,19 @@ class CheckRegistry:
         # Wait for all checks to complete
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Collect all issues, handling any exceptions and applying filters
-        all_issues = []
+        # Build issues_map, handling exceptions and applying filters
+        issues_map = {}
         for idx, result in enumerate(results):
             if isinstance(result, Exception):
-                # Log error but continue with other checks
                 logger.warning("Check '%s' failed: %s", task_checks[idx].check_id, result)
             elif isinstance(result, list):
-                all_issues.extend(self._process_issues(result, task_checks[idx], configs[idx], filepath))
+                processed = self._process_issues(result, task_checks[idx], configs[idx], filepath)
+                issues_map[task_checks[idx].check_id] = processed
 
-        return all_issues
+        if self.suppress_superseded:
+            issues_map = self._apply_supersedes(statement, enabled_checks, issues_map)
+
+        return [issue for issues in issues_map.values() for issue in issues]
 
     async def execute_checks_sequential(
         self,
@@ -561,19 +608,22 @@ class CheckRegistry:
         Returns:
             List of all ValidationIssue objects from all checks
         """
-        all_issues = []
         enabled_checks = self.get_enabled_checks()
+        issues_map: dict[str, list[ValidationIssue]] = {}
 
         for check in enabled_checks:
             config = self.get_config(check.check_id)
             if config:
                 try:
                     issues = await check.execute(statement, statement_idx, fetcher, config)
-                    all_issues.extend(self._process_issues(issues, check, config, filepath))
+                    issues_map[check.check_id] = self._process_issues(issues, check, config, filepath)
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     logger.warning("Check '%s' failed: %s", check.check_id, e)
 
-        return all_issues
+        if self.suppress_superseded:
+            issues_map = self._apply_supersedes(statement, enabled_checks, issues_map)
+
+        return [issue for issues in issues_map.values() for issue in issues]
 
     async def execute_policy_checks(
         self,
@@ -654,7 +704,11 @@ class CheckRegistry:
         return all_issues
 
 
-def create_default_registry(enable_parallel: bool = True, include_builtin_checks: bool = True) -> CheckRegistry:
+def create_default_registry(
+    enable_parallel: bool = True,
+    include_builtin_checks: bool = True,
+    suppress_superseded: bool = False,
+) -> CheckRegistry:
     """
     Create a registry with all built-in checks registered.
 
@@ -664,11 +718,13 @@ def create_default_registry(enable_parallel: bool = True, include_builtin_checks
     Args:
         enable_parallel: If True, checks will execute in parallel (default: True)
         include_builtin_checks: If True, register built-in checks (default: True)
+        suppress_superseded: If True, suppress redundant findings when a superseding
+            check fires (default: False here; config layer enables it by default)
 
     Returns:
         CheckRegistry with all built-in checks registered (if include_builtin_checks=True)
     """
-    registry = CheckRegistry(enable_parallel=enable_parallel)
+    registry = CheckRegistry(enable_parallel=enable_parallel, suppress_superseded=suppress_superseded)
 
     if include_builtin_checks:
         # Import and register built-in checks

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -128,6 +128,8 @@ DEFAULT_CONFIG = {
         # individual: Post each as an individual review comment
         # modified_statements_only: Individual comments for modified statements only
         "off_diff_comment_mode": "summary_only",
+        # Suppress redundant findings for statements already flagged by full_wildcard.
+        "suppress_superseded_findings": True,
     },
     # ========================================================================
     # AWS IAM Validation Checks (17 checks total)

--- a/iam_validator/core/constants.py
+++ b/iam_validator/core/constants.py
@@ -31,6 +31,35 @@ DEFAULT_ARN_VALIDATION_PATTERN = rf"^arn:{ARN_PARTITION_REGEX}:[a-z0-9\-]+:[a-z0
 MAX_ARN_LENGTH = 2048
 
 # ============================================================================
+# IAM Policy Version Literals
+# ============================================================================
+# Centralized so MCP, fix tools, and templates can't drift. AWS recognises two
+# IAM policy language versions: "2012-10-17" (current) and "2008-10-17" (legacy).
+# New policies should always use "2012-10-17".
+IAM_POLICY_VERSION_CURRENT = "2012-10-17"
+IAM_POLICY_VERSION_LEGACY = "2008-10-17"
+IAM_POLICY_VERSIONS_VALID: frozenset[str] = frozenset({IAM_POLICY_VERSION_CURRENT, IAM_POLICY_VERSION_LEGACY})
+
+# ============================================================================
+# Default region per AWS partition
+# ============================================================================
+# AWS service endpoints are partition-specific. `us-east-1` is only valid in
+# the commercial partition. Any tool calling boto3 with a partition other than
+# `aws` MUST use a region that exists in that partition or the SDK rejects the
+# request before it leaves the box. Centralized so MCP, CLI, and tests
+# converge on the same defaults.
+PARTITION_DEFAULT_REGION: dict[str, str] = {
+    "aws": "us-east-1",
+    "aws-cn": "cn-north-1",
+    "aws-us-gov": "us-gov-west-1",
+    "aws-eusc": "eusc-de-east-1",
+    "aws-iso": "us-iso-east-1",
+    "aws-iso-b": "us-isob-east-1",
+    "aws-iso-e": "eu-isoe-west-1",
+    "aws-iso-f": "us-isof-south-1",
+}
+
+# ============================================================================
 # AWS IAM Policy Size Limits
 # ============================================================================
 # These limits are enforced by AWS and policies exceeding them will be rejected

--- a/iam_validator/core/formatters/enhanced.py
+++ b/iam_validator/core/formatters/enhanced.py
@@ -445,11 +445,14 @@ class EnhancedFormatter(OutputFormatter):
             # Structurally valid policies but may have security/best-practice findings
             has_critical = any(i.severity in constants.HIGH_SEVERITY_LEVELS for r in report.results for i in r.issues)
 
+            _p = lambda n, word: f"{n} {word}" + ("" if n == 1 else "s")  # noqa: E731
             if has_critical:
                 status = Text("⚠️ All Policies Structurally Valid (with findings)", style="bold red")
                 message = Text(
                     f"All {report.total_policies} policies are structurally valid (AWS-accepted), but "
-                    f"{policies_with_findings} have {report.total_issues} finding(s) that must be addressed.",
+                    f"{_p(policies_with_findings, 'policy')} "
+                    f"{'has' if policies_with_findings == 1 else 'have'} "
+                    f"{_p(report.total_issues, 'finding')} that must be addressed.",
                     style="red",
                 )
                 border_color = "red"
@@ -457,8 +460,9 @@ class EnhancedFormatter(OutputFormatter):
                 status = Text("✅ All Policies Structurally Valid (with advisories)", style="bold yellow")
                 message = Text(
                     f"All {report.total_policies} policies are structurally valid, but "
-                    f"{policies_with_findings} have {report.total_issues} advisory finding(s) "
-                    f"that should be reviewed.",
+                    f"{_p(policies_with_findings, 'policy')} "
+                    f"{'has' if policies_with_findings == 1 else 'have'} "
+                    f"{_p(report.total_issues, 'advisory finding')} that should be reviewed.",
                     style="yellow",
                 )
                 border_color = "yellow"

--- a/iam_validator/core/models.py
+++ b/iam_validator/core/models.py
@@ -142,6 +142,16 @@ class Statement(BaseModel):
             return []
         return [self.not_resource] if isinstance(self.not_resource, str) else self.not_resource
 
+    def is_full_wildcard_allow(self) -> bool:
+        """True if this statement grants Allow */* (conditions do not prevent suppression)."""
+        if self.effect != "Allow":
+            return False
+        if self.not_action or self.not_resource:
+            return False
+        actions = self.get_actions()
+        resources = self.get_resources()
+        return bool(actions) and bool(resources) and set(actions) == {"*"} and set(resources) == {"*"}
+
 
 class IAMPolicy(BaseModel):
     """IAM policy document."""

--- a/iam_validator/core/policy_checks.py
+++ b/iam_validator/core/policy_checks.py
@@ -178,7 +178,12 @@ async def validate_policies(
     enable_parallel = config.get_setting("parallel_execution", True)
     enable_builtin_checks = config.get_setting("enable_builtin_checks", True)
 
-    registry = create_default_registry(enable_parallel=enable_parallel, include_builtin_checks=enable_builtin_checks)
+    suppress_superseded = config.get_setting("suppress_superseded_findings", False)
+    registry = create_default_registry(
+        enable_parallel=enable_parallel,
+        include_builtin_checks=enable_builtin_checks,
+        suppress_superseded=suppress_superseded,
+    )
 
     if not enable_builtin_checks:
         logger.info("Built-in checks disabled - using only custom checks")
@@ -290,11 +295,27 @@ async def _validate_policy_with_registry(
     policy_type_issues = await policy_type_validation.execute_policy(policy, policy_file, policy_type=policy_type)
     result.issues.extend(policy_type_issues)  # pylint: disable=no-member
 
+    # Pre-scan for full-wildcard statements so policy-level findings for those
+    # statement indices can be suppressed below (same logic as statement-level).
+    suppressed_statement_indices: set[int] = set()
+    if registry.suppress_superseded and registry.is_enabled("full_wildcard"):
+        for idx, statement in enumerate(policy.statement or []):
+            if statement.is_full_wildcard_allow():
+                suppressed_statement_indices.add(idx)
+
     # Run policy-level checks first (checks that need to see the entire policy)
     # These checks examine relationships between statements, not individual statements
     policy_level_issues = await registry.execute_policy_checks(
         policy, policy_file, fetcher, policy_type, raw_policy_dict=raw_policy_dict
     )
+
+    # Drop policy-level findings that reference a suppressed statement — they are
+    # redundant when full_wildcard already flags the entire statement as */*.
+    if suppressed_statement_indices:
+        policy_level_issues = [
+            issue for issue in policy_level_issues if issue.statement_index not in suppressed_statement_indices
+        ]
+
     result.issues.extend(policy_level_issues)  # pylint: disable=no-member
 
     # Execute all statement-level checks for each statement

--- a/iam_validator/mcp/CLAUDE.md
+++ b/iam_validator/mcp/CLAUDE.md
@@ -1,8 +1,8 @@
 # MCP Module — Model Context Protocol Server
 
-FastMCP server exposing IAM validation, generation, and AWS-query tools to AI
-assistants. Entry point: `iam-validator-mcp` (calls `iam_validator.mcp:run_server`).
-Extends [../../CLAUDE.md](../../CLAUDE.md).
+FastMCP server exposing IAM validation, generation, AWS-query, and Access
+Analyzer tools to AI assistants. Entry point: `iam-validator-mcp` (calls
+`iam_validator.mcp:run_server`). Extends [../../CLAUDE.md](../../CLAUDE.md).
 
 ---
 
@@ -10,8 +10,12 @@ Extends [../../CLAUDE.md](../../CLAUDE.md).
 
 ```bash
 uv sync --extra mcp && iam-validator-mcp
-mise run mcp:inspector                          # debug with MCP Inspector
-iam-validator-mcp --org-config ./org-policy.yaml  # pre-load org config
+mise run mcp:inspector                                # debug with MCP Inspector
+iam-validator-mcp --config ./iam-validator.yaml       # pre-load config
+iam-validator-mcp --custom-checks-dir ./my-checks     # CLI parity (custom checks)
+iam-validator-mcp --aws-services-dir ./aws-services   # CLI parity (offline AWS data)
+iam-validator-mcp --profile validate-only             # token-efficient profile
+iam-validator-mcp --list-profiles                     # print profile taxonomy
 ```
 
 End-user install + Claude Desktop config: see `docs/integrations/mcp-server.md`.
@@ -22,43 +26,80 @@ End-user install + Claude Desktop config: see `docs/integrations/mcp-server.md`.
 
 ```
 mcp/
-├── __init__.py            # exports create_server, run_server, models
-├── server.py              # FastMCP server: 35+ @mcp.tool, 6 @mcp.resource
+├── __init__.py            # CLI argparse, entry-point, profile dispatch
+├── server.py              # FastMCP server: 33 @mcp.tool, 8 @mcp.resource (~2.5K lines)
 ├── models.py              # 5 Pydantic request/response models
-├── session_config.py      # ValidatorConfig wrapper for session-scoped org config
+├── session_config.py      # ValidatorConfig + CLI-paths storage (custom_checks_dir, aws_services_dir)
+├── check_metadata.py      # 12 curated examples driving get_issue_guidance / iam://checks/{check_id}
 ├── tools/
-│   ├── validation.py      # validate_policy, quick_validate, validate_policies_batch
+│   ├── validation.py      # validate_policy, quick_validate (forwards SessionConfigManager paths)
 │   ├── generation.py      # generate_policy_from_template, build_minimal_policy, suggest_actions, …
 │   ├── query.py           # query_service_actions, query_action_details, expand_wildcard_action, …
+│   ├── analyze.py         # analyze_policy — wraps boto3 Access Analyzer in asyncio.to_thread
 │   └── org_config_tools.py # set/get/clear organization_config, check_org_compliance, validate_with_config
 └── templates/
     ├── __init__.py
     └── builtin.py         # 15 templates with variable substitution
 ```
 
-`server.py` lifespan owns one shared `AWSServiceFetcher` so all tool calls reuse
-the cache.
+`server.py` lifespan owns one shared `AWSServiceFetcher` AND a per-`(region,
+profile)` boto3 session cache so all tool calls reuse them.
 
 ---
 
-## Tools (35+)
+## Tools (33) — tagged for `--profile` gating
 
-Categories — see `server.py` for the authoritative list:
+Every tool carries exactly one functional tag (some also carry `mutating`).
+The `--profile` flag uses these tags to enable/disable groups:
 
-- **Validation (3)** — `validate_policy`, `quick_validate`, `validate_policies_batch`
-- **Generation (6)** — `generate_policy_from_template`, `build_minimal_policy`,
-  `list_templates`, `suggest_actions`, `get_required_conditions`, `check_sensitive_actions`
-- **Query (10)** — `query_service_actions`, `query_action_details`,
-  `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`,
-  `list_checks`, `get_policy_summary`, `list_sensitive_actions`,
-  `get_condition_requirements_for_action`, `query_actions_batch`
-- **Organization config (6)** — `set/get/clear_organization_config`,
-  `load_organization_config_from_yaml`, `check_org_compliance`, `validate_with_config`
+| Tag          | Tools                                                                                                                                                                                                                                               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validate`   | `validate_policy`, `quick_validate`, `validate_policies_batch`, `get_policy_summary`, `get_active_profile`                                                                                                                                          |
+| `query`      | `query_service_actions`, `query_action_details`, `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`, `get_condition_requirements_for_action`, `query_actions_batch`, `check_actions_batch`                                       |
+| `generation` | `generate_policy_from_template`, `build_minimal_policy`, `suggest_actions`, `get_required_conditions`, `check_sensitive_actions`                                                                                                                    |
+| `fix`        | `fix_policy_issues`, `get_issue_guidance`, `explain_policy`, `compare_policies`, `build_arn` (live-data tool: consults `query_arn_formats`)                                                                                                         |
+| `orgconfig`  | `set_/get_/clear_organization_config` (set/clear also tagged `mutating`), `load_organization_config_from_yaml` (also `mutating`), `check_org_compliance`, `validate_with_config`, `set_/get_/clear_custom_instructions` (set/clear also `mutating`) |
+| `analyze`    | `aws_access_analyzer_validate` (only tool with `openWorldHint=True` — calls live AWS API)                                                                                                                                                           |
 
-## Resources (6)
+### Profiles
 
-`iam://templates`, `iam://checks`, `iam://sensitive-categories`,
-`iam://org-config-schema`, `iam://org-config-examples`, `iam://workflow-examples`.
+| Profile              | Behaviour                                                   |
+| -------------------- | ----------------------------------------------------------- |
+| `full`               | All tools (default)                                         |
+| `validate-only`      | Only `validate` tag — smallest token footprint              |
+| `validate-and-query` | `validate` + `query` (no live AWS API; analyze is excluded) |
+| `no-generation`      | Everything except `generation`                              |
+| `read-only`          | Excludes anything tagged `mutating` — useful for CI/sandbox |
+
+`apply_profile` snapshots `mcp._transforms` (FastMCP private attr) at module
+load so successive profile changes can reset cleanly. The
+`tests/mcp/test_profiles.py::test_apply_profile_is_not_an_mcp_tool` regression
+test guards against accidentally exposing the helper as a tool.
+
+### Token cost
+
+Tags + tool annotations + slimmed `BASE_INSTRUCTIONS` produce these footprints
+(instructions + tool descriptions, characters):
+
+| Profile              | Tools | Total | % full |
+| -------------------- | ----- | ----- | ------ |
+| `full`               | 33    | 4445  | 100%   |
+| `validate-only`      | 5     | 1609  | 36%    |
+| `validate-and-query` | 13    | 2173  | 48%    |
+
+## Resources (8)
+
+Static resources cache client-side and don't count against per-turn token
+budget the way tool descriptions do:
+
+- `iam://templates` — list of available policy templates
+- `iam://checks` — registered check catalog (id, description, default_severity)
+- `iam://sensitive-categories` — sensitive-action category descriptions
+- `iam://sensitive-actions/{category}` — actions for a category (parameterized)
+- `iam://checks/{check_id}` — per-check docs, registry-driven (parameterized)
+- `iam://config-schema` — JSON Schema for session config
+- `iam://config-examples` — example YAML configs by security posture
+- `iam://workflow-examples` — guided example workflows
 
 ## Templates (15)
 
@@ -74,9 +115,9 @@ Categories — see `server.py` for the authoritative list:
 ### Tool
 
 Implement in `tools/<category>.py`, then register in `server.py` with
-`@mcp.tool()` plus a docstring (the docstring becomes the Claude-facing
-description). The `server.py` shim is intentionally thin — it just delegates to
-the implementation.
+`@mcp.tool(tags={"<one-tag>"}, annotations=ToolAnnotations(...))` plus a
+docstring (the docstring becomes the Claude-facing description). Pick a single
+tag; if it could fit two, the dominant one is right.
 
 ### Resource
 
@@ -87,17 +128,30 @@ async def my_resource() -> str:
     return json.dumps({...}, indent=2)
 ```
 
+Parameterized:
+
+```python
+@mcp.resource("iam://my-thing/{name}")
+async def my_thing(name: str) -> str:
+    return json.dumps({"name": name, "data": ...}, indent=2)
+```
+
+### Curated check example
+
+If a new check has a clean, short example, add an entry to `CHECK_EXAMPLES` in
+`iam_validator/mcp/check_metadata.py`. Without an entry, `get_issue_guidance`
+falls back to registry-driven defaults (description + severity from the check
+class) — already useful, just less specific.
+
 ### Template
 
-Append to `TEMPLATES` in `templates/builtin.py`:
+Append to `TEMPLATES` in `templates/builtin.py` — one entry per template:
 
 ```python
 TEMPLATES["my-template"] = {
     "name": "my-template",
     "description": "What this template does",
-    "variables": [
-        {"name": "param1", "description": "...", "required": True},
-    ],
+    "variables": [{"name": "param1", "description": "...", "required": True}],
     "policy": {"Version": "2012-10-17", "Statement": [...]},
 }
 ```
@@ -110,5 +164,15 @@ TEMPLATES["my-template"] = {
 uv run pytest tests/mcp/
 ```
 
-Mock fetcher / network — no real API calls. Debug interactively via `mise run mcp:inspector`.
-Requires `fastmcp>=2.0.0` (installed via `uv sync --extra mcp`).
+Test files of note:
+
+- `test_constants_alignment.py` — guard rails: MCP must source shared literals from `core/constants`
+- `test_check_metadata.py` — every registered check must yield useful guidance
+- `test_build_arn.py` — placeholders dict, deprecated `resource_name`, partition validation
+- `test_profiles.py` — tag-based gating + idempotency
+- `test_transport.py` — in-process FastMCP `Client` round-trip (annotations, resources, errors)
+- `test_analyze.py` — Access Analyzer wrapper + cached boto3 session
+
+Mock fetcher / network — no real API or AWS calls. Debug interactively via
+`mise run mcp:inspector`. Requires `fastmcp>=3.2,<4` (installed via
+`uv sync --extra mcp`).

--- a/iam_validator/mcp/__init__.py
+++ b/iam_validator/mcp/__init__.py
@@ -83,19 +83,75 @@ def run_server() -> None:
         metavar="FILE",
         help="Path to configuration YAML file to load at startup",
     )
-    parser.add_argument(
+    # --instructions and --instructions-file are mutually exclusive: both set
+    # CustomInstructionsManager and only one wins, so the previous "silently
+    # ignore --instructions if --instructions-file is set" behaviour was a
+    # footgun.
+    instructions_group = parser.add_mutually_exclusive_group()
+    instructions_group.add_argument(
         "--instructions",
         type=str,
         metavar="TEXT",
-        help="Custom instructions to append to default LLM instructions",
+        help="Inline custom instructions to append to default LLM instructions. Mutually exclusive with --instructions-file.",
     )
-    parser.add_argument(
+    instructions_group.add_argument(
         "--instructions-file",
         type=str,
         metavar="FILE",
-        help="Path to file containing custom instructions (markdown, txt)",
+        help="Path to file containing custom instructions (markdown, txt). Mutually exclusive with --instructions.",
+    )
+    parser.add_argument(
+        "--custom-checks-dir",
+        type=str,
+        metavar="DIR",
+        help=(
+            "Directory of Python modules with custom PolicyCheck subclasses to "
+            "auto-discover (CLI parity). Precedence: this flag > YAML config > built-in defaults."
+        ),
+    )
+    parser.add_argument(
+        "--aws-services-dir",
+        type=str,
+        metavar="DIR",
+        help=(
+            "Directory of pre-downloaded AWS service definitions for offline mode "
+            "(populate via 'iam-validator sync-services'). Precedence: this flag > "
+            "YAML config > online fetch."
+        ),
+    )
+    parser.add_argument(
+        "--profile",
+        choices=[
+            "full",
+            "validate-only",
+            "validate-and-query",
+            "no-generation",
+            "read-only",
+        ],
+        default="full",
+        help=(
+            "Limit which MCP tools are exposed (tag-based gating). "
+            "'full' = all tools (default). "
+            "'validate-only' = validation tools only (smallest token footprint). "
+            "'validate-and-query' = validation + AWS service-reference query tools "
+            "(does NOT include the live AWS Access Analyzer; use 'full' or 'no-generation' for that). "
+            "'no-generation' = everything except policy generation. "
+            "'read-only' = excludes any tool tagged 'mutating' (set_*, clear_*, load_*) — useful for CI / sandbox."
+        ),
+    )
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="Print the profile -> tool taxonomy and exit.",
     )
     args = parser.parse_args()
+
+    if args.list_profiles:
+        from iam_validator.mcp.server import PROFILE_DESCRIPTIONS
+
+        for name, desc in PROFILE_DESCRIPTIONS.items():
+            print(f"{name:>20s}  {desc}")
+        sys.exit(0)
 
     # Load config if provided (may include custom_instructions)
     if args.config:
@@ -136,6 +192,26 @@ def run_server() -> None:
     elif args.instructions:
         CustomInstructionsManager.set_instructions(args.instructions, source="cli")
         print("Custom instructions set from CLI argument", file=sys.stderr)
+
+    # Plumb CLI parity paths into the session manager so validate_policy and
+    # related tools forward them to validate_policies()
+    if args.custom_checks_dir or args.aws_services_dir:
+        SessionConfigManager.set_paths(
+            custom_checks_dir=args.custom_checks_dir,
+            aws_services_dir=args.aws_services_dir,
+        )
+        if args.custom_checks_dir:
+            print(f"Custom checks dir: {args.custom_checks_dir}", file=sys.stderr)
+        if args.aws_services_dir:
+            print(f"AWS services dir: {args.aws_services_dir}", file=sys.stderr)
+
+    # Apply tool visibility profile before starting the server.
+    if args.profile != "full":
+        from iam_validator.mcp.server import apply_profile, set_active_profile
+
+        apply_profile(args.profile)
+        set_active_profile(args.profile)
+        print(f"MCP profile: {args.profile}", file=sys.stderr)
 
     try:
         from iam_validator.mcp.server import run_server as _run_server

--- a/iam_validator/mcp/check_metadata.py
+++ b/iam_validator/mcp/check_metadata.py
@@ -1,0 +1,232 @@
+"""Curated examples / fix_steps per check_id.
+
+`get_issue_guidance` and `get_check_details` consult this module for hand-written
+copy-pasteable examples and remediation steps. For check_ids without a curated
+entry, those tools fall back to registry-driven defaults.
+
+When a new check is added in `iam_validator/checks/`, add an entry here if there
+is a clear, short example. Checks without a clean example fall through to the
+registry-driven path and still return useful (if generic) guidance.
+"""
+
+from typing import Any
+
+from iam_validator.core.constants import IAM_POLICY_VERSION_CURRENT
+
+# Curated examples per check_id. Keep entries short and copy-pastable.
+CHECK_EXAMPLES: dict[str, dict[str, Any]] = {
+    "wildcard_action": {
+        "example_violation": {"Effect": "Allow", "Action": "*", "Resource": "*"},
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject", "s3:ListBucket"],
+            "Resource": "arn:aws:s3:::my-bucket/*",
+        },
+        "fix_steps": [
+            "Identify what the policy user actually needs to do",
+            "Use suggest_actions or query_service_actions to find specific actions",
+            "Replace '*' with the specific action list",
+        ],
+        "related": ["suggest_actions", "query_service_actions", "iam://templates"],
+        "category": "security",
+    },
+    "wildcard_resource": {
+        "example_violation": {"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "*"},
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": "arn:aws:s3:::my-bucket/*",
+        },
+        "fix_steps": [
+            "Determine the exact resources the principal needs",
+            "Use query_arn_formats('<service>') to get the ARN template",
+            "Replace '*' with explicit ARN(s)",
+        ],
+        "related": ["query_arn_formats", "build_arn"],
+        "category": "security",
+    },
+    "full_wildcard": {
+        "example_violation": {"Effect": "Allow", "Action": "*", "Resource": "*"},
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": "arn:aws:s3:::my-bucket/*",
+        },
+        "fix_steps": [
+            "Treat as a critical finding — never deploy `*`/`*`.",
+            "Replace both Action and Resource with explicit values.",
+        ],
+        "related": ["iam://templates", "build_minimal_policy"],
+        "category": "security",
+    },
+    "service_wildcard": {
+        "example_violation": {"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject", "s3:PutObject"],
+            "Resource": "arn:aws:s3:::my-bucket/*",
+        },
+        "fix_steps": [
+            "Replace `<service>:*` with the explicit subset.",
+            "Use expand_wildcard_action to see what `s3:*` actually expands to before narrowing.",
+        ],
+        "related": ["expand_wildcard_action", "query_service_actions"],
+        "category": "security",
+    },
+    "sensitive_action": {
+        "example_violation": {
+            "Effect": "Allow",
+            "Action": "iam:CreateAccessKey",
+            "Resource": "*",
+        },
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": "iam:CreateAccessKey",
+            "Resource": "arn:aws:iam::123456789012:user/${aws:username}",
+            "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+        },
+        "fix_steps": [
+            "Confirm the sensitive action is truly required",
+            "Use check_sensitive_actions to see the risk category",
+            "Use get_required_conditions to see required guardrails",
+            "Add Condition + scoped Resource",
+        ],
+        "related": ["check_sensitive_actions", "get_required_conditions"],
+        "category": "security",
+    },
+    "action_validation": {
+        "example_violation": {"Effect": "Allow", "Action": ["S3:GetObjects"], "Resource": "*"},
+        "example_fix": {"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "*"},
+        "fix_steps": [
+            "Lowercase the service prefix",
+            "Verify the action exists with query_action_details",
+            "Re-run validate_policy",
+        ],
+        "related": ["query_action_details", "query_service_actions", "expand_wildcard_action"],
+        "category": "aws",
+    },
+    "policy_structure": {
+        "example_violation": {"Statement": [{"Action": "s3:*"}]},
+        "example_fix": {
+            "Version": IAM_POLICY_VERSION_CURRENT,
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::my-bucket/*",
+                }
+            ],
+        },
+        "fix_steps": [
+            f'Add `Version: "{IAM_POLICY_VERSION_CURRENT}"`',
+            "Each Statement needs Effect, Action, Resource",
+            "Run fix_policy_issues for auto-fixes",
+        ],
+        "related": ["fix_policy_issues", "validate_policy"],
+        "category": "structure",
+    },
+    "action_condition_enforcement": {
+        "example_violation": {
+            "Effect": "Allow",
+            "Action": ["iam:CreateUser"],
+            "Resource": "*",
+        },
+        "example_fix": {
+            "Effect": "Allow",
+            "Action": ["iam:CreateUser"],
+            "Resource": "*",
+            "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+        },
+        "fix_steps": [
+            "Use get_required_conditions(['<action>'])",
+            "Add the recommended Condition block",
+        ],
+        "related": ["get_required_conditions", "fix_policy_issues"],
+        "category": "security",
+    },
+    "not_action_not_resource": {
+        "example_violation": {"Effect": "Allow", "NotAction": "iam:*", "Resource": "*"},
+        "example_fix": {"Effect": "Deny", "Action": "iam:*", "Resource": "*"},
+        "fix_steps": [
+            "Prefer explicit allow-lists over NotAction/NotResource",
+            "If you mean a deny, use Effect: Deny with Action",
+        ],
+        "related": ["validate_policy"],
+        "category": "anti-pattern",
+    },
+    "sid_uniqueness": {
+        "example_violation": {
+            "Statement": [
+                {"Sid": "A", "Effect": "Allow", "Action": "s3:Get*"},
+                {"Sid": "A", "Effect": "Allow", "Action": "s3:Put*"},
+            ]
+        },
+        "example_fix": {
+            "Statement": [
+                {"Sid": "AllowReads", "Effect": "Allow", "Action": "s3:Get*"},
+                {"Sid": "AllowWrites", "Effect": "Allow", "Action": "s3:Put*"},
+            ]
+        },
+        "fix_steps": [
+            "Rename duplicates to be unique",
+            "fix_policy_issues auto-renames by appending the index",
+        ],
+        "related": ["fix_policy_issues"],
+        "category": "structure",
+    },
+    "principal_validation": {
+        "example_violation": {
+            "Effect": "Allow",
+            "Principal": {"AWS": "*"},
+            "Action": "sts:AssumeRole",
+        },
+        "example_fix": {
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:role/Trusted"},
+            "Action": "sts:AssumeRole",
+        },
+        "fix_steps": [
+            "Replace `*` with the specific principal ARN",
+            "Add an aws:PrincipalOrgID condition for org-wide trust",
+        ],
+        "related": ["validate_policy"],
+        "category": "security",
+    },
+    "trust_policy_validation": {
+        "example_violation": {
+            "Version": IAM_POLICY_VERSION_CURRENT,
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        },
+        "example_fix": {
+            "Version": IAM_POLICY_VERSION_CURRENT,
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": "123456789012"}},
+                }
+            ],
+        },
+        "fix_steps": [
+            "Service principals: add aws:SourceAccount/aws:SourceArn to prevent confused deputy",
+            "Cross-account: add ExternalId condition",
+        ],
+        "related": ["generate_policy_from_template"],
+        "category": "security",
+    },
+}
+
+
+def get_check_metadata(check_id: str) -> dict[str, Any]:
+    """Return curated metadata for a check, or {} if no curated entry exists."""
+    return CHECK_EXAMPLES.get(check_id, {})
+
+
+__all__ = ["CHECK_EXAMPLES", "get_check_metadata"]

--- a/iam_validator/mcp/server.py
+++ b/iam_validator/mcp/server.py
@@ -18,8 +18,14 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 
 from iam_validator.core.aws_service import AWSServiceFetcher
+from iam_validator.core.check_registry import CheckRegistry, create_default_registry
+from iam_validator.core.constants import (
+    IAM_POLICY_VERSION_CURRENT,
+    IAM_POLICY_VERSIONS_VALID,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,12 +48,40 @@ async def server_lifespan(_server: FastMCP):
     )
     await fetcher.__aenter__()
 
+    # Cache boto3 sessions per (region, profile) — Session() costs ~50ms each.
+    aws_sessions: dict[tuple[str, str | None], Any] = {}
+
     try:
-        # Store fetcher in server context for tools to access
-        yield {"fetcher": fetcher}
+        yield {"fetcher": fetcher, "aws_sessions": aws_sessions}
     finally:
-        # Cleanup on shutdown
         await fetcher.__aexit__(None, None, None)
+
+
+def get_aws_session(ctx: Any, region: str, profile: str | None) -> Any:
+    """Return a (cached) boto3 Session for ``(region, profile)``.
+
+    Mirrors ``get_shared_fetcher``'s fallback: if no lifespan context is
+    available (tests, direct calls outside MCP), build a fresh session each
+    call rather than crashing.
+    """
+    import boto3
+
+    lifespan = getattr(getattr(ctx, "request_context", None), "lifespan_context", None)
+    cache = lifespan.get("aws_sessions") if isinstance(lifespan, dict) else None
+
+    if cache is None:
+        kwargs: dict[str, Any] = {"region_name": region}
+        if profile:
+            kwargs["profile_name"] = profile
+        return boto3.Session(**kwargs)
+
+    key = (region, profile)
+    if key not in cache:
+        kwargs = {"region_name": region}
+        if profile:
+            kwargs["profile_name"] = profile
+        cache[key] = boto3.Session(**kwargs)
+    return cache[key]
 
 
 def get_shared_fetcher(ctx: Any) -> AWSServiceFetcher | None:
@@ -61,33 +95,31 @@ def get_shared_fetcher(ctx: Any) -> AWSServiceFetcher | None:
 
     Note:
         When None is returned, callers typically create a new fetcher instance.
-        This is logged as a warning since it may lead to:
-        - Redundant HTTP connections
-        - Cache misses (new fetcher has empty cache)
-        - Potential performance degradation
+        Logged at DEBUG level — happens routinely in tests and direct callers
+        outside of an MCP request context.
     """
     if ctx and hasattr(ctx, "request_context") and ctx.request_context:
         lifespan_ctx = ctx.request_context.lifespan_context
         if lifespan_ctx and "fetcher" in lifespan_ctx:
             return lifespan_ctx["fetcher"]
 
-    logger.warning(
-        "Shared fetcher unavailable from context. A new fetcher instance will be created, which may impact performance."
-    )
+    logger.debug("Shared fetcher unavailable from context; tool will create a new one.")
     return None
 
 
 # =============================================================================
-# Cached Registry for list_checks
+# Cached Registry for list_checks and registry-driven guidance
 # =============================================================================
+
+# Module-level: built once at import. Tools just read.
+# create_default_registry() is sync and cheap (no I/O, just instantiates check
+# classes), so eager init eliminates any race-condition surface.
+_REGISTRY: CheckRegistry = create_default_registry()
 
 
 @functools.lru_cache(maxsize=1)
 def _get_cached_checks() -> tuple[dict[str, Any], ...]:
     """Get cached check registry (initialized once, thread-safe via lru_cache)."""
-    from iam_validator.core.check_registry import create_default_registry
-
-    registry = create_default_registry()
     return tuple(
         sorted(
             [
@@ -96,7 +128,7 @@ def _get_cached_checks() -> tuple[dict[str, Any], ...]:
                     "description": check_instance.description,
                     "default_severity": check_instance.default_severity,
                 }
-                for check_instance in registry.get_all_checks()
+                for check_instance in _REGISTRY.get_all_checks()
             ],
             key=lambda x: x["check_id"],
         )
@@ -107,7 +139,7 @@ def _get_cached_checks() -> tuple[dict[str, Any], ...]:
 # Base Instructions (constant)
 # =============================================================================
 
-BASE_INSTRUCTIONS = """
+_BASE_INSTRUCTIONS_TEMPLATE = """
 You are an AWS IAM security expert generating secure, least-privilege policies.
 
 ## CORE PRINCIPLES
@@ -118,76 +150,23 @@ You are an AWS IAM security expert generating secure, least-privilege policies.
 ## ABSOLUTE RULES (GUARDRAIL: DO NOT REMOVE)
 - NEVER generate `"Action": "*"` or `"Resource": "*"` with write actions
 - NEVER allow `iam:*`, `sts:AssumeRole`, `kms:*` without conditions
-- NEVER guess ARN formats - use query_arn_formats
-- ALWAYS validate actions exist - typos create security gaps
+- NEVER guess ARN formats — use query_arn_formats
+- ALWAYS validate actions exist — typos create security gaps
 - ALWAYS present security_notes from generation tools
 
 ## VALIDATION LOOP PREVENTION (GUARDRAIL: DO NOT REMOVE)
-
-⛔ **HARD LIMIT: Maximum 2 validate_policy calls per request**
-
-| Severity | Action |
-|----------|--------|
-| error/critical | Fix using `example` field |
-| high/medium/low/warning | **PRESENT AS-IS** - informational only |
-
-**Workflow:**
-1. Generate policy (template or build_minimal_policy)
-2. validate_policy (call #1) → fix error/critical only
-3. validate_policy (call #2) → **FINAL - present policy with any warnings**
-
-**Stop signs:** Called validate >2 times, same warning repeating, trying to "fix" warnings.
-**When in doubt: PRESENT THE POLICY.**
-
-## SENSITIVE ACTIONS (490+ tracked)
-- credential_exposure (CRITICAL): sts:AssumeRole, iam:CreateAccessKey → MFA, IP limits
-- privilege_escalation (CRITICAL): iam:AttachUserPolicy, iam:PassRole → resource scope
-- data_access/resource_exposure (HIGH): s3:GetObject, s3:PutBucketPolicy → scope, encryption
-
-## TOOL QUICK REFERENCE
-| Task | Tool |
-|------|------|
-| Create policy | list_templates → generate_policy_from_template, or build_minimal_policy |
-| Validate | validate_policy (full) or quick_validate (summary) |
-| Fix structure | fix_policy_issues (Version, SIDs, case) |
-| Fix guidance | get_issue_guidance or issue.example field |
-| Find actions | query_service_actions or suggest_actions |
-| ARN formats | query_arn_formats |
-| Batch ops | validate_policies_batch, query_actions_batch |
-
-## CONDITION KEYS (IMPORTANT)
-When adding conditions, check BOTH:
-1. **Action conditions**: Use get_required_conditions or query_action_details for action-specific keys
-2. **Resource conditions**: Use query_condition_keys(service) - resources have their own condition keys
-Example: s3:GetObject supports action conditions AND s3 bucket/object resource conditions (s3:prefix, etc.)
-
-## ANTI-PATTERNS
-- `"Resource": "arn:aws:s3:::*"` → use specific bucket ARN
-- `"Action": "s3:*"` → use specific actions with resources
-- `iam:PassRole` without `iam:PassedToService` condition
-
-## TRUST POLICIES
-Principal required, Resource not used. Auto-detected by validate_policy.
-Use generate_policy_from_template("cross-account-assume-role") for cross-account.
-
-## IAM ACTION FORMAT (CRITICAL)
-Format: `<service>:<ActionName>` (e.g., `s3:GetObject`, `lambda:InvokeFunction`)
-- Service: lowercase (`s3`, not `S3`)
-- Action: PascalCase (`GetObject`, not `getobject`)
-- Wildcards: `s3:Get*`, `s3:*`
-
-## POLICY STRUCTURE
-```json
-{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": ["arn:aws:s3:::bucket/*"]}]}
-```
-- Version: Always "2012-10-17"
-- Effect: "Allow" or "Deny" (exact case)
-- Use query_arn_formats for correct ARN patterns
+HARD LIMIT: maximum 2 validate_policy calls per request.
+Fix `error`/`critical` using the issue's `example` field; present the policy with
+remaining `high`/`medium`/`low`/`warning` items as informational only.
+When in doubt, PRESENT THE POLICY.
 
 ## RESOURCES
-- iam://templates, iam://checks, iam://workflow-examples
-- Prompts: generate_secure_policy, fix_policy_issues_workflow, review_policy_security
+iam://templates, iam://checks, iam://sensitive-actions/{category},
+iam://checks/{check_id}, iam://workflow-examples.
+Default policy Version is "__VERSION__".
 """
+
+BASE_INSTRUCTIONS = _BASE_INSTRUCTIONS_TEMPLATE.replace("__VERSION__", IAM_POLICY_VERSION_CURRENT)
 
 
 def get_instructions() -> str:
@@ -213,11 +192,81 @@ mcp = FastMCP(
 
 
 # =============================================================================
+# Profile-based tool gating (FastMCP tag-based enable/disable)
+# =============================================================================
+#
+# We snapshot _transforms after server construction (zero baseline transforms
+# at this point) so apply_profile() can reset to a clean slate when the active
+# profile changes. _transforms is a private FastMCP attribute; if FastMCP
+# renames it the test in tests/mcp/test_profiles.py will catch the regression.
+_BASELINE_TRANSFORMS_LEN: int = len(mcp._transforms)
+_ACTIVE_PROFILE: str = "full"
+
+
+PROFILE_DESCRIPTIONS: dict[str, str] = {
+    "full": "All tools (default).",
+    "validate-only": "Validation tools only — smallest token footprint.",
+    "validate-and-query": (
+        "Validation + AWS service-reference query tools. Does NOT include the live "
+        "AWS Access Analyzer (use 'full' or 'no-generation' for that)."
+    ),
+    "no-generation": "Everything except policy generation tools.",
+    "read-only": (
+        "Excludes any tool tagged 'mutating' (set_/clear_/load_*). Tag-based, not "
+        "annotation-based — destructiveHint=False is intentional for session-only "
+        "mutators per MCP spec, but they're still hidden here via the mutating tag."
+    ),
+}
+
+
+def apply_profile(profile: str) -> None:
+    """Apply tool visibility profile by tag-based enable/disable.
+
+    Idempotent: safe to call multiple times. Resets to the baseline transform
+    state before applying the new profile so successive calls don't compound.
+
+    Args:
+        profile: One of full, validate-only, validate-and-query, no-generation,
+            read-only.
+
+    Raises:
+        ValueError: Unknown profile name.
+    """
+    # Drop any profile-applied transforms from previous calls.
+    del mcp._transforms[_BASELINE_TRANSFORMS_LEN:]
+
+    if profile == "full":
+        return
+    if profile == "validate-only":
+        mcp.enable(tags={"validate"}, only=True)
+        return
+    if profile == "validate-and-query":
+        mcp.enable(tags={"validate", "query"}, only=True)
+        return
+    if profile == "no-generation":
+        mcp.disable(tags={"generation"})
+        return
+    if profile == "read-only":
+        mcp.disable(tags={"mutating"})
+        return
+    raise ValueError(f"Unknown profile: {profile}. Allowed: {sorted(PROFILE_DESCRIPTIONS.keys())}")
+
+
+def set_active_profile(profile: str) -> None:
+    """Record the active profile name (for `get_active_profile` introspection)."""
+    global _ACTIVE_PROFILE
+    _ACTIVE_PROFILE = profile
+
+
+# =============================================================================
 # Validation Tools
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"validate"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def validate_policy(
     policy: dict[str, Any],
     policy_type: str | None = None,
@@ -237,49 +286,21 @@ async def validate_policy(
     Returns:
         {is_valid, issues, policy_file}
     """
+    from iam_validator.mcp.tools.validation import issue_to_dict
     from iam_validator.mcp.tools.validation import validate_policy as _validate
 
     result = await _validate(policy=policy, policy_type=policy_type, use_org_config=use_org_config)
-
-    # Build issue list based on verbosity
-    if verbose:
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "suggestion": issue.suggestion,
-                "example": issue.example,
-                "check_id": issue.check_id,
-                "statement_index": issue.statement_index,
-                "action": getattr(issue, "action", None),
-                "resource": getattr(issue, "resource", None),
-                "field_name": getattr(issue, "field_name", None),
-                "risk_explanation": issue.risk_explanation,
-                "documentation_url": issue.documentation_url,
-                "remediation_steps": issue.remediation_steps,
-            }
-            for issue in result.issues
-        ]
-    else:
-        # Lean response - only essential fields
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "suggestion": issue.suggestion,
-                "check_id": issue.check_id,
-            }
-            for issue in result.issues
-        ]
-
     return {
         "is_valid": result.is_valid,
-        "issues": issues,
+        "issues": [issue_to_dict(i, verbose=verbose) for i in result.issues],
         "policy_file": result.policy_file,
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"validate"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def quick_validate(policy: dict[str, Any]) -> dict[str, Any]:
     """Quick pass/fail validation returning only essential info.
 
@@ -294,12 +315,103 @@ async def quick_validate(policy: dict[str, Any]) -> dict[str, Any]:
     return await _quick_validate(policy=policy)
 
 
+@mcp.tool(
+    tags={"validate"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_active_profile() -> dict[str, Any]:
+    """Return the active MCP profile and the tools it currently exposes.
+
+    Useful when a tool you expect is missing — confirms the server profile.
+    """
+    tools = await mcp.list_tools()
+    return {
+        "profile": _ACTIVE_PROFILE,
+        "tool_count": len(tools),
+        "tool_names": sorted(t.name for t in tools),
+    }
+
+
+@mcp.tool(
+    tags={"analyze"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+)
+async def aws_access_analyzer_validate(
+    policy: dict[str, Any],
+    ctx: Context,
+    policy_type: str = "IDENTITY_POLICY",
+    partition: str = "aws",
+    region: str | None = None,
+    profile: str | None = None,
+    timeout_seconds: float = 30.0,
+) -> dict[str, Any]:
+    """Run AWS Access Analyzer ValidatePolicy against the policy.
+
+    This tool calls the live AWS Access Analyzer API and requires AWS
+    credentials. Complements the local ``validate_policy`` tool by surfacing
+    AWS-only checks (deprecated globals, type-specific rules). Slower than
+    ``validate_policy`` because it incurs an HTTP round-trip per call.
+
+    Args:
+        policy: IAM policy dict (Version + Statement).
+        policy_type: One of "IDENTITY_POLICY", "RESOURCE_POLICY",
+            "SERVICE_CONTROL_POLICY".
+        partition: AWS partition (aws, aws-cn, aws-us-gov, aws-eusc,
+            aws-iso, aws-iso-b, aws-iso-e, aws-iso-f). Used to default
+            ``region`` if omitted.
+        region: AWS region for the API call. When omitted, defaults to the
+            canonical region for the chosen ``partition`` (e.g. ``aws-cn`` →
+            ``cn-north-1``).
+        profile: Optional AWS profile name.
+        timeout_seconds: Hard timeout on the AWS API call (default 30s).
+            Prevents an unresponsive AWS endpoint from blocking the MCP server.
+
+    Returns:
+        ``{findings: [...], finding_count: int}``. Each finding has
+        ``finding_type``, ``issue_code``, ``message``, ``learn_more_link``,
+        ``locations``.
+
+    Raises:
+        ToolError: bad policy_type, unsupported partition, missing AWS
+            credentials, AWS API failure, or timeout.
+    """
+    import asyncio as _asyncio
+
+    from fastmcp.exceptions import ToolError
+
+    from iam_validator.core.constants import PARTITION_DEFAULT_REGION
+    from iam_validator.mcp.tools.analyze import analyze_policy as _analyze
+
+    if partition not in PARTITION_DEFAULT_REGION:
+        raise ToolError(f"Unsupported partition '{partition}'. Allowed: {', '.join(sorted(PARTITION_DEFAULT_REGION))}.")
+
+    effective_region = region or PARTITION_DEFAULT_REGION[partition]
+
+    session = get_aws_session(ctx, effective_region, profile)
+    try:
+        return await _asyncio.wait_for(
+            _analyze(
+                policy=policy,
+                policy_type=policy_type,
+                region=effective_region,
+                profile=profile,
+                session=session,
+            ),
+            timeout=timeout_seconds,
+        )
+    except _asyncio.TimeoutError as e:
+        raise ToolError(f"AWS Access Analyzer call timed out after {timeout_seconds}s.") from e
+
+
 # =============================================================================
 # Generation Tools
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"generation"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def generate_policy_from_template(
     template_name: str,
     variables: dict[str, str],
@@ -320,44 +432,25 @@ async def generate_policy_from_template(
     from iam_validator.mcp.tools.generation import (
         generate_policy_from_template as _generate,
     )
+    from iam_validator.mcp.tools.validation import issue_to_dict
 
     result = await _generate(template_name=template_name, variables=variables)
-
-    if verbose:
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "suggestion": issue.suggestion,
-                "example": issue.example,
-                "check_id": issue.check_id,
-                "risk_explanation": issue.risk_explanation,
-                "remediation_steps": issue.remediation_steps,
-            }
-            for issue in result.validation.issues
-        ]
-    else:
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "check_id": issue.check_id,
-            }
-            for issue in result.validation.issues
-        ]
 
     return {
         "policy": result.policy,
         "validation": {
             "is_valid": result.validation.is_valid,
-            "issues": issues,
+            "issues": [issue_to_dict(i, verbose=verbose) for i in result.validation.issues],
         },
         "security_notes": result.security_notes,
         "template_used": result.template_used,
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"generation"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def build_minimal_policy(
     actions: list[str],
     resources: list[str],
@@ -376,57 +469,24 @@ async def build_minimal_policy(
         {policy, validation, security_notes}
     """
     from iam_validator.mcp.tools.generation import build_minimal_policy as _build
+    from iam_validator.mcp.tools.validation import issue_to_dict
 
     result = await _build(actions=actions, resources=resources, conditions=conditions)
-
-    if verbose:
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "suggestion": issue.suggestion,
-                "example": issue.example,
-                "check_id": issue.check_id,
-                "risk_explanation": issue.risk_explanation,
-                "remediation_steps": issue.remediation_steps,
-            }
-            for issue in result.validation.issues
-        ]
-    else:
-        issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "check_id": issue.check_id,
-            }
-            for issue in result.validation.issues
-        ]
 
     return {
         "policy": result.policy,
         "validation": {
             "is_valid": result.validation.is_valid,
-            "issues": issues,
+            "issues": [issue_to_dict(i, verbose=verbose) for i in result.validation.issues],
         },
         "security_notes": result.security_notes,
     }
 
 
-@mcp.tool()
-async def list_templates() -> list[dict[str, Any]]:
-    """List available policy templates and their required variables.
-
-    Call this before generate_policy_from_template.
-
-    Returns:
-        List of {name, description, variables}
-    """
-    from iam_validator.mcp.tools.generation import list_templates as _list_templates
-
-    return await _list_templates()
-
-
-@mcp.tool()
+@mcp.tool(
+    tags={"generation"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def suggest_actions(
     description: str,
     service: str | None = None,
@@ -445,7 +505,10 @@ async def suggest_actions(
     return await _suggest(description=description, service=service)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"generation"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_required_conditions(actions: list[str]) -> dict[str, Any]:
     """Get recommended IAM conditions for actions based on security best practices.
 
@@ -464,7 +527,10 @@ async def get_required_conditions(actions: list[str]) -> dict[str, Any]:
     return await _get_conditions(actions=actions)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"generation"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def check_sensitive_actions(
     actions: list[str],
     verbose: bool = False,
@@ -506,9 +572,13 @@ async def check_sensitive_actions(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def query_service_actions(
     service: str,
+    ctx: Context,
     access_level: str | None = None,
     limit: int | None = None,
     offset: int = 0,
@@ -528,7 +598,8 @@ async def query_service_actions(
     """
     from iam_validator.mcp.tools.query import query_service_actions as _query
 
-    all_actions = await _query(service=service, access_level=access_level)
+    fetcher = get_shared_fetcher(ctx)
+    all_actions = await _query(service=service, access_level=access_level, fetcher=fetcher)
     total = len(all_actions)
 
     # Apply pagination
@@ -548,8 +619,11 @@ async def query_service_actions(
     }
 
 
-@mcp.tool()
-async def query_action_details(action: str) -> dict[str, Any] | None:
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def query_action_details(action: str, ctx: Context) -> dict[str, Any] | None:
     """Get metadata for a specific action.
 
     Args:
@@ -560,7 +634,8 @@ async def query_action_details(action: str) -> dict[str, Any] | None:
     """
     from iam_validator.mcp.tools.query import query_action_details as _query
 
-    result = await _query(action=action)
+    fetcher = get_shared_fetcher(ctx)
+    result = await _query(action=action, fetcher=fetcher)
     if result is None:
         return None
     return {
@@ -573,8 +648,11 @@ async def query_action_details(action: str) -> dict[str, Any] | None:
     }
 
 
-@mcp.tool()
-async def expand_wildcard_action(pattern: str) -> list[str]:
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def expand_wildcard_action(pattern: str, ctx: Context) -> list[str]:
     """Expand wildcard action pattern to specific actions.
 
     Args:
@@ -585,11 +663,15 @@ async def expand_wildcard_action(pattern: str) -> list[str]:
     """
     from iam_validator.mcp.tools.query import expand_wildcard_action as _expand
 
-    return await _expand(pattern=pattern)
+    fetcher = get_shared_fetcher(ctx)
+    return await _expand(pattern=pattern, fetcher=fetcher)
 
 
-@mcp.tool()
-async def query_condition_keys(service: str) -> list[str]:
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def query_condition_keys(service: str, ctx: Context) -> list[str]:
     """Get resource-level condition keys for a service.
 
     Use with get_required_conditions for complete condition coverage (action + resource).
@@ -602,11 +684,15 @@ async def query_condition_keys(service: str) -> list[str]:
     """
     from iam_validator.mcp.tools.query import query_condition_keys as _query
 
-    return await _query(service=service)
+    fetcher = get_shared_fetcher(ctx)
+    return await _query(service=service, fetcher=fetcher)
 
 
-@mcp.tool()
-async def query_arn_formats(service: str) -> list[dict[str, Any]]:
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def query_arn_formats(service: str, ctx: Context) -> list[dict[str, Any]]:
     """Get ARN format patterns for a service's resources.
 
     Args:
@@ -617,22 +703,14 @@ async def query_arn_formats(service: str) -> list[dict[str, Any]]:
     """
     from iam_validator.mcp.tools.query import query_arn_formats as _query
 
-    return await _query(service=service)
+    fetcher = get_shared_fetcher(ctx)
+    return await _query(service=service, fetcher=fetcher)
 
 
-@mcp.tool()
-async def list_checks() -> list[dict[str, Any]]:
-    """List all available validation checks.
-
-    Returns:
-        List of {check_id, description, default_severity}
-    """
-    # Use cached registry instead of creating new one each call
-    # Convert tuple back to list for API compatibility
-    return list(_get_cached_checks())
-
-
-@mcp.tool()
+@mcp.tool(
+    tags={"validate"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_policy_summary(policy: dict[str, Any]) -> dict[str, Any]:
     """Get summary statistics for a policy.
 
@@ -656,47 +734,10 @@ async def get_policy_summary(policy: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
-async def list_sensitive_actions(
-    category: str | None = None,
-    limit: int | None = None,
-    offset: int = 0,
-    verbose: bool = False,
-) -> dict[str, Any]:
-    """List sensitive actions from the 490+ action catalog.
-
-    Args:
-        category: Filter by "credential_exposure", "data_access", "privilege_escalation", or "resource_exposure"
-        limit: Max actions to return
-        offset: Skip N actions for pagination
-        verbose: Return full action details (True) or names only (False)
-
-    Returns:
-        {actions, total, has_more}
-    """
-    from iam_validator.mcp.tools.query import list_sensitive_actions as _list_sensitive
-
-    all_actions = await _list_sensitive(category=category)
-    total = len(all_actions)
-
-    # Apply pagination
-    if offset:
-        all_actions = all_actions[offset:]
-    if limit:
-        all_actions = all_actions[:limit]
-
-    # Lean response: just action names if not verbose
-    if not verbose and all_actions and isinstance(all_actions[0], dict):
-        all_actions = [a.get("action", a) if isinstance(a, dict) else a for a in all_actions]
-
-    return {
-        "actions": all_actions,
-        "total": total,
-        "has_more": offset + len(all_actions) < total,
-    }
-
-
-@mcp.tool()
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_condition_requirements_for_action(action: str) -> dict[str, Any] | None:
     """Get condition requirements for a specific action.
 
@@ -716,7 +757,10 @@ async def get_condition_requirements_for_action(action: str) -> dict[str, Any] |
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"fix"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def fix_policy_issues(
     policy: dict[str, Any],
     issues_to_fix: list[str] | None = None,
@@ -758,12 +802,9 @@ async def fix_policy_issues(
 
     # Fix 1: Missing or invalid Version (structural fix)
     if should_fix("policy_structure"):
-        if "Version" not in fixed_policy or fixed_policy.get("Version") not in [
-            "2012-10-17",
-            "2008-10-17",
-        ]:
-            fixed_policy["Version"] = "2012-10-17"
-            fixes_applied.append("Added Version: 2012-10-17")
+        if "Version" not in fixed_policy or fixed_policy.get("Version") not in IAM_POLICY_VERSIONS_VALID:
+            fixed_policy["Version"] = IAM_POLICY_VERSION_CURRENT
+            fixes_applied.append(f"Added Version: {IAM_POLICY_VERSION_CURRENT}")
 
     # Fix 2: Duplicate SIDs (structural fix)
     if should_fix("sid_uniqueness") and "sid_uniqueness" in issue_check_ids:
@@ -779,33 +820,38 @@ async def fix_policy_issues(
                 else:
                     seen_sids[sid] = i
 
-    # Fix 3: Normalize action case (service prefix should be lowercase)
+    # Fix 3: Normalize action case (service prefix should be lowercase) on
+    # both Action AND NotAction. Service prefixes in IAM are always lowercase;
+    # `S3:GetObject` is invalid AWS syntax regardless of which key holds it.
     if should_fix("action_validation"):
         statements = fixed_policy.get("Statement", [])
         if isinstance(statements, dict):
             statements = [statements]
 
         for stmt in statements:
-            actions = stmt.get("Action", [])
-            was_string = isinstance(actions, str)
-            if was_string:
-                actions = [actions]
+            for action_key in ("Action", "NotAction"):
+                if action_key not in stmt:
+                    continue
+                actions = stmt[action_key]
+                was_string = isinstance(actions, str)
+                if was_string:
+                    actions = [actions]
 
-            normalized = []
-            for action in actions:
-                if ":" in action:
-                    service, name = action.split(":", 1)
-                    if service != service.lower():
-                        new_action = f"{service.lower()}:{name}"
-                        normalized.append(new_action)
-                        fixes_applied.append(f"Normalized action case: {action} → {new_action}")
+                normalized = []
+                for action in actions:
+                    if ":" in action:
+                        service, name = action.split(":", 1)
+                        if service != service.lower():
+                            new_action = f"{service.lower()}:{name}"
+                            normalized.append(new_action)
+                            fixes_applied.append(f"Normalized {action_key} case: {action} → {new_action}")
+                        else:
+                            normalized.append(action)
                     else:
                         normalized.append(action)
-                else:
-                    normalized.append(action)
 
-            if normalized:
-                stmt["Action"] = normalized[0] if (was_string and len(normalized) == 1) else normalized
+                if normalized:
+                    stmt[action_key] = normalized[0] if (was_string and len(normalized) == 1) else normalized
 
     # Collect issues that require manual intervention
     # Include the example and suggestion from the validator for guidance
@@ -827,189 +873,71 @@ async def fix_policy_issues(
             }
         )
 
+    from iam_validator.mcp.tools.validation import issue_to_dict
+
     # Re-validate the fixed policy
     final_result = await _validate(policy=fixed_policy, policy_type=effective_policy_type)
-
-    if verbose:
-        validation_issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "suggestion": issue.suggestion,
-                "example": issue.example,
-                "check_id": issue.check_id,
-            }
-            for issue in final_result.issues
-        ]
-    else:
-        validation_issues = [
-            {
-                "severity": issue.severity,
-                "message": issue.message,
-                "check_id": issue.check_id,
-            }
-            for issue in final_result.issues
-        ]
 
     return {
         "fixed_policy": fixed_policy,
         "fixes_applied": fixes_applied,
-        "unfixed_issues": unfixed_issues if verbose else len(unfixed_issues),
+        "unfixed_issues": unfixed_issues,
+        "unfixed_count": len(unfixed_issues),
         "validation": {
             "is_valid": final_result.is_valid,
             "issue_count": len(final_result.issues),
-            "issues": validation_issues,
+            "issues": [issue_to_dict(i, verbose=verbose) for i in final_result.issues],
         },
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"fix"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_issue_guidance(check_id: str) -> dict[str, Any]:
-    """Get step-by-step fix guidance for a validation issue.
+    """Get fix guidance for a validation issue (registry-driven).
 
     Args:
         check_id: Check ID (e.g., "wildcard_action", "sensitive_action")
 
     Returns:
-        {check_id, description, common_causes, fix_steps, example_before, example_after, related_tools}
+        {check_id, description, default_severity, fix_steps,
+         example_before, example_after, related}
     """
-    guidance_db: dict[str, dict[str, Any]] = {
-        "wildcard_action": {
-            "check_id": "wildcard_action",
-            "description": "Detects policies that use Action: '*' granting all permissions",
-            "common_causes": [
-                "Trying to grant broad access without knowing specific actions",
-                "Copy-pasted from an overly permissive example",
-            ],
-            "fix_steps": [
-                "1. Identify what the policy user actually needs to do",
-                "2. Use suggest_actions('describe what you need', 'service') to find actions",
-                "3. Replace '*' with the specific action list",
-                "4. Re-validate with validate_policy",
-            ],
-            "example_before": '{"Action": "*", "Resource": "*"}',
-            "example_after": '{"Action": ["s3:GetObject", "s3:ListBucket"], "Resource": "arn:aws:s3:::my-bucket/*"}',
-            "related_tools": ["suggest_actions", "query_service_actions", "list_templates"],
-        },
-        "wildcard_resource": {
-            "check_id": "wildcard_resource",
-            "description": "Detects policies that use Resource: '*' granting access to all resources",
-            "common_causes": [
-                "Not knowing the correct ARN format",
-                "Wanting the policy to work across multiple resources",
-            ],
-            "fix_steps": [
-                "1. Determine which specific resources need access",
-                "2. Use query_arn_formats('service') to get ARN patterns",
-                "3. Replace '*' with specific ARNs or ARN patterns",
-                "4. Re-validate with validate_policy",
-            ],
-            "example_before": '{"Action": ["s3:GetObject"], "Resource": "*"}',
-            "example_after": '{"Action": ["s3:GetObject"], "Resource": ["arn:aws:s3:::my-bucket/*", "arn:aws:s3:::my-bucket"]}',
-            "related_tools": ["query_arn_formats", "get_policy_summary"],
-        },
-        "action_validation": {
-            "check_id": "action_validation",
-            "description": "Detects actions that don't exist in AWS",
-            "common_causes": [
-                "Typo in action name (e.g., 'S3:GetObject' instead of 's3:GetObject')",
-                "Using deprecated action name",
-                "Wrong service prefix",
-            ],
-            "fix_steps": [
-                "1. Check the service prefix is lowercase (s3, not S3)",
-                "2. Use query_service_actions('service') to list valid actions",
-                "3. Use query_action_details('service:action') to verify action exists",
-                "4. Fix the action name and re-validate",
-            ],
-            "example_before": '{"Action": ["S3:GetObjects"]}',
-            "example_after": '{"Action": ["s3:GetObject"]}',
-            "related_tools": [
-                "query_service_actions",
-                "query_action_details",
-                "expand_wildcard_action",
-            ],
-        },
-        "sensitive_action": {
-            "check_id": "sensitive_action",
-            "description": "Detects high-risk actions that can lead to privilege escalation or data exposure",
-            "common_causes": [
-                "Granting IAM, STS, or KMS permissions without restrictions",
-                "Allowing actions that can modify security settings",
-            ],
-            "fix_steps": [
-                "1. Verify the sensitive action is truly needed",
-                "2. Use check_sensitive_actions(['action']) to understand the risk",
-                "3. Use get_required_conditions(['action']) to get recommended conditions",
-                "4. Add conditions to restrict when the action can be used",
-                "5. Re-validate with validate_policy",
-            ],
-            "example_before": '{"Action": ["iam:PassRole"], "Resource": "*"}',
-            "example_after": '{"Action": ["iam:PassRole"], "Resource": "arn:aws:iam::123456789012:role/LambdaRole", "Condition": {"StringEquals": {"iam:PassedToService": "lambda.amazonaws.com"}}}',
-            "related_tools": [
-                "check_sensitive_actions",
-                "get_required_conditions",
-                "fix_policy_issues",
-            ],
-        },
-        "action_condition_enforcement": {
-            "check_id": "action_condition_enforcement",
-            "description": "Detects sensitive actions that should have conditions but don't",
-            "common_causes": [
-                "Not aware that certain actions need conditions",
-                "Conditions were forgotten during policy creation",
-            ],
-            "fix_steps": [
-                "1. Use get_required_conditions(['action']) to see what's needed",
-                "2. Add the Condition block to the statement",
-                "3. Common conditions: MFA, SourceIp, PassedToService",
-                "4. Use fix_policy_issues to auto-add basic conditions",
-            ],
-            "example_before": '{"Action": ["iam:CreateUser"], "Resource": "*"}',
-            "example_after": '{"Action": ["iam:CreateUser"], "Resource": "*", "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}}}',
-            "related_tools": [
-                "get_required_conditions",
-                "fix_policy_issues",
-                "check_sensitive_actions",
-            ],
-        },
-        "policy_structure": {
-            "check_id": "policy_structure",
-            "description": "Detects missing or malformed policy structure",
-            "common_causes": [
-                "Missing Version field",
-                "Missing Statement array",
-                "Invalid Effect value",
-            ],
-            "fix_steps": [
-                "1. Ensure Version is '2012-10-17' (recommended)",
-                "2. Ensure Statement is an array of statement objects",
-                "3. Each statement must have Effect, Action, and Resource",
-                "4. Use fix_policy_issues to auto-fix structure issues",
-            ],
-            "example_before": '{"Statement": [{"Action": "s3:*"}]}',
-            "example_after": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "arn:aws:s3:::bucket/*"}]}',
-            "related_tools": ["fix_policy_issues", "validate_policy"],
-        },
-    }
+    from iam_validator.mcp.check_metadata import get_check_metadata
 
-    if check_id in guidance_db:
-        return guidance_db[check_id]
+    check = _REGISTRY.get_check(check_id)
+    metadata = get_check_metadata(check_id)
 
-    # Generic guidance for unknown check_id
+    if check is None and not metadata:
+        return {
+            "check_id": check_id,
+            "description": f"Unknown check: {check_id}",
+            "default_severity": None,
+            "fix_steps": [
+                "Read the iam://checks resource for the catalog of available checks.",
+            ],
+            "example_before": None,
+            "example_after": None,
+            "related": ["iam://checks", "validate_policy"],
+        }
+
     return {
         "check_id": check_id,
-        "description": f"Validation check: {check_id}",
-        "common_causes": ["Check the validation message for specific details"],
-        "fix_steps": [
-            "1. Read the issue message and suggestion from validate_policy",
-            "2. Use the example field if provided",
-            "3. Use list_checks() to get more info about available checks",
-            "4. Consult AWS IAM documentation",
-        ],
-        "example_before": "See the issue's example field",
-        "example_after": "Apply the suggestion from the issue",
-        "related_tools": ["validate_policy", "list_checks", "fix_policy_issues"],
+        "description": check.description if check else metadata.get("description", ""),
+        "default_severity": check.default_severity if check else None,
+        "fix_steps": metadata.get(
+            "fix_steps",
+            [
+                "Read the issue's `message` and `suggestion` fields from validate_policy",
+                "Apply the example fix from the issue, if provided",
+                "Re-validate with validate_policy",
+            ],
+        ),
+        "example_before": metadata.get("example_violation"),
+        "example_after": metadata.get("example_fix"),
+        "related": metadata.get("related", ["validate_policy", "fix_policy_issues"]),
     }
 
 
@@ -1018,215 +946,247 @@ async def get_issue_guidance(check_id: str) -> dict[str, Any]:
 # =============================================================================
 
 
-@mcp.tool()
 async def get_check_details(check_id: str) -> dict[str, Any]:
-    """Get full documentation for a validation check.
+    """Get full documentation for a validation check (registry-driven).
+
+    Exposed as the parameterised MCP resource ``iam://checks/{check_id}``.
 
     Args:
         check_id: Check ID (e.g., "wildcard_action", "sensitive_action")
 
     Returns:
-        {check_id, description, default_severity, category, example_violation, example_fix, configuration, related_checks}
+        {check_id, description, default_severity, category, example_violation,
+         example_fix, configuration, related}
     """
-    from iam_validator.core.check_registry import create_default_registry
+    from iam_validator.mcp.check_metadata import get_check_metadata
 
-    registry = create_default_registry()
+    check = _REGISTRY.get_check(check_id)
+    metadata = get_check_metadata(check_id)
 
-    # Check metadata database
-    check_metadata: dict[str, dict[str, Any]] = {
-        "wildcard_action": {
-            "category": "security",
-            "example_violation": {"Effect": "Allow", "Action": "*", "Resource": "*"},
-            "example_fix": {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": "arn:aws:s3:::my-bucket/*",
-            },
-            "configuration": {"enabled": True, "severity": "configurable"},
-            "related_checks": ["wildcard_resource", "full_wildcard", "service_wildcard"],
-        },
-        "wildcard_resource": {
-            "category": "security",
-            "example_violation": {
-                "Effect": "Allow",
-                "Action": ["s3:PutObject"],
-                "Resource": "*",
-            },
-            "example_fix": {
-                "Effect": "Allow",
-                "Action": ["s3:PutObject"],
-                "Resource": "arn:aws:s3:::my-bucket/*",
-            },
-            "configuration": {"enabled": True, "severity": "configurable"},
-            "related_checks": ["wildcard_action", "full_wildcard"],
-        },
-        "sensitive_action": {
-            "category": "security",
-            "example_violation": {
-                "Effect": "Allow",
-                "Action": ["iam:CreateAccessKey"],
-                "Resource": "*",
-            },
-            "example_fix": {
-                "Effect": "Allow",
-                "Action": ["iam:CreateAccessKey"],
-                "Resource": "arn:aws:iam::123456789012:user/${aws:username}",
-                "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
-            },
-            "configuration": {"enabled": True, "severity": "high"},
-            "related_checks": ["action_condition_enforcement"],
-        },
-        "action_validation": {
-            "category": "aws",
-            "example_violation": {"Effect": "Allow", "Action": ["S3:GetObjects"], "Resource": "*"},
-            "example_fix": {"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "*"},
-            "configuration": {"enabled": True},
-            "related_checks": ["policy_structure"],
-        },
-        "policy_structure": {
-            "category": "structure",
-            "example_violation": {"Statement": [{"Action": "s3:*"}]},
-            "example_fix": {
-                "Version": "2012-10-17",
-                "Statement": [{"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "*"}],
-            },
-            "configuration": {"enabled": True},
-            "related_checks": ["sid_uniqueness"],
-        },
-    }
-
-    # Get check from registry
-    if check_id in registry._checks:
-        check = registry._checks[check_id]
-        metadata = check_metadata.get(check_id, {})
-
+    if check is None:
         return {
             "check_id": check_id,
-            "description": check.description,
-            "default_severity": check.default_severity,
-            "category": metadata.get("category", "general"),
+            "description": "Check not found",
+            "default_severity": None,
+            "category": metadata.get("category", "unknown"),
             "example_violation": metadata.get("example_violation"),
             "example_fix": metadata.get("example_fix"),
-            "configuration": metadata.get("configuration", {"enabled": True}),
-            "related_checks": metadata.get("related_checks", []),
+            "configuration": {},
+            "related": metadata.get("related", []),
         }
 
     return {
         "check_id": check_id,
-        "description": "Check not found",
-        "default_severity": "unknown",
-        "category": "unknown",
-        "example_violation": None,
-        "example_fix": None,
-        "configuration": {},
-        "related_checks": [],
+        "description": check.description,
+        "default_severity": check.default_severity,
+        "category": metadata.get("category", "general"),
+        "example_violation": metadata.get("example_violation"),
+        "example_fix": metadata.get("example_fix"),
+        "configuration": {"enabled": True, "severity": check.default_severity},
+        "related": metadata.get("related", []),
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"fix"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def explain_policy(
     policy: dict[str, Any],
+    ctx: Context,
     verbose: bool = False,
 ) -> dict[str, Any]:
-    """Generate human-readable explanation of policy permissions and security concerns.
+    """Generate a human-readable explanation of policy permissions.
+
+    Access-level classification is sourced from the live AWS service reference
+    (Read / Write / List / Tagging / Permissions management) — not a name-prefix
+    heuristic. NotAction / NotResource / Principal / NotPrincipal are surfaced
+    explicitly because they invert the meaning of a statement.
 
     Args:
         policy: IAM policy dictionary
         verbose: Return all fields (True) or essential only (False)
 
     Returns:
-        {summary, statements, services_accessed, security_concerns, recommendations}
+        {summary, statements, services_accessed, security_concerns,
+         recommendations, has_wildcards, has_conditions}
     """
+    from iam_validator.checks.utils.action_parser import parse_action
     from iam_validator.mcp.tools.query import get_policy_summary as _get_summary
+    from iam_validator.sdk.query_utils import _get_access_level
 
     summary = await _get_summary(policy)
+
     statements = policy.get("Statement", [])
     if isinstance(statements, dict):
         statements = [statements]
 
-    statement_explanations = []
-    security_concerns = []
-    recommendations = []
+    fetcher = get_shared_fetcher(ctx)
+
+    # Cache fetched service definitions across statements (one fetch per service).
+    service_cache: dict[str, Any] = {}
+
+    async def _classify(action: str) -> str:
+        """Authoritative access-level for one action via the live service ref.
+
+        Returns one of: "full" (`*` or `service:*`), "wildcard-pattern"
+        (e.g. `s3:Get*`), "Read"/"Write"/"List"/"Tagging"/"permissions-management"
+        for resolved actions, or "unknown" when the lookup fails.
+        """
+        if action == "*":
+            return "full"
+        parsed = parse_action(action)
+        if parsed is None:
+            return "unknown"
+        if parsed.action_name == "*":
+            return "full"
+        if "*" in parsed.action_name:
+            return "wildcard-pattern"
+        if fetcher is None:
+            return "unknown"
+        try:
+            if parsed.service not in service_cache:
+                service_cache[parsed.service] = await fetcher.fetch_service_by_name(parsed.service)
+            service_detail = service_cache[parsed.service]
+            actions_dict = getattr(service_detail, "actions", {}) or {}
+            # Case-insensitive lookup; AWS canonical casing varies.
+            detail = actions_dict.get(parsed.action_name)
+            if detail is None:
+                for k, v in actions_dict.items():
+                    if k.lower() == parsed.action_name.lower():
+                        detail = v
+                        break
+            if detail is None:
+                return "unknown"
+            return _get_access_level(detail)
+        except Exception:
+            return "unknown"
+
+    def _as_list(v: Any) -> list[Any]:
+        if v is None:
+            return []
+        return v if isinstance(v, list) else [v]
+
+    statement_explanations: list[dict[str, Any]] = []
+    security_concerns: list[str] = []
+    recommendations: list[str] = []
     services_with_access: dict[str, set[str]] = {}
 
+    total_allow = 0
+    total_deny = 0
+
     for idx, stmt in enumerate(statements):
-        effect = stmt.get("Effect", "Allow")
-        actions = stmt.get("Action", [])
-        resources = stmt.get("Resource", [])
-        conditions = stmt.get("Condition", {})
+        effect_raw = (stmt.get("Effect") or "Allow").strip()
+        effect_lower = effect_raw.lower()
+        if effect_lower == "allow":
+            total_allow += 1
+        elif effect_lower == "deny":
+            total_deny += 1
 
-        if isinstance(actions, str):
-            actions = [actions]
-        if isinstance(resources, str):
-            resources = [resources]
+        actions = _as_list(stmt.get("Action"))
+        not_actions = _as_list(stmt.get("NotAction"))
+        resources = _as_list(stmt.get("Resource"))
+        not_resources = _as_list(stmt.get("NotResource"))
+        principal = stmt.get("Principal")
+        not_principal = stmt.get("NotPrincipal")
+        conditions = stmt.get("Condition") or {}
 
-        # Analyze actions by service
-        for action in actions:
-            if ":" in action:
-                service = action.split(":")[0]
-                action_name = action.split(":")[1]
-                if service not in services_with_access:
-                    services_with_access[service] = set()
+        action_list = actions or not_actions
+        action_negated = bool(not_actions and not actions)
 
-                if action_name == "*":
-                    services_with_access[service].add("full")
-                elif (
-                    action_name.startswith("Get")
-                    or action_name.startswith("List")
-                    or action_name.startswith("Describe")
-                ):
-                    services_with_access[service].add("read")
-                elif (
-                    action_name.startswith("Put")
-                    or action_name.startswith("Create")
-                    or action_name.startswith("Update")
-                ):
-                    services_with_access[service].add("write")
-                elif action_name.startswith("Delete") or action_name.startswith("Remove"):
-                    services_with_access[service].add("delete")
+        # Per-service access classification using the authoritative service ref.
+        for action in action_list:
+            if action == "*":
+                services_with_access.setdefault("*", set()).add("full")
+                continue
+            level = await _classify(str(action))
+            parsed = parse_action(str(action))
+            service = parsed.service if parsed else "*"
+            services_with_access.setdefault(service, set()).add(level)
+
+        # Security concerns. Allow + wildcards is the classic anti-pattern; the
+        # `Not*` keywords flip the meaning so they get their own concern lines.
+        if effect_lower == "allow":
+            if any(a == "*" for a in actions):
+                if any(r == "*" for r in resources):
+                    security_concerns.append(
+                        f"Statement {idx}: Allow Action:*, Resource:* — full administrative access."
+                    )
+                    recommendations.append(
+                        f'Statement {idx}: replace `Action: "*"` and `Resource: "*"` with explicit values.'
+                    )
                 else:
-                    services_with_access[service].add("other")
-            elif action == "*":
-                security_concerns.append(f"Statement {idx}: Full admin access with Action: '*'")
-                recommendations.append("Replace Action: '*' with specific actions")
+                    security_concerns.append(
+                        f"Statement {idx}: Allow Action:* — grants every action on the listed resources."
+                    )
+                    recommendations.append(f'Statement {idx}: replace `Action: "*"` with the explicit action list.')
+            elif any(r == "*" for r in resources):
+                security_concerns.append(f"Statement {idx}: Allow with Resource:* — scope resources to specific ARNs.")
+                recommendations.append(f'Statement {idx}: replace `Resource: "*"` with explicit ARN(s).')
 
-        # Check for wildcards
-        if "*" in resources:
-            if effect == "Allow":
-                security_concerns.append(f"Statement {idx}: Allows access to all resources")
-                recommendations.append(f"Statement {idx}: Scope resources to specific ARNs")
+            if not_actions:
+                security_concerns.append(
+                    f"Statement {idx}: Effect:Allow with NotAction is an anti-pattern — "
+                    "the Allow surface is everything *except* the listed actions."
+                )
+                recommendations.append(
+                    f"Statement {idx}: prefer an explicit `Action` allow-list. "
+                    "If you mean to deny, use `Effect:Deny` with `Action`."
+                )
+            if not_resources:
+                security_concerns.append(
+                    f"Statement {idx}: NotResource is rarely correct — implicit allow on every "
+                    "ARN except the listed ones."
+                )
 
-        # Build explanation
-        action_desc = ", ".join(actions[:3]) + ("..." if len(actions) > 3 else "")
-        resource_desc = ", ".join(resources[:2]) + ("..." if len(resources) > 2 else "")
+        # Trust-policy / resource-policy concerns.
+        if isinstance(principal, dict) and principal.get("AWS") == "*":
+            security_concerns.append(f"Statement {idx}: Principal AWS:* — allows access from any AWS account.")
+        elif principal == "*":
+            security_concerns.append(f"Statement {idx}: Principal:* — anonymous public access.")
+        if not_principal:
+            security_concerns.append(
+                f"Statement {idx}: NotPrincipal is fragile — confirm intent (negation in resource policies)."
+            )
+
+        # Per-statement explanation.
+        action_desc_field = "NotAction" if action_negated else "Action"
+        action_desc = ", ".join(map(str, action_list[:3])) + ("..." if len(action_list) > 3 else "")
+        resource_desc_field = "NotResource" if (not_resources and not resources) else "Resource"
+        resource_target = not_resources if (not_resources and not resources) else resources
+        resource_desc = ", ".join(map(str, resource_target[:2])) + ("..." if len(resource_target) > 2 else "")
         condition_desc = f" with {len(conditions)} condition(s)" if conditions else ""
 
-        explanation = f"{effect}s {action_desc} on {resource_desc}{condition_desc}"
+        explanation = (
+            f"{effect_raw}s {action_desc_field} {action_desc or '<empty>'} "
+            f"on {resource_desc_field} {resource_desc or '<empty>'}{condition_desc}"
+        )
         statement_explanations.append(
             {
                 "index": idx,
                 "sid": stmt.get("Sid", f"Statement{idx}"),
-                "effect": effect,
+                "effect": effect_raw,
+                "uses_not_action": action_negated,
+                "uses_not_resource": bool(not_resources and not resources),
                 "explanation": explanation,
-                "action_count": len(actions),
+                "action_count": len(action_list),
                 "has_conditions": bool(conditions),
+                "condition_keys": sorted(
+                    {k for op_block in conditions.values() if isinstance(op_block, dict) for k in op_block.keys()}
+                )
+                if isinstance(conditions, dict)
+                else [],
             }
         )
 
-    # Build services summary
-    services_summary = []
-    for service, access_types in services_with_access.items():
-        services_summary.append(
-            {
-                "service": service,
-                "access_types": sorted(access_types),
-            }
-        )
+    services_summary = [
+        {"service": service, "access_types": sorted(levels)} for service, levels in sorted(services_with_access.items())
+    ]
 
-    # Generate summary
-    total_allow = sum(1 for s in statements if s.get("Effect") == "Allow")
-    total_deny = len(statements) - total_allow
-    brief_summary = f"Policy with {len(statements)} statement(s): {total_allow} Allow, {total_deny} Deny across {len(services_with_access)} service(s)"
+    brief_summary = (
+        f"Policy with {len(statements)} statement(s): "
+        f"{total_allow} Allow, {total_deny} Deny across {len(services_with_access)} service(s)"
+    )
 
     if verbose:
         return {
@@ -1238,167 +1198,129 @@ async def explain_policy(
             "has_wildcards": summary.has_wildcards,
             "has_conditions": summary.has_conditions,
         }
-    else:
-        return {
-            "summary": brief_summary,
-            "security_concerns": security_concerns,
-            "recommendations": recommendations,
-            "has_wildcards": summary.has_wildcards,
-            "statement_count": len(statement_explanations),
-            "services_count": len(services_summary),
-        }
+    return {
+        "summary": brief_summary,
+        "security_concerns": security_concerns,
+        "recommendations": recommendations,
+        "has_wildcards": summary.has_wildcards,
+        "statement_count": len(statement_explanations),
+        "services_count": len(services_summary),
+    }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"fix"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def build_arn(
     service: str,
     resource_type: str,
-    resource_name: str,
+    ctx: Context,
+    placeholders: dict[str, str] | None = None,
+    resource_name: str | None = None,
     region: str = "",
     account_id: str = "",
     partition: str = "aws",
 ) -> dict[str, Any]:
-    """Build a valid ARN from components with format validation.
+    """Build an AWS ARN from the live AWS service reference.
+
+    Call query_arn_formats(service) first to discover placeholder names for the
+    target resource_type. Returns valid=False with unfilled_placeholders when
+    input is incomplete.
 
     Args:
-        service: AWS service (e.g., "s3", "lambda", "dynamodb")
-        resource_type: Resource type (e.g., "bucket", "function", "table")
-        resource_name: Name of the resource
-        region: AWS region (empty for global resources)
-        account_id: 12-digit AWS account ID (empty for S3)
-        partition: "aws", "aws-cn", or "aws-us-gov"
+        service: AWS service prefix (e.g., "s3", "lambda")
+        resource_type: Resource type (e.g., "bucket", "function") — must match
+            the live service reference exactly (case-insensitive).
+        placeholders: Map of {placeholder_name: value} for resource-specific
+            placeholders (e.g., {"BucketName": "my-bucket"}). Use either the
+            bare name or `${Name}` form.
+        resource_name: DEPRECATED. Pass `placeholders={...}` instead. Removal
+            target: v1.21.0. When set on a single-placeholder template (and
+            placeholders is empty), the value is substituted automatically.
+        region: AWS region. Required for templates that contain `${Region}`.
+        account_id: 12-digit AWS account ID. Required for templates that
+            contain `${Account}`.
+        partition: AWS partition. Supported: aws, aws-cn, aws-us-gov, aws-eusc,
+            aws-iso, aws-iso-b, aws-iso-e, aws-iso-f.
 
     Returns:
-        {arn, valid, notes}
+        {arn, valid, notes, format_template, unfilled_placeholders}
+
+    Raises:
+        ToolError: input-validation errors (bad partition, unknown resource_type).
     """
-    # ARN format patterns by service
-    arn_patterns: dict[str, dict[str, Any]] = {
-        "s3": {
-            "bucket": {
-                "format": "arn:{partition}:s3:::{resource}",
-                "needs_region": False,
-                "needs_account": False,
-            },
-            "object": {
-                "format": "arn:{partition}:s3:::{resource}",
-                "needs_region": False,
-                "needs_account": False,
-            },
-        },
-        "lambda": {
-            "function": {
-                "format": "arn:{partition}:lambda:{region}:{account}:function:{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "dynamodb": {
-            "table": {
-                "format": "arn:{partition}:dynamodb:{region}:{account}:table/{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "iam": {
-            "user": {
-                "format": "arn:{partition}:iam::{account}:user/{resource}",
-                "needs_region": False,
-                "needs_account": True,
-            },
-            "role": {
-                "format": "arn:{partition}:iam::{account}:role/{resource}",
-                "needs_region": False,
-                "needs_account": True,
-            },
-            "policy": {
-                "format": "arn:{partition}:iam::{account}:policy/{resource}",
-                "needs_region": False,
-                "needs_account": True,
-            },
-        },
-        "sqs": {
-            "queue": {
-                "format": "arn:{partition}:sqs:{region}:{account}:{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "sns": {
-            "topic": {
-                "format": "arn:{partition}:sns:{region}:{account}:{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "ec2": {
-            "instance": {
-                "format": "arn:{partition}:ec2:{region}:{account}:instance/{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-            "vpc": {
-                "format": "arn:{partition}:ec2:{region}:{account}:vpc/{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "secretsmanager": {
-            "secret": {
-                "format": "arn:{partition}:secretsmanager:{region}:{account}:secret:{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-        "kms": {
-            "key": {
-                "format": "arn:{partition}:kms:{region}:{account}:key/{resource}",
-                "needs_region": True,
-                "needs_account": True,
-            },
-        },
-    }
+    import logging as _logging
+    import re as _re
+
+    from fastmcp.exceptions import ToolError
+
+    from iam_validator.core.constants import ARN_PARTITION_REGEX
+    from iam_validator.mcp.tools.query import query_arn_formats
+
+    if not _re.fullmatch(ARN_PARTITION_REGEX, partition):
+        raise ToolError(
+            f"Unsupported partition '{partition}'. "
+            "Allowed: aws, aws-cn, aws-us-gov, aws-eusc, aws-iso, aws-iso-b, aws-iso-e, aws-iso-f."
+        )
+
+    fetcher = get_shared_fetcher(ctx)
+    arn_types = await query_arn_formats(service, fetcher=fetcher)
+
+    matched = next(
+        (t for t in arn_types if t.get("resource_type", "").lower() == resource_type.lower()),
+        None,
+    )
+    if matched is None:
+        raise ToolError(
+            f"Unknown resource_type '{resource_type}' for service '{service}'. "
+            f"Use query_arn_formats('{service}') to see available types."
+        )
+
+    formats = matched.get("arn_formats") or []
+    template = formats[0] if formats else None
+    if template is None:
+        raise ToolError(f"No ARN format published for {service}/{resource_type}.")
+
+    arn = template.replace("${Partition}", partition).replace("${Region}", region).replace("${Account}", account_id)
+
+    user_map = placeholders or {}
+    for key, value in user_map.items():
+        token = key if key.startswith("${") and key.endswith("}") else f"${{{key}}}"
+        arn = arn.replace(token, value)
+
+    remaining = _re.findall(r"\$\{[^}]+\}", arn)
+
+    if resource_name is not None:
+        _logging.getLogger(__name__).warning(
+            "build_arn(resource_name=...) is deprecated; "
+            "pass placeholders={'<Name>': value} instead. Removal target: v1.21.0."
+        )
+        if len(remaining) == 1 and not user_map:
+            arn = arn.replace(remaining[0], resource_name)
+            remaining = []
 
     notes: list[str] = []
-    valid = True
+    if not region and "${Region}" in template:
+        notes.append("Region is required for this ARN format.")
+    if not account_id and "${Account}" in template:
+        notes.append("Account ID is required for this ARN format.")
+    if remaining:
+        notes.append(f"Unfilled placeholders remain: {remaining}. Pass them via the `placeholders` dict.")
 
-    # Get pattern for service/resource type
-    service_patterns = arn_patterns.get(service.lower(), {})
-    pattern_info = service_patterns.get(resource_type.lower())
-
-    if not pattern_info:
-        # Generic fallback
-        if region and account_id:
-            arn = f"arn:{partition}:{service}:{region}:{account_id}:{resource_type}/{resource_name}"
-        elif account_id:
-            arn = f"arn:{partition}:{service}::{account_id}:{resource_type}/{resource_name}"
-        else:
-            arn = f"arn:{partition}:{service}:::{resource_type}/{resource_name}"
-        notes.append("Unknown service/resource combination. Using generic format.")
-        return {"arn": arn, "valid": True, "notes": notes}
-
-    # Validate required fields
-    if pattern_info["needs_region"] and not region:
-        notes.append(f"Region is required for {service}:{resource_type}")
-        valid = False
-        region = "{region}"
-
-    if pattern_info["needs_account"] and not account_id:
-        notes.append(f"Account ID is required for {service}:{resource_type}")
-        valid = False
-        account_id = "{account_id}"
-
-    # Build ARN from pattern
-    arn = pattern_info["format"].format(
-        partition=partition,
-        region=region,
-        account=account_id,
-        resource=resource_name,
-    )
-
-    return {"arn": arn, "valid": valid, "notes": notes}
+    return {
+        "arn": arn,
+        "valid": not remaining and "${Region}" not in arn and "${Account}" not in arn,
+        "notes": notes,
+        "format_template": template,
+        "unfilled_placeholders": remaining,
+    }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"fix"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def compare_policies(
     policy_a: dict[str, Any],
     policy_b: dict[str, Any],
@@ -1406,108 +1328,189 @@ async def compare_policies(
 ) -> dict[str, Any]:
     """Compare two IAM policies and highlight differences.
 
+    Compares actions, NotActions, resources, NotResources, principals,
+    NotPrincipals, and conditions independently. Statement-level matching uses
+    a canonical signature (effect + sorted actions + sorted resources +
+    canonical conditions) — NOT statement index — so a Sid-less rearrangement
+    doesn't produce phantom diffs.
+
     Args:
         policy_a: First policy (baseline)
         policy_b: Second policy (comparison)
         verbose: Return all fields (True) or essential only (False)
 
     Returns:
-        {summary, added_actions, removed_actions, added_resources, removed_resources, condition_changes, effect_changes}
+        ``{summary, added_actions, removed_actions, added_resources,
+        removed_resources, added_not_actions, removed_not_actions,
+        added_not_resources, removed_not_resources, added_principals,
+        removed_principals, condition_changes, statement_diff}``
     """
+    import json as _json
 
-    def extract_policy_elements(policy: dict[str, Any]) -> dict[str, Any]:
+    def _norm_list(v: Any) -> list[str]:
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [v]
+        return [str(x) for x in v]
+
+    def _norm_principal(p: Any) -> list[str]:
+        """Flatten Principal/NotPrincipal into a sorted set of "Type:Value" pairs."""
+        if p is None:
+            return []
+        if p == "*":
+            return ["*:*"]
+        if isinstance(p, dict):
+            out: list[str] = []
+            for ptype, vals in p.items():
+                vals = _norm_list(vals)
+                out.extend(f"{ptype}:{v}" for v in vals)
+            return sorted(out)
+        return [str(p)]
+
+    def _canon_condition(cond: Any) -> str:
+        """Canonical JSON for deep condition equality (sorted keys)."""
+        if not cond:
+            return ""
+        try:
+            return _json.dumps(cond, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return repr(cond)
+
+    def extract(policy: dict[str, Any]) -> dict[str, Any]:
         statements = policy.get("Statement", [])
         if isinstance(statements, dict):
             statements = [statements]
 
-        all_actions: set[str] = set()
-        all_resources: set[str] = set()
-        all_conditions: list[dict[str, Any]] = []
-        effects: dict[str, str] = {}
+        actions: set[str] = set()
+        not_actions: set[str] = set()
+        resources: set[str] = set()
+        not_resources: set[str] = set()
+        principals: set[str] = set()
+        not_principals: set[str] = set()
+        condition_keys: set[str] = set()
+        # Canonical statement signatures, used for stable per-statement diff.
+        signatures: set[tuple[str, ...]] = set()
 
-        for idx, stmt in enumerate(statements):
-            sid = stmt.get("Sid", f"stmt_{idx}")
-            effect = stmt.get("Effect", "Allow")
-            effects[sid] = effect
+        for stmt in statements:
+            effect = (stmt.get("Effect") or "Allow").strip().lower()
+            stmt_actions = sorted(_norm_list(stmt.get("Action")))
+            stmt_not_actions = sorted(_norm_list(stmt.get("NotAction")))
+            stmt_resources = sorted(_norm_list(stmt.get("Resource")))
+            stmt_not_resources = sorted(_norm_list(stmt.get("NotResource")))
+            stmt_principals = _norm_principal(stmt.get("Principal"))
+            stmt_not_principals = _norm_principal(stmt.get("NotPrincipal"))
+            stmt_cond = _canon_condition(stmt.get("Condition"))
 
-            actions = stmt.get("Action", [])
-            if isinstance(actions, str):
-                actions = [actions]
-            all_actions.update(actions)
+            actions.update(stmt_actions)
+            not_actions.update(stmt_not_actions)
+            resources.update(stmt_resources)
+            not_resources.update(stmt_not_resources)
+            principals.update(stmt_principals)
+            not_principals.update(stmt_not_principals)
 
-            resources = stmt.get("Resource", [])
-            if isinstance(resources, str):
-                resources = [resources]
-            all_resources.update(resources)
+            cond_dict = stmt.get("Condition") or {}
+            if isinstance(cond_dict, dict):
+                for op_block in cond_dict.values():
+                    if isinstance(op_block, dict):
+                        condition_keys.update(op_block.keys())
 
-            if "Condition" in stmt:
-                all_conditions.append({"sid": sid, "condition": stmt["Condition"]})
-
-        return {
-            "actions": all_actions,
-            "resources": all_resources,
-            "conditions": all_conditions,
-            "effects": effects,
-        }
-
-    elements_a = extract_policy_elements(policy_a)
-    elements_b = extract_policy_elements(policy_b)
-
-    added_actions = sorted(elements_b["actions"] - elements_a["actions"])
-    removed_actions = sorted(elements_a["actions"] - elements_b["actions"])
-    added_resources = sorted(elements_b["resources"] - elements_a["resources"])
-    removed_resources = sorted(elements_a["resources"] - elements_b["resources"])
-
-    # Compare effects for matching SIDs
-    effect_changes = []
-    common_sids = set(elements_a["effects"].keys()) & set(elements_b["effects"].keys())
-    for sid in common_sids:
-        if elements_a["effects"][sid] != elements_b["effects"][sid]:
-            effect_changes.append(
-                {
-                    "sid": sid,
-                    "policy_a": elements_a["effects"][sid],
-                    "policy_b": elements_b["effects"][sid],
-                }
+            signatures.add(
+                (
+                    effect,
+                    "/".join(stmt_actions),
+                    "/".join(stmt_not_actions),
+                    "/".join(stmt_resources),
+                    "/".join(stmt_not_resources),
+                    "/".join(stmt_principals),
+                    "/".join(stmt_not_principals),
+                    stmt_cond,
+                )
             )
 
-    # Summarize
-    changes = []
-    if added_actions:
-        changes.append(f"{len(added_actions)} action(s) added")
-    if removed_actions:
-        changes.append(f"{len(removed_actions)} action(s) removed")
-    if added_resources:
-        changes.append(f"{len(added_resources)} resource(s) added")
-    if removed_resources:
-        changes.append(f"{len(removed_resources)} resource(s) removed")
-    if effect_changes:
-        changes.append(f"{len(effect_changes)} effect change(s)")
+        return {
+            "actions": actions,
+            "not_actions": not_actions,
+            "resources": resources,
+            "not_resources": not_resources,
+            "principals": principals,
+            "not_principals": not_principals,
+            "condition_keys": condition_keys,
+            "signatures": signatures,
+        }
 
-    summary = ", ".join(changes) if changes else "No significant differences found"
+    a = extract(policy_a)
+    b = extract(policy_b)
 
+    added_actions = sorted(b["actions"] - a["actions"])
+    removed_actions = sorted(a["actions"] - b["actions"])
+    added_not_actions = sorted(b["not_actions"] - a["not_actions"])
+    removed_not_actions = sorted(a["not_actions"] - b["not_actions"])
+    added_resources = sorted(b["resources"] - a["resources"])
+    removed_resources = sorted(a["resources"] - b["resources"])
+    added_not_resources = sorted(b["not_resources"] - a["not_resources"])
+    removed_not_resources = sorted(a["not_resources"] - b["not_resources"])
+    added_principals = sorted(b["principals"] - a["principals"])
+    removed_principals = sorted(a["principals"] - b["principals"])
+    added_not_principals = sorted(b["not_principals"] - a["not_principals"])
+    removed_not_principals = sorted(a["not_principals"] - b["not_principals"])
+    added_condition_keys = sorted(b["condition_keys"] - a["condition_keys"])
+    removed_condition_keys = sorted(a["condition_keys"] - b["condition_keys"])
+
+    statements_added = len(b["signatures"] - a["signatures"])
+    statements_removed = len(a["signatures"] - b["signatures"])
+
+    parts: list[str] = []
+    if added_actions or removed_actions:
+        parts.append(f"{len(added_actions)} action(s) added, {len(removed_actions)} removed")
+    if added_not_actions or removed_not_actions:
+        parts.append(f"NotAction: +{len(added_not_actions)}/-{len(removed_not_actions)}")
+    if added_resources or removed_resources:
+        parts.append(f"{len(added_resources)} resource(s) added, {len(removed_resources)} removed")
+    if added_not_resources or removed_not_resources:
+        parts.append(f"NotResource: +{len(added_not_resources)}/-{len(removed_not_resources)}")
+    if added_principals or removed_principals:
+        parts.append(f"Principal: +{len(added_principals)}/-{len(removed_principals)}")
+    if added_condition_keys or removed_condition_keys:
+        parts.append(f"condition keys: +{len(added_condition_keys)}/-{len(removed_condition_keys)}")
+    if statements_added or statements_removed:
+        parts.append(f"statements: +{statements_added}/-{statements_removed}")
+
+    summary = "; ".join(parts) if parts else "No significant differences found"
+
+    full = {
+        "summary": summary,
+        "added_actions": added_actions,
+        "removed_actions": removed_actions,
+        "added_not_actions": added_not_actions,
+        "removed_not_actions": removed_not_actions,
+        "added_resources": added_resources,
+        "removed_resources": removed_resources,
+        "added_not_resources": added_not_resources,
+        "removed_not_resources": removed_not_resources,
+        "added_principals": added_principals,
+        "removed_principals": removed_principals,
+        "added_not_principals": added_not_principals,
+        "removed_not_principals": removed_not_principals,
+        "added_condition_keys": added_condition_keys,
+        "removed_condition_keys": removed_condition_keys,
+        "statements_added": statements_added,
+        "statements_removed": statements_removed,
+    }
     if verbose:
-        return {
-            "summary": summary,
-            "added_actions": added_actions,
-            "removed_actions": removed_actions,
-            "added_resources": added_resources,
-            "removed_resources": removed_resources,
-            "condition_changes": {
-                "policy_a_conditions": len(elements_a["conditions"]),
-                "policy_b_conditions": len(elements_b["conditions"]),
-            },
-            "effect_changes": effect_changes,
-        }
-    else:
-        return {
-            "summary": summary,
-            "added_actions_count": len(added_actions),
-            "removed_actions_count": len(removed_actions),
-            "added_resources_count": len(added_resources),
-            "removed_resources_count": len(removed_resources),
-            "effect_changes_count": len(effect_changes),
-        }
+        return full
+    # Lean: counts only, but always include `summary` and the headline added/removed lists.
+    return {
+        "summary": summary,
+        "added_actions_count": len(added_actions),
+        "removed_actions_count": len(removed_actions),
+        "added_resources_count": len(added_resources),
+        "removed_resources_count": len(removed_resources),
+        "added_principals_count": len(added_principals),
+        "removed_principals_count": len(removed_principals),
+        "statements_added": statements_added,
+        "statements_removed": statements_removed,
+    }
 
 
 # =============================================================================
@@ -1515,12 +1518,16 @@ async def compare_policies(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"validate"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def validate_policies_batch(
     policies: list[dict[str, Any]],
     ctx: Context,
     policy_type: str | None = None,
     verbose: bool = False,
+    max_concurrency: int = 10,
 ) -> list[dict[str, Any]]:
     """Validate multiple IAM policies in parallel (more efficient than multiple validate_policy calls).
 
@@ -1528,57 +1535,40 @@ async def validate_policies_batch(
         policies: List of IAM policy dictionaries
         policy_type: "identity", "resource", or "trust" (auto-detected if None)
         verbose: Return all fields (True) or essential only (False)
+        max_concurrency: Maximum concurrent validations (default 10) — caps the
+            thundering herd against AWS-side rate limits when N is large.
 
     Returns:
         List of {policy_index, is_valid, issues}
     """
     import asyncio
 
+    from iam_validator.mcp.tools.validation import issue_to_dict
     from iam_validator.mcp.tools.validation import validate_policy as _validate
 
     # Ensure shared fetcher is available (validates actions exist)
     _ = get_shared_fetcher(ctx)
 
+    sem = asyncio.Semaphore(max(1, max_concurrency))
+
     async def validate_one(idx: int, policy: dict[str, Any]) -> dict[str, Any]:
-        result = await _validate(policy=policy, policy_type=policy_type)
-
-        if verbose:
-            issues = [
-                {
-                    "severity": issue.severity,
-                    "message": issue.message,
-                    "suggestion": issue.suggestion,
-                    "example": issue.example,
-                    "check_id": issue.check_id,
-                    "statement_index": issue.statement_index,
-                    "action": getattr(issue, "action", None),
-                    "resource": getattr(issue, "resource", None),
-                    "field_name": getattr(issue, "field_name", None),
-                }
-                for issue in result.issues
-            ]
-        else:
-            issues = [
-                {
-                    "severity": issue.severity,
-                    "message": issue.message,
-                    "check_id": issue.check_id,
-                }
-                for issue in result.issues
-            ]
-
+        async with sem:
+            result = await _validate(policy=policy, policy_type=policy_type)
         return {
             "policy_index": idx,
             "is_valid": result.is_valid,
-            "issues": issues,
+            "issues": [issue_to_dict(i, verbose=verbose) for i in result.issues],
         }
 
-    # Run all validations in parallel
+    # Run all validations in parallel (capped by max_concurrency)
     results = await asyncio.gather(*[validate_one(i, p) for i, p in enumerate(policies)])
     return list(results)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def query_actions_batch(actions: list[str], ctx: Context) -> dict[str, dict[str, Any] | None]:
     """Get details for multiple actions in parallel (more efficient than multiple query_action_details calls).
 
@@ -1619,7 +1609,10 @@ async def query_actions_batch(actions: list[str], ctx: Context) -> dict[str, dic
     return dict(query_results)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"query"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def check_actions_batch(
     actions: list[str],
     ctx: Context,
@@ -1727,7 +1720,15 @@ async def check_actions_batch(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig", "mutating"},
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 async def set_organization_config(
     config: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1745,7 +1746,10 @@ async def set_organization_config(
     return await set_organization_config_impl(config)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_organization_config() -> dict[str, Any]:
     """Get the current session organization configuration.
 
@@ -1757,7 +1761,15 @@ async def get_organization_config() -> dict[str, Any]:
     return await get_organization_config_impl()
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig", "mutating"},
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 async def clear_organization_config() -> dict[str, str]:
     """Clear session organization config, reverting to defaults.
 
@@ -1769,7 +1781,15 @@ async def clear_organization_config() -> dict[str, str]:
     return await clear_organization_config_impl()
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig", "mutating"},
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 async def load_organization_config_from_yaml(
     yaml_content: str,
 ) -> dict[str, Any]:
@@ -1788,7 +1808,10 @@ async def load_organization_config_from_yaml(
     return await load_organization_config_from_yaml_impl(yaml_content)
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def check_org_compliance(
     policy: dict[str, Any],
     verbose: bool = False,
@@ -1817,7 +1840,10 @@ async def check_org_compliance(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def validate_with_config(
     policy: dict[str, Any],
     config: dict[str, Any],
@@ -1843,7 +1869,15 @@ async def validate_with_config(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig", "mutating"},
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 async def set_custom_instructions(
     instructions: str,
 ) -> dict[str, Any]:
@@ -1875,7 +1909,10 @@ async def set_custom_instructions(
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig"},
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
 async def get_custom_instructions() -> dict[str, Any]:
     """Get current custom instructions.
 
@@ -1893,7 +1930,15 @@ async def get_custom_instructions() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    tags={"orgconfig", "mutating"},
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
 async def clear_custom_instructions() -> dict[str, str]:
     """Clear custom instructions, reverting to defaults.
 
@@ -1967,6 +2012,32 @@ async def sensitive_categories_resource() -> str:
     }
 
     return json.dumps(serializable, indent=2)
+
+
+@mcp.resource("iam://sensitive-actions/{category}")
+async def sensitive_actions_resource(category: str) -> str:
+    """List sensitive actions for a category (parameterized resource).
+
+    Replaces the former ``list_sensitive_actions`` tool. Categories:
+    credential_exposure, data_access, privilege_escalation, resource_exposure.
+    """
+    import json
+
+    from iam_validator.mcp.tools.query import list_sensitive_actions as _list_sensitive
+
+    actions = await _list_sensitive(category=category)
+    return json.dumps({"category": category, "actions": actions}, indent=2)
+
+
+@mcp.resource("iam://checks/{check_id}")
+async def check_details_resource(check_id: str) -> str:
+    """Per-check documentation (parameterized resource).
+
+    Replaces the former ``get_check_details`` tool.
+    """
+    import json
+
+    return json.dumps(await get_check_details(check_id), indent=2)
 
 
 @mcp.resource("iam://config-schema")

--- a/iam_validator/mcp/session_config.py
+++ b/iam_validator/mcp/session_config.py
@@ -42,7 +42,42 @@ class SessionConfigManager:
 
     _session_config: ValidatorConfig | None = None
     _config_source: str = "none"
+    _custom_checks_dir: str | None = None
+    _aws_services_dir: str | None = None
     _lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def set_paths(
+        cls,
+        custom_checks_dir: str | None = None,
+        aws_services_dir: str | None = None,
+    ) -> None:
+        """Store CLI-supplied paths (custom checks dir, offline AWS services dir).
+
+        Args:
+            custom_checks_dir: Directory of Python modules with custom PolicyCheck
+                subclasses to auto-discover (CLI parity with --custom-checks-dir).
+            aws_services_dir: Directory of pre-downloaded AWS service definitions
+                for offline mode (CLI parity with --aws-services-dir).
+        """
+        with cls._lock:
+            if custom_checks_dir is not None:
+                cls._custom_checks_dir = custom_checks_dir
+            if aws_services_dir is not None:
+                cls._aws_services_dir = aws_services_dir
+
+    @classmethod
+    def get_paths(cls) -> tuple[str | None, str | None]:
+        """Return (custom_checks_dir, aws_services_dir) snapshot."""
+        with cls._lock:
+            return cls._custom_checks_dir, cls._aws_services_dir
+
+    @classmethod
+    def clear_paths(cls) -> None:
+        """Clear both CLI-supplied paths (used by tests for isolation)."""
+        with cls._lock:
+            cls._custom_checks_dir = None
+            cls._aws_services_dir = None
 
     @classmethod
     def set_config(cls, config_dict: dict[str, Any], source: str = "session") -> ValidatorConfig:

--- a/iam_validator/mcp/tools/analyze.py
+++ b/iam_validator/mcp/tools/analyze.py
@@ -1,0 +1,92 @@
+"""AWS Access Analyzer integration for MCP.
+
+Wraps the existing sync :class:`AccessAnalyzerValidator` in
+``asyncio.to_thread`` so an MCP async tool can call it without blocking the
+event loop. The MCP wrapper in ``server.py`` passes a cached
+:class:`boto3.Session` to avoid re-creating sessions per call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+from fastmcp.exceptions import ToolError
+
+if TYPE_CHECKING:
+    import boto3
+
+
+async def analyze_policy(
+    policy: dict[str, Any],
+    policy_type: str = "IDENTITY_POLICY",
+    region: str = "us-east-1",
+    profile: str | None = None,
+    session: boto3.Session | None = None,
+) -> dict[str, Any]:
+    """Run AWS Access Analyzer ValidatePolicy on a policy dict.
+
+    Args:
+        policy: Policy as a dict (Version + Statement).
+        policy_type: One of "IDENTITY_POLICY", "RESOURCE_POLICY",
+            "SERVICE_CONTROL_POLICY". RESOURCE_CONTROL_POLICY and TRUST_POLICY
+            are not currently exposed by the underlying enum.
+        region: AWS region for the Access Analyzer API call. Ignored for
+            session/client construction when ``session`` is provided; only
+            recorded on the validator for logging.
+        profile: Optional AWS profile name. Same: ignored when ``session`` is
+            provided.
+        session: Pre-built boto3.Session. When supplied, the boto3 client is
+            created from this session and ``region``/``profile`` are NOT used
+            to construct the session (they're still passed through to the
+            validator's ``self.region`` / ``self.profile`` for log lines).
+
+    Returns:
+        ``{findings, finding_count}``. Each finding has finding_type, issue_code,
+        message, learn_more_link, locations.
+
+    Raises:
+        ToolError: AWS credentials missing, bad policy_type, or API failure.
+    """
+    from iam_validator.core.access_analyzer import AccessAnalyzerValidator, PolicyType
+
+    try:
+        pt = PolicyType(policy_type)
+    except ValueError as e:
+        raise ToolError(
+            f"Invalid policy_type '{policy_type}'. Allowed: IDENTITY_POLICY, RESOURCE_POLICY, SERVICE_CONTROL_POLICY."
+        ) from e
+
+    try:
+        if session is not None:
+            validator = AccessAnalyzerValidator(region=region, policy_type=pt, session=session)
+        else:
+            validator = AccessAnalyzerValidator(region=region, policy_type=pt, profile=profile)
+        findings = await asyncio.to_thread(validator.validate_policy, policy)
+    except NoCredentialsError as e:
+        raise ToolError(
+            f"AWS credentials required. Configure AWS_PROFILE/env vars or pass profile=. Detail: {e}"
+        ) from e
+    except ClientError as e:
+        err = e.response.get("Error", {})
+        raise ToolError(f"AWS API error {err.get('Code', '?')}: {err.get('Message', str(e))}") from e
+    except BotoCoreError as e:
+        raise ToolError(f"AWS SDK error: {e}") from e
+
+    return {
+        "findings": [
+            {
+                "finding_type": (f.finding_type.value if hasattr(f.finding_type, "value") else str(f.finding_type)),
+                "issue_code": f.issue_code,
+                "message": f.message,
+                "learn_more_link": f.learn_more_link,
+                "locations": f.locations,
+            }
+            for f in findings
+        ],
+        "finding_count": len(findings),
+    }
+
+
+__all__ = ["analyze_policy"]

--- a/iam_validator/mcp/tools/validation.py
+++ b/iam_validator/mcp/tools/validation.py
@@ -15,12 +15,41 @@ from typing import Any
 
 import yaml
 
-from iam_validator.core.models import IAMPolicy
+from iam_validator.core.models import IAMPolicy, ValidationIssue
 from iam_validator.core.policy_checks import validate_policies
 from iam_validator.mcp.models import ValidationResult
 
 # Track temp files for cleanup on exit (safety net for abnormal termination)
 _temp_files_to_cleanup: set[Path] = set()
+
+
+def issue_to_dict(issue: ValidationIssue, *, verbose: bool = False) -> dict[str, Any]:
+    """Map a ``ValidationIssue`` to the JSON shape MCP tools return.
+
+    Single source of truth for the verbose-vs-lean projection so every
+    validation/generation tool reports identical fields.
+    """
+    if not verbose:
+        return {
+            "severity": issue.severity,
+            "message": issue.message,
+            "suggestion": issue.suggestion,
+            "check_id": issue.check_id,
+        }
+    return {
+        "severity": issue.severity,
+        "message": issue.message,
+        "suggestion": issue.suggestion,
+        "example": issue.example,
+        "check_id": issue.check_id,
+        "statement_index": issue.statement_index,
+        "action": getattr(issue, "action", None),
+        "resource": getattr(issue, "resource", None),
+        "field_name": getattr(issue, "field_name", None),
+        "risk_explanation": issue.risk_explanation,
+        "documentation_url": issue.documentation_url,
+        "remediation_steps": issue.remediation_steps,
+    }
 
 
 def _cleanup_temp_files() -> None:
@@ -183,8 +212,21 @@ async def validate_policy(
     # Normalize the policy type
     normalized_type = policy_type_mapping.get(effective_policy_type.lower(), "IDENTITY_POLICY")
 
-    # Parse the dict into an IAMPolicy model
-    iam_policy = IAMPolicy(**policy)
+    # Parse the dict into an IAMPolicy model. Surface schema errors as a clean
+    # ToolError instead of letting Pydantic's ValidationError stacktrace leak
+    # through the MCP protocol.
+    from fastmcp.exceptions import ToolError
+    from pydantic import ValidationError as _PydanticValidationError
+
+    try:
+        iam_policy = IAMPolicy(**policy)
+    except _PydanticValidationError as e:
+        raise ToolError(
+            f"Malformed IAM policy: {e.error_count()} validation error(s). "
+            "First error: " + (e.errors()[0].get("msg", "unknown") if e.errors() else "unknown")
+        ) from e
+    except (TypeError, ValueError) as e:
+        raise ToolError(f"Malformed IAM policy: {e}") from e
 
     # Determine config path and session_config to use
     session_config = None
@@ -193,6 +235,12 @@ async def validate_policy(
         from iam_validator.mcp.session_config import SessionConfigManager
 
         session_config = SessionConfigManager.get_config()
+
+    # Pull CLI-supplied paths (--custom-checks-dir / --aws-services-dir) so the
+    # MCP tool reaches feature parity with the CLI's `iam-validator validate`.
+    from iam_validator.mcp.session_config import SessionConfigManager
+
+    custom_dir, services_dir = SessionConfigManager.get_paths()
 
     # Use context manager for temp file to ensure cleanup
     with _temp_config_file(session_config) as temp_path:
@@ -204,6 +252,8 @@ async def validate_policy(
             policies=[("inline-policy", iam_policy)],
             config_path=effective_config_path,
             policy_type=normalized_type,  # type: ignore
+            custom_checks_dir=custom_dir,
+            aws_services_dir=services_dir,
         )
 
     # Get the first (and only) result
@@ -334,8 +384,15 @@ async def quick_validate(policy: dict[str, Any]) -> dict[str, Any]:
         if issue.check_id == "sensitive_action":
             sensitive_actions_count += 1
 
-        # Detect wildcard issues
-        if issue.check_id in {"wildcard_action", "wildcard_resource", "service_wildcard"}:
+        # Detect wildcard issues — keep this set in lockstep with the wildcard
+        # checks registered in core/check_registry.py. Missing one here causes
+        # `wildcards_detected` to silently lie (1.20.0 fix: include full_wildcard).
+        if issue.check_id in {
+            "wildcard_action",
+            "wildcard_resource",
+            "service_wildcard",
+            "full_wildcard",
+        }:
             wildcards_detected = True
 
     # Return simplified result with enhanced fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,63 +6,63 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "boogy", email = "0xboogy@gmail.com" }]
 license = { text = "MIT" }
-keywords = ["aws", "iam", "policy", "security", "validation", "github-action"]
+keywords = ["aws", "github-action", "iam", "policy", "security", "validation"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Topic :: Security",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: System :: Systems Administration",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Security",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "httpx[http2]>=0.27.0",
-    "pydantic>=2.0.0",
-    "pyyaml>=6.0",
-    "rich>=13.0.0",
-    "boto3>=1.28.0",
-    "botocore>=1.40.55",
+  "boto3>=1.28.0",
+  "botocore>=1.40.55",
+  "httpx[http2]>=0.27.0",
+  "pydantic>=2.0.0",
+  "pyyaml>=6.0",
+  "rich>=13.0.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/boogy/iam-policy-validator"
-Documentation = "https://boogy.github.io/iam-policy-validator"
-Repository = "https://github.com/boogy/iam-policy-validator"
-Issues = "https://github.com/boogy/iam-policy-validator/issues"
 Changelog = "https://github.com/boogy/iam-policy-validator/blob/main/CHANGELOG.md"
+Documentation = "https://boogy.github.io/iam-policy-validator"
+Homepage = "https://github.com/boogy/iam-policy-validator"
+Issues = "https://github.com/boogy/iam-policy-validator/issues"
+Repository = "https://github.com/boogy/iam-policy-validator"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=7.0.0",
-    "pytest-benchmark>=4.0.0",
-    "mypy>=1.0.0",
-    "ruff>=0.1.0",
-    "types-pyyaml",
-    "types-boto3",
+  "pytest>=7.0.0",
+  "pytest-asyncio>=0.21.0",
+  "pytest-cov>=7.0.0",
+  "pytest-benchmark>=4.0.0",
+  "mypy>=1.0.0",
+  "ruff>=0.1.0",
+  "types-pyyaml",
+  "types-boto3",
 ]
 docs = [
-    "mkdocs>=1.6.0",
-    "mkdocs-material>=9.5.0",
-    "mkdocstrings[python]>=0.24.0",
-    "mkdocs-gen-files>=0.5.0",
-    "mkdocs-literate-nav>=0.6.0",
+  "mkdocs>=1.6.0",
+  "mkdocs-material>=9.5.0",
+  "mkdocstrings[python]>=0.24.0",
+  "mkdocs-gen-files>=0.5.0",
+  "mkdocs-literate-nav>=0.6.0",
 ]
 mcp = [
-    "fastmcp>=2.14.1",
+  "fastmcp>=3.2,<4",
 ]
 
 [project.scripts]
-iam-validator = "iam_validator.core.cli:main"
 iam-policy-validator = "iam_validator.core.cli:main"  # Alias matching package name
+iam-validator = "iam_validator.core.cli:main"
 iam-validator-mcp = "iam_validator.mcp:run_server"
 
 [build-system]
@@ -101,14 +101,14 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
-    "-v",
-    "--strict-markers",
-    "--tb=short",
-    "-p no:benchmark",
+  "-v",
+  "--strict-markers",
+  "--tb=short",
+  "-p no:benchmark",
 ]
 markers = [
-    "benchmark: marks tests as benchmarks (deselect with '-m \"not benchmark\"')",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
+  "benchmark: marks tests as benchmarks (deselect with '-m \"not benchmark\"')",
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "integration: marks tests as integration tests",
 ]
 asyncio_mode = "auto"

--- a/tests/checks/test_full_wildcard_check.py
+++ b/tests/checks/test_full_wildcard_check.py
@@ -69,3 +69,45 @@ class TestFullWildcardCheck:
         issues = await check.execute(statement, 0, fetcher, config)
         assert len(issues) == 1
         assert issues[0].severity == "critical"
+
+
+class TestFullWildcardCheckSupersedes:
+    """Tests for FullWildcardCheck.supersedes and matches()."""
+
+    def test_supersedes_contains_expected_ids(self):
+        check = FullWildcardCheck()
+        expected = {
+            "wildcard_action",
+            "wildcard_resource",
+            "service_wildcard",
+            "action_resource_matching",
+            "sensitive_action",
+            "action_condition_enforcement",
+            "mfa_condition_antipattern",
+        }
+        assert check.supersedes == expected
+
+    def test_matches_bare_allow_star_star(self):
+        check = FullWildcardCheck()
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        assert check.matches(statement) is True
+
+    def test_matches_true_for_condition(self):
+        check = FullWildcardCheck()
+        statement = Statement(
+            Effect="Allow",
+            Action="*",
+            Resource="*",
+            Condition={"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+        )
+        assert check.matches(statement) is True
+
+    def test_matches_false_for_deny(self):
+        check = FullWildcardCheck()
+        statement = Statement(Effect="Deny", Action="*", Resource="*")
+        assert check.matches(statement) is False
+
+    def test_matches_false_for_not_action(self):
+        check = FullWildcardCheck()
+        statement = Statement(Effect="Allow", NotAction="*", Resource="*")
+        assert check.matches(statement) is False

--- a/tests/core/test_full_wildcard_suppression.py
+++ b/tests/core/test_full_wildcard_suppression.py
@@ -1,0 +1,348 @@
+"""Integration tests for full-wildcard suppression (suppress_superseded_findings)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from iam_validator.checks.full_wildcard import FullWildcardCheck
+from iam_validator.core.check_registry import CheckConfig, CheckRegistry, PolicyCheck
+from iam_validator.core.models import Statement, ValidationIssue
+
+
+def _make_mock_fetcher():
+    fetcher = MagicMock()
+    fetcher.validate_action = AsyncMock(return_value=(True, None, False))
+    fetcher.expand_wildcard_action = AsyncMock(return_value=["s3:GetObject"])
+    fetcher.fetch_service_by_name = AsyncMock(return_value=None)
+    return fetcher
+
+
+def _make_registry(suppress: bool = False) -> CheckRegistry:
+    return CheckRegistry(suppress_superseded=suppress)
+
+
+def _make_issue_check_class(check_id: str, severity: str = "medium") -> type:
+    """Dynamically create a concrete PolicyCheck subclass that always emits one issue."""
+
+    async def _execute(self, statement, statement_idx, fetcher, config):
+        return [
+            ValidationIssue(
+                severity=self.get_severity(config),
+                statement_index=statement_idx,
+                issue_type=f"test_{check_id}",
+                message=f"Issue from {check_id}",
+            )
+        ]
+
+    # Build the class with execute defined in the class body to satisfy __init_subclass__
+    cls = type(
+        f"_Mock_{check_id}",
+        (PolicyCheck,),
+        {
+            "check_id": check_id,
+            "description": f"Mock {check_id}",
+            "default_severity": severity,
+            "execute": _execute,
+        },
+    )
+    return cls
+
+
+def _add_issue_check(registry: CheckRegistry, check_id: str, severity: str = "medium") -> None:
+    """Register a mock check that always emits one issue."""
+    cls = _make_issue_check_class(check_id, severity)
+    registry.register(cls())
+    registry.configure_check(check_id, CheckConfig(check_id=check_id, enabled=True))
+
+
+class TestSuppressSupersededDefault:
+    """With suppress_superseded=False (default), all checks run normally."""
+
+    async def test_all_checks_run_on_full_wildcard(self):
+        registry = _make_registry(suppress=False)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+        _add_issue_check(registry, "wildcard_resource")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "full_wildcard" in check_ids
+        assert "wildcard_action" in check_ids
+        assert "wildcard_resource" in check_ids
+
+
+class TestSuppressSupersededEnabled:
+    """With suppress_superseded=True, redundant checks are suppressed for */* statements."""
+
+    async def test_superseded_checks_suppressed_for_full_wildcard(self):
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+        _add_issue_check(registry, "wildcard_resource")
+        _add_issue_check(registry, "sensitive_action")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "full_wildcard" in check_ids
+        assert "wildcard_action" not in check_ids
+        assert "wildcard_resource" not in check_ids
+        assert "sensitive_action" not in check_ids
+
+    async def test_suppression_note_added_to_full_wildcard_issue(self):
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        fw_issues = [i for i in issues if i.check_id == "full_wildcard"]
+        assert len(fw_issues) == 1
+        assert "checks suppressed" in fw_issues[0].message
+
+    async def test_sibling_statement_gets_full_checks(self):
+        """Non-wildcard sibling statements should still receive all checks."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        # Sibling: specific action, resource wildcard — NOT a full */* statement
+        statement = Statement(Effect="Allow", Action=["s3:GetObject"], Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "wildcard_action" in check_ids
+
+    async def test_condition_present_still_suppresses(self):
+        """Allow */* with conditions still triggers suppression — conditions don't change the root cause."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        statement = Statement(
+            Effect="Allow",
+            Action="*",
+            Resource="*",
+            Condition={"StringEquals": {"aws:ResourceTag/owner": "${aws:PrincipalTag/owner}"}},
+        )
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "full_wildcard" in check_ids
+        assert "wildcard_action" not in check_ids
+
+    async def test_full_wildcard_disabled_no_suppression(self):
+        """When full_wildcard is disabled, no suppression occurs."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=False))
+        _add_issue_check(registry, "wildcard_action")
+        _add_issue_check(registry, "wildcard_resource")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        # full_wildcard disabled so no suppression; other checks run
+        assert "wildcard_action" in check_ids
+        assert "wildcard_resource" in check_ids
+
+    async def test_deny_statement_no_suppression(self):
+        """Deny */* does NOT trigger suppression."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        statement = Statement(Effect="Deny", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        # No full_wildcard issue (Deny), so no suppression; wildcard_action runs
+        assert "wildcard_action" in check_ids
+
+    async def test_duplicate_wildcard_list_suppressed(self):
+        """Allow ["*","*"] Resource ["*","*"] still triggers suppression."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        statement = Statement(Effect="Allow", Action=["*", "*"], Resource=["*", "*"])
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "full_wildcard" in check_ids
+        assert "wildcard_action" not in check_ids
+
+    async def test_not_action_no_suppression(self):
+        """NotAction:* does NOT trigger suppression."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+
+        statement = Statement(Effect="Allow", NotAction="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "wildcard_action" in check_ids
+
+    async def test_custom_check_not_in_supersedes_is_suppressed(self):
+        """Custom checks not in supersedes are also suppressed for */* statements."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "my_custom_abac_check")
+        _add_issue_check(registry, "another_custom_check")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        check_ids = {i.check_id for i in issues}
+        assert "full_wildcard" in check_ids
+        assert "my_custom_abac_check" not in check_ids
+        assert "another_custom_check" not in check_ids
+
+    async def test_suppression_note_lists_all_suppressed_ids(self):
+        """Suppression note lists all suppressed IDs including custom checks."""
+        registry = _make_registry(suppress=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+        _add_issue_check(registry, "wildcard_action")
+        _add_issue_check(registry, "my_custom_check")
+
+        statement = Statement(Effect="Allow", Action="*", Resource="*")
+        fetcher = _make_mock_fetcher()
+        issues = await registry.execute_checks_parallel(statement, 0, fetcher)
+
+        fw_issues = [i for i in issues if i.check_id == "full_wildcard"]
+        assert len(fw_issues) == 1
+        note = fw_issues[0].message
+        assert "wildcard_action" in note
+        assert "my_custom_check" in note
+
+
+class TestPolicyLevelSuppression:
+    """Policy-level findings for suppressed statement indices are filtered out."""
+
+    async def test_policy_level_findings_suppressed_for_full_wildcard_statement(self):
+        """Policy-level findings referencing a */* statement index are dropped."""
+
+        from iam_validator.core.models import IAMPolicy
+
+        # Build a minimal registry with full_wildcard enabled + a mock policy-level check
+        registry = CheckRegistry(suppress_superseded=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+
+        # Add a mock policy-level check that emits a finding for statement index 0
+        async def _execute_policy(self_inner, policy, policy_file, fetcher, config, **kwargs):
+            return [
+                ValidationIssue(
+                    severity="high",
+                    statement_index=0,
+                    issue_type="test_policy_level",
+                    message="Policy-level issue for stmt 0",
+                )
+            ]
+
+        cls = type(
+            "_MockPolicyLevelCheck",
+            (PolicyCheck,),
+            {
+                "check_id": "mock_policy_level",
+                "description": "Mock policy-level check",
+                "default_severity": "high",
+                "execute_policy": _execute_policy,
+            },
+        )
+        registry.register(cls())
+        registry.configure_check("mock_policy_level", CheckConfig(check_id="mock_policy_level", enabled=True))
+
+        policy = IAMPolicy(Statement=[{"Effect": "Allow", "Action": "*", "Resource": "*"}])
+        fetcher = _make_mock_fetcher()
+
+        from iam_validator.core.policy_checks import _validate_policy_with_registry
+
+        result = await _validate_policy_with_registry(
+            policy=policy,
+            policy_file="test.json",
+            registry=registry,
+            fetcher=fetcher,
+            fail_on_severities=["error", "critical"],
+        )
+
+        check_ids = {i.check_id for i in result.issues}
+        assert "full_wildcard" in check_ids
+        assert "mock_policy_level" not in check_ids
+
+    async def test_policy_level_findings_kept_for_non_full_wildcard_statement(self):
+        """Policy-level findings for non-*/* statement indices are kept."""
+        from iam_validator.core.models import IAMPolicy
+
+        registry = CheckRegistry(suppress_superseded=True)
+        registry.register(FullWildcardCheck())
+        registry.configure_check("full_wildcard", CheckConfig(check_id="full_wildcard", enabled=True))
+
+        # Policy-level check emits for statement index 1 (not the */* statement at 0)
+        async def _execute_policy(self_inner, policy, policy_file, fetcher, config, **kwargs):
+            return [
+                ValidationIssue(
+                    severity="high",
+                    statement_index=1,
+                    issue_type="test_policy_level",
+                    message="Policy-level issue for stmt 1",
+                )
+            ]
+
+        cls = type(
+            "_MockPolicyLevelCheck2",
+            (PolicyCheck,),
+            {
+                "check_id": "mock_policy_level2",
+                "description": "Mock policy-level check 2",
+                "default_severity": "high",
+                "execute_policy": _execute_policy,
+            },
+        )
+        registry.register(cls())
+        registry.configure_check("mock_policy_level2", CheckConfig(check_id="mock_policy_level2", enabled=True))
+
+        policy = IAMPolicy(
+            Statement=[
+                {"Effect": "Allow", "Action": "*", "Resource": "*"},  # idx 0 — suppressed
+                {"Effect": "Allow", "Action": ["s3:GetObject"], "Resource": "*"},  # idx 1 — kept
+            ]
+        )
+        fetcher = _make_mock_fetcher()
+
+        from iam_validator.core.policy_checks import _validate_policy_with_registry
+
+        result = await _validate_policy_with_registry(
+            policy=policy,
+            policy_file="test.json",
+            registry=registry,
+            fetcher=fetcher,
+            fail_on_severities=["error", "critical"],
+        )
+
+        check_ids = {i.check_id for i in result.issues}
+        assert "mock_policy_level2" in check_ids

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -422,3 +422,53 @@ class TestValidationReport:
         assert "1 clean" in summary
         assert "2 with errors" in summary
         assert "2 with findings" in summary
+
+
+class TestIsFullWildcardAllow:
+    """Tests for Statement.is_full_wildcard_allow()."""
+
+    def test_allow_star_star_returns_true(self):
+        s = Statement(Effect="Allow", Action="*", Resource="*")
+        assert s.is_full_wildcard_allow() is True
+
+    def test_allow_list_star_list_star_returns_true(self):
+        s = Statement(Effect="Allow", Action=["*"], Resource=["*"])
+        assert s.is_full_wildcard_allow() is True
+
+    def test_allow_duplicate_star_returns_true(self):
+        s = Statement(Effect="Allow", Action=["*", "*"], Resource=["*", "*"])
+        assert s.is_full_wildcard_allow() is True
+
+    def test_allow_star_action_list_resource_returns_true(self):
+        s = Statement(Effect="Allow", Action="*", Resource=["*"])
+        assert s.is_full_wildcard_allow() is True
+
+    def test_deny_star_star_returns_false(self):
+        s = Statement(Effect="Deny", Action="*", Resource="*")
+        assert s.is_full_wildcard_allow() is False
+
+    def test_allow_star_star_with_condition_returns_true(self):
+        s = Statement(
+            Effect="Allow", Action="*", Resource="*", Condition={"Bool": {"aws:MultiFactorAuthPresent": "true"}}
+        )
+        assert s.is_full_wildcard_allow() is True
+
+    def test_allow_not_action_returns_false(self):
+        s = Statement(Effect="Allow", NotAction="*", Resource="*")
+        assert s.is_full_wildcard_allow() is False
+
+    def test_allow_not_resource_returns_false(self):
+        s = Statement(Effect="Allow", Action="*", NotResource="*")
+        assert s.is_full_wildcard_allow() is False
+
+    def test_allow_star_mixed_resources_returns_false(self):
+        s = Statement(Effect="Allow", Action=["*"], Resource=["*", "arn:aws:s3:::bucket"])
+        assert s.is_full_wildcard_allow() is False
+
+    def test_allow_star_action_absent_resource_returns_false(self):
+        s = Statement(Effect="Allow", Action="*")
+        assert s.is_full_wildcard_allow() is False
+
+    def test_allow_absent_action_star_resource_returns_false(self):
+        s = Statement(Effect="Allow", Resource="*")
+        assert s.is_full_wildcard_allow() is False

--- a/tests/mcp/test_accuracy_fixes.py
+++ b/tests/mcp/test_accuracy_fixes.py
@@ -1,0 +1,467 @@
+"""Production-readiness fixes for MCP tools.
+
+Tests the accuracy / robustness improvements made on top of v1.20.0:
+
+- ``explain_policy`` uses authoritative access_level from the live service ref
+  and surfaces NotAction / NotResource / Principal anti-patterns.
+- ``quick_validate`` includes ``full_wildcard`` in wildcards_detected.
+- ``compare_policies`` uses canonical statement signatures (not stmt_idx).
+- ``fix_policy_issues`` normalizes ``NotAction`` (not just ``Action``).
+- ``aws_access_analyzer_validate`` defaults region per partition + timeout.
+- Malformed input → clean ``ToolError`` (not Pydantic stacktrace).
+- ``unfixed_issues`` always returns a list with separate count.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from iam_validator.core.constants import PARTITION_DEFAULT_REGION
+from iam_validator.mcp import server
+
+
+@pytest.fixture
+def stub_ctx_no_fetcher():
+    """Context where get_shared_fetcher returns None (forces fallback paths)."""
+    return SimpleNamespace(request_context=None)
+
+
+# ---------------------------------------------------------------------------
+# explain_policy — authoritative access-level + NotAction/NotResource handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def explain_ctx(monkeypatch):
+    """Stub a fetcher returning authoritative access_level metadata."""
+
+    # Build a service_detail mock whose .actions dict matches what
+    # _get_access_level expects (annotations.Properties flags).
+    def make_action(props: dict[str, bool]):
+        m = MagicMock()
+        m.annotations = {"Properties": props}
+        return m
+
+    s3 = MagicMock()
+    s3.actions = {
+        "GetObject": make_action({"IsRead": True}),
+        "PutObject": make_action({"IsWrite": True}),
+        "ListBucket": make_action({"IsList": True}),
+    }
+    iam = MagicMock()
+    iam.actions = {
+        "AttachUserPolicy": make_action({"IsPermissionManagement": True}),
+        "TagUser": make_action({"IsTaggingOnly": True}),
+    }
+
+    fetcher = MagicMock()
+
+    async def fake_fetch(name: str):
+        return {"s3": s3, "iam": iam}[name]
+
+    fetcher.fetch_service_by_name = AsyncMock(side_effect=fake_fetch)
+
+    # Patch get_shared_fetcher to return this fetcher.
+    monkeypatch.setattr(server, "get_shared_fetcher", lambda ctx: fetcher)
+
+    return SimpleNamespace(request_context=None)
+
+
+async def test_explain_policy_uses_authoritative_access_level(explain_ctx):
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:PutObject", "iam:AttachUserPolicy"],
+                "Resource": "arn:aws:s3:::b/*",
+            }
+        ],
+    }
+    result = await server.explain_policy(policy, ctx=explain_ctx, verbose=True)
+    services = {s["service"]: set(s["access_types"]) for s in result["services_accessed"]}
+    # _get_access_level returns "read" for IsRead, "write" for IsWrite, "permissions-management" for IsPermissionManagement
+    assert services["s3"] == {"read", "write"}
+    assert services["iam"] == {"permissions-management"}
+
+
+async def test_explain_policy_flags_not_action(explain_ctx):
+    """Effect:Allow + NotAction is an anti-pattern; must show up in concerns."""
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "NotAction": "iam:CreateUser",
+                "Resource": "*",
+            }
+        ],
+    }
+    result = await server.explain_policy(policy, ctx=explain_ctx, verbose=True)
+    concerns = " ".join(result["security_concerns"])
+    assert "NotAction" in concerns
+    assert any("Effect:Allow with NotAction" in c for c in result["security_concerns"])
+    assert result["statements"][0]["uses_not_action"] is True
+
+
+async def test_explain_policy_flags_principal_wildcard(explain_ctx):
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "sts:AssumeRole",
+                "Resource": "*",
+            }
+        ],
+    }
+    result = await server.explain_policy(policy, ctx=explain_ctx, verbose=True)
+    concerns = " ".join(result["security_concerns"])
+    assert "Principal AWS:*" in concerns
+
+
+async def test_explain_policy_case_insensitive_effect(explain_ctx):
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "allow", "Action": "s3:GetObject", "Resource": "*"}],
+    }
+    result = await server.explain_policy(policy, ctx=explain_ctx, verbose=True)
+    assert "1 Allow" in result["summary"]
+
+
+# ---------------------------------------------------------------------------
+# quick_validate — wildcards_detected must include full_wildcard
+# ---------------------------------------------------------------------------
+
+
+async def test_quick_validate_detects_full_wildcard(monkeypatch):
+    """A policy emitting a full_wildcard issue must report wildcards_detected=True."""
+    from iam_validator.core.models import ValidationIssue
+    from iam_validator.mcp.models import ValidationResult
+    from iam_validator.mcp.tools import validation as validation_mod
+
+    fake_result = ValidationResult(
+        is_valid=False,
+        issues=[
+            ValidationIssue(
+                severity="critical",
+                statement_index=0,
+                issue_type="overly_permissive",
+                message="Action and Resource are both '*'",
+                suggestion="...",
+                check_id="full_wildcard",
+            )
+        ],
+        policy_file="inline-policy",
+    )
+
+    async def fake_validate(**kwargs):
+        return fake_result
+
+    monkeypatch.setattr(validation_mod, "validate_policy", fake_validate)
+
+    result = await validation_mod.quick_validate({"Version": "2012-10-17", "Statement": []})
+    assert result["wildcards_detected"] is True
+
+
+# ---------------------------------------------------------------------------
+# compare_policies — canonical signatures, NotAction/NotResource/Principal
+# ---------------------------------------------------------------------------
+
+
+async def test_compare_policies_no_phantom_diff_when_only_sids_change():
+    """Re-ordering statements (no Sids) must not be reported as a change."""
+    a = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::a/*"},
+            {"Effect": "Deny", "Action": "iam:*", "Resource": "*"},
+        ],
+    }
+    b = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {"Effect": "Deny", "Action": "iam:*", "Resource": "*"},
+            {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::a/*"},
+        ],
+    }
+    result = await server.compare_policies(a, b, verbose=True)
+    assert result["statements_added"] == 0
+    assert result["statements_removed"] == 0
+    assert result["added_actions"] == []
+    assert result["removed_actions"] == []
+
+
+async def test_compare_policies_diffs_not_action_independently():
+    a = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "NotAction": "iam:CreateUser", "Resource": "*"}],
+    }
+    b = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "NotAction": ["iam:CreateUser", "s3:DeleteBucket"], "Resource": "*"}],
+    }
+    result = await server.compare_policies(a, b, verbose=True)
+    assert "s3:DeleteBucket" in result["added_not_actions"]
+    assert result["added_actions"] == []  # not the same field
+
+
+async def test_compare_policies_diffs_principal():
+    a = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::111:role/A"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+    b = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ["arn:aws:iam::111:role/A", "arn:aws:iam::222:role/B"]},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+    result = await server.compare_policies(a, b, verbose=True)
+    assert "AWS:arn:aws:iam::222:role/B" in result["added_principals"]
+
+
+# ---------------------------------------------------------------------------
+# fix_policy_issues — NotAction case normalization
+# ---------------------------------------------------------------------------
+
+
+async def test_fix_policy_issues_normalizes_not_action_case(monkeypatch):
+    """NotAction prefixes must be lowercased like Action."""
+    from iam_validator.core.models import ValidationIssue
+    from iam_validator.mcp.models import ValidationResult
+    from iam_validator.mcp.tools import validation as validation_mod
+
+    # Force action_validation to fire so the case-fix runs.
+    fake_initial = ValidationResult(
+        is_valid=False,
+        issues=[
+            ValidationIssue(
+                severity="error",
+                statement_index=0,
+                issue_type="invalid_action",
+                message="Service prefix must be lowercase",
+                suggestion="lowercase service",
+                check_id="action_validation",
+            )
+        ],
+        policy_file="inline-policy",
+    )
+    fake_final = ValidationResult(is_valid=True, issues=[], policy_file="inline-policy")
+
+    calls = {"n": 0}
+
+    async def fake_validate(**kwargs):
+        calls["n"] += 1
+        return fake_initial if calls["n"] == 1 else fake_final
+
+    monkeypatch.setattr(validation_mod, "validate_policy", fake_validate)
+    monkeypatch.setattr(validation_mod, "_detect_policy_type", lambda _p: "identity")
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "NotAction": "S3:GetObject", "Resource": "*"}],
+    }
+    result = await server.fix_policy_issues(policy)
+    assert result["fixed_policy"]["Statement"][0]["NotAction"] == "s3:GetObject"
+    assert any("NotAction" in fix for fix in result["fixes_applied"])
+
+
+async def test_fix_policy_issues_returns_consistent_unfixed_shape(monkeypatch):
+    """unfixed_issues is always a list; unfixed_count is always an int."""
+    from iam_validator.core.models import ValidationIssue
+    from iam_validator.mcp.models import ValidationResult
+    from iam_validator.mcp.tools import validation as validation_mod
+
+    fake = ValidationResult(
+        is_valid=False,
+        issues=[
+            ValidationIssue(
+                severity="medium",
+                statement_index=0,
+                issue_type="overly_permissive",
+                message="wildcard",
+                suggestion="...",
+                check_id="wildcard_action",
+            )
+        ],
+        policy_file="inline-policy",
+    )
+    finals = [fake, fake]
+
+    async def fake_validate(**kwargs):
+        return finals.pop(0) if finals else fake
+
+    monkeypatch.setattr(validation_mod, "validate_policy", fake_validate)
+    monkeypatch.setattr(validation_mod, "_detect_policy_type", lambda _p: "identity")
+
+    policy = {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}
+
+    lean = await server.fix_policy_issues(policy, verbose=False)
+    verbose = await server.fix_policy_issues(policy, verbose=True)
+    assert isinstance(lean["unfixed_issues"], list)
+    assert isinstance(verbose["unfixed_issues"], list)
+    assert lean["unfixed_count"] == verbose["unfixed_count"]
+
+
+# ---------------------------------------------------------------------------
+# aws_access_analyzer_validate — partition→region defaulting + bad partition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "partition,expected_region",
+    [
+        ("aws", "us-east-1"),
+        ("aws-cn", "cn-north-1"),
+        ("aws-us-gov", "us-gov-west-1"),
+    ],
+)
+def test_partition_default_region_table(partition: str, expected_region: str):
+    assert PARTITION_DEFAULT_REGION[partition] == expected_region
+
+
+async def test_aws_access_analyzer_validate_rejects_bad_partition(monkeypatch):
+    """Unknown partition raises ToolError before touching boto3."""
+    # Stub get_aws_session so we can confirm it's never reached.
+    called = {"hit": False}
+
+    def fake_get_aws_session(ctx, region, profile):
+        called["hit"] = True
+        return MagicMock()
+
+    monkeypatch.setattr(server, "get_aws_session", fake_get_aws_session)
+
+    with pytest.raises(ToolError, match="Unsupported partition"):
+        await server.aws_access_analyzer_validate(
+            policy={"Version": "2012-10-17", "Statement": []},
+            ctx=SimpleNamespace(request_context=None),
+            partition="aws-bogus",
+        )
+    assert called["hit"] is False
+
+
+async def test_aws_access_analyzer_validate_uses_partition_default_region(monkeypatch):
+    """When region is omitted, defaults to PARTITION_DEFAULT_REGION[partition]."""
+    captured_region: dict[str, Any] = {}
+
+    def fake_get_aws_session(ctx, region, profile):
+        captured_region["region"] = region
+        return MagicMock()
+
+    async def fake_analyze(**kwargs):
+        captured_region["analyze_region"] = kwargs.get("region")
+        return {"findings": [], "finding_count": 0}
+
+    monkeypatch.setattr(server, "get_aws_session", fake_get_aws_session)
+    monkeypatch.setattr("iam_validator.mcp.tools.analyze.analyze_policy", fake_analyze)
+
+    await server.aws_access_analyzer_validate(
+        policy={"Version": "2012-10-17", "Statement": []},
+        ctx=SimpleNamespace(request_context=None),
+        partition="aws-cn",
+    )
+    assert captured_region["region"] == "cn-north-1"
+    assert captured_region["analyze_region"] == "cn-north-1"
+
+
+async def test_aws_access_analyzer_validate_timeout(monkeypatch):
+    """Hung AWS API call surfaces as a ToolError, not an open hang."""
+    import asyncio
+
+    def fake_get_aws_session(ctx, region, profile):
+        return MagicMock()
+
+    async def slow_analyze(**kwargs):
+        await asyncio.sleep(5)
+        return {"findings": [], "finding_count": 0}
+
+    monkeypatch.setattr(server, "get_aws_session", fake_get_aws_session)
+    monkeypatch.setattr("iam_validator.mcp.tools.analyze.analyze_policy", slow_analyze)
+
+    with pytest.raises(ToolError, match="timed out"):
+        await server.aws_access_analyzer_validate(
+            policy={"Version": "2012-10-17", "Statement": []},
+            ctx=SimpleNamespace(request_context=None),
+            timeout_seconds=0.1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Malformed input → clean ToolError
+# ---------------------------------------------------------------------------
+
+
+async def test_validate_policy_malformed_raises_tool_error():
+    """Schema-violating policy dict raises ToolError, not a Pydantic stacktrace."""
+    from iam_validator.mcp.tools import validation as validation_mod
+
+    # Statement set to a non-list/dict value triggers a Pydantic ValidationError
+    # because the IAMPolicy model rejects scalars there.
+    with pytest.raises(ToolError, match="Malformed IAM policy"):
+        await validation_mod.validate_policy(policy={"Version": "2012-10-17", "Statement": 12345})
+
+
+# ---------------------------------------------------------------------------
+# DRY: issue_to_dict helper produces the documented shapes
+# ---------------------------------------------------------------------------
+
+
+def test_issue_to_dict_lean_shape():
+    from iam_validator.core.models import ValidationIssue
+    from iam_validator.mcp.tools.validation import issue_to_dict
+
+    issue = ValidationIssue(
+        severity="medium",
+        statement_index=0,
+        issue_type="overly_permissive",
+        message="m",
+        suggestion="s",
+        check_id="wildcard_action",
+    )
+    lean = issue_to_dict(issue, verbose=False)
+    assert set(lean.keys()) == {"severity", "message", "suggestion", "check_id"}
+
+
+def test_issue_to_dict_verbose_includes_all_fields():
+    from iam_validator.core.models import ValidationIssue
+    from iam_validator.mcp.tools.validation import issue_to_dict
+
+    issue = ValidationIssue(
+        severity="medium",
+        statement_index=0,
+        issue_type="overly_permissive",
+        message="m",
+        suggestion="s",
+        check_id="wildcard_action",
+    )
+    verbose = issue_to_dict(issue, verbose=True)
+    expected = {
+        "severity",
+        "message",
+        "suggestion",
+        "example",
+        "check_id",
+        "statement_index",
+        "action",
+        "resource",
+        "field_name",
+        "risk_explanation",
+        "documentation_url",
+        "remediation_steps",
+    }
+    assert set(verbose.keys()) == expected

--- a/tests/mcp/test_analyze.py
+++ b/tests/mcp/test_analyze.py
@@ -1,0 +1,112 @@
+"""Tests for the AWS Access Analyzer MCP integration.
+
+Mocks at the boto3 boundary — no real AWS calls.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from iam_validator.mcp.tools.analyze import analyze_policy
+
+
+@pytest.fixture
+def mock_session():
+    """boto3.Session mock returning a client whose validate_policy returns one finding."""
+    response = {
+        "findings": [
+            {
+                "findingType": "ERROR",
+                "issueCode": "INVALID_ACTION",
+                "findingDetails": "Action s3:GetObjects does not exist.",
+                "learnMoreLink": "https://docs.aws.amazon.com/access-analyzer/findings",
+                "locations": [
+                    {
+                        "path": [{"value": "Statement"}],
+                        "span": {
+                            "start": {"line": 1, "column": 1, "offset": 0},
+                            "end": {"line": 1, "column": 10, "offset": 10},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    client = MagicMock()
+    client.validate_policy.return_value = response
+    sess = MagicMock()
+    sess.client.return_value = client
+    return sess
+
+
+async def test_analyze_returns_findings(mock_session):
+    result = await analyze_policy(
+        {"Version": "2012-10-17", "Statement": []},
+        session=mock_session,
+    )
+    assert result["finding_count"] == 1
+    assert result["findings"][0]["issue_code"] == "INVALID_ACTION"
+    assert result["findings"][0]["finding_type"] == "ERROR"
+
+
+async def test_analyze_invalid_policy_type_raises():
+    with pytest.raises(ToolError, match="Invalid policy_type"):
+        await analyze_policy({}, policy_type="BOGUS")
+
+
+def test_get_aws_session_caches_per_region_profile(monkeypatch):
+    """Same (region, profile) returns the same Session; different keys do not."""
+    from iam_validator.mcp.server import get_aws_session
+
+    created: list = []
+
+    class FakeSession:
+        def __init__(self, **kw):
+            created.append(kw)
+            self.kw = kw
+
+    monkeypatch.setattr("boto3.Session", FakeSession)
+
+    cache: dict = {}
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context={"aws_sessions": cache}))
+
+    a1 = get_aws_session(ctx, "us-east-1", None)
+    a2 = get_aws_session(ctx, "us-east-1", None)
+    b = get_aws_session(ctx, "us-west-2", None)
+
+    assert a1 is a2, "Same key must return the same Session"
+    assert a1 is not b, "Different region must yield a different Session"
+    assert len(created) == 2, "Only two Session() constructions: us-east-1, us-west-2"
+
+
+def test_get_aws_session_falls_back_when_no_lifespan(monkeypatch):
+    """Tests / direct callers without an MCP lifespan must not crash."""
+    from iam_validator.mcp.server import get_aws_session
+
+    class FakeSession:
+        def __init__(self, **kw):
+            self.kw = kw
+
+    monkeypatch.setattr("boto3.Session", FakeSession)
+
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=None))
+    s = get_aws_session(ctx, "eu-west-1", None)
+    assert s.kw == {"region_name": "eu-west-1"}
+
+
+def test_get_aws_session_includes_profile_when_set(monkeypatch):
+    """profile= must propagate into the Session constructor."""
+    from iam_validator.mcp.server import get_aws_session
+
+    class FakeSession:
+        def __init__(self, **kw):
+            self.kw = kw
+
+    monkeypatch.setattr("boto3.Session", FakeSession)
+
+    cache: dict = {}
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context={"aws_sessions": cache}))
+    s = get_aws_session(ctx, "us-east-1", "my-profile")
+    assert s.kw == {"region_name": "us-east-1", "profile_name": "my-profile"}

--- a/tests/mcp/test_build_arn.py
+++ b/tests/mcp/test_build_arn.py
@@ -1,0 +1,180 @@
+"""Tests for the rewritten ``build_arn`` MCP tool.
+
+The tool now consults the live AWSServiceFetcher via ``query_arn_formats``.
+We monkeypatch that single function with a stub returning canned templates so
+tests run hermetically (no network, no caches).
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from iam_validator.mcp import server
+
+
+@pytest.fixture
+def stub_ctx():
+    """Minimal ctx the tool will pass to get_shared_fetcher (returns None — fetcher is bypassed)."""
+    return SimpleNamespace(request_context=None)
+
+
+@pytest.fixture
+def patch_arn_formats(monkeypatch):
+    """Return a function that registers a canned response for query_arn_formats."""
+
+    def _patch(formats: list[dict[str, Any]]):
+        async def _fake(service: str, fetcher: Any = None) -> list[dict[str, Any]]:  # noqa: ARG001
+            return formats
+
+        # build_arn imports query_arn_formats from this module at call time.
+        monkeypatch.setattr("iam_validator.mcp.tools.query.query_arn_formats", _fake, raising=True)
+
+    return _patch
+
+
+# ---------------------------------------------------------------------------
+# 1. Single-placeholder template (s3 bucket)
+# ---------------------------------------------------------------------------
+
+
+async def test_single_placeholder_via_placeholders_dict(stub_ctx, patch_arn_formats):
+    patch_arn_formats(
+        [
+            {
+                "resource_type": "bucket",
+                "arn_formats": ["arn:${Partition}:s3:::${BucketName}"],
+            }
+        ]
+    )
+    result = await server.build_arn(
+        service="s3",
+        resource_type="bucket",
+        ctx=stub_ctx,
+        placeholders={"BucketName": "my-bucket"},
+    )
+    assert result["valid"] is True
+    assert result["arn"] == "arn:aws:s3:::my-bucket"
+    assert result["unfilled_placeholders"] == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-placeholder template (eks access-entry, all values provided)
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_placeholder_template_fully_filled(stub_ctx, patch_arn_formats):
+    template = (
+        "arn:${Partition}:eks:${Region}:${Account}:access-entry/"
+        "${ClusterName}/${IamIdentityType}/${IamIdentityAccountID}/"
+        "${IamIdentityName}/${UUID}"
+    )
+    patch_arn_formats([{"resource_type": "access-entry", "arn_formats": [template]}])
+    result = await server.build_arn(
+        service="eks",
+        resource_type="access-entry",
+        ctx=stub_ctx,
+        region="us-east-1",
+        account_id="123456789012",
+        placeholders={
+            "ClusterName": "prod",
+            "IamIdentityType": "user",
+            "IamIdentityAccountID": "123456789012",
+            "IamIdentityName": "alice",
+            "UUID": "abcd-1234",
+        },
+    )
+    assert result["valid"] is True
+    assert result["unfilled_placeholders"] == []
+    assert "${" not in result["arn"]
+    assert "prod" in result["arn"] and "alice" in result["arn"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-placeholder template, missing values → valid=False with detail
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_placeholder_missing_returns_unfilled(stub_ctx, patch_arn_formats):
+    template = "arn:${Partition}:eks:${Region}:${Account}:access-entry/${ClusterName}/${UUID}"
+    patch_arn_formats([{"resource_type": "access-entry", "arn_formats": [template]}])
+    result = await server.build_arn(
+        service="eks",
+        resource_type="access-entry",
+        ctx=stub_ctx,
+        region="us-east-1",
+        account_id="123456789012",
+        placeholders={"ClusterName": "prod"},
+    )
+    assert result["valid"] is False
+    assert "${UUID}" in result["unfilled_placeholders"]
+    assert any("Unfilled placeholders" in note for note in result["notes"])
+
+
+# ---------------------------------------------------------------------------
+# 4. Bad partition → ToolError (input-validation, not data-incomplete)
+# ---------------------------------------------------------------------------
+
+
+async def test_bad_partition_raises_tool_error(stub_ctx, patch_arn_formats):
+    patch_arn_formats([{"resource_type": "bucket", "arn_formats": ["arn:${Partition}:s3:::${BucketName}"]}])
+    with pytest.raises(ToolError, match="Unsupported partition"):
+        await server.build_arn(
+            service="s3",
+            resource_type="bucket",
+            ctx=stub_ctx,
+            partition="aws-bogus",
+        )
+
+
+async def test_unknown_resource_type_raises_tool_error(stub_ctx, patch_arn_formats):
+    patch_arn_formats([{"resource_type": "bucket", "arn_formats": ["arn:${Partition}:s3:::${BucketName}"]}])
+    with pytest.raises(ToolError, match="Unknown resource_type"):
+        await server.build_arn(
+            service="s3",
+            resource_type="nonexistent",
+            ctx=stub_ctx,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Deprecated resource_name shortcut (single-placeholder + warning)
+# ---------------------------------------------------------------------------
+
+
+async def test_resource_name_deprecation(stub_ctx, patch_arn_formats, caplog):
+    patch_arn_formats([{"resource_type": "bucket", "arn_formats": ["arn:${Partition}:s3:::${BucketName}"]}])
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="iam_validator.mcp.server"):
+        result = await server.build_arn(
+            service="s3",
+            resource_type="bucket",
+            ctx=stub_ctx,
+            resource_name="legacy-bucket",
+        )
+
+    assert result["valid"] is True
+    assert result["arn"] == "arn:aws:s3:::legacy-bucket"
+    assert any("deprecated" in record.message.lower() for record in caplog.records), (
+        "deprecation warning must be emitted"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partition acceptance (aws-eusc, aws-iso* etc.)
+# ---------------------------------------------------------------------------
+
+
+async def test_eusc_partition_accepted(stub_ctx, patch_arn_formats):
+    patch_arn_formats([{"resource_type": "bucket", "arn_formats": ["arn:${Partition}:s3:::${BucketName}"]}])
+    result = await server.build_arn(
+        service="s3",
+        resource_type="bucket",
+        ctx=stub_ctx,
+        placeholders={"BucketName": "my-bucket"},
+        partition="aws-eusc",
+    )
+    assert result["valid"] is True
+    assert result["arn"] == "arn:aws-eusc:s3:::my-bucket"

--- a/tests/mcp/test_check_metadata.py
+++ b/tests/mcp/test_check_metadata.py
@@ -1,0 +1,88 @@
+"""Ensure every registered check has a useful get_issue_guidance response."""
+
+import pytest
+
+from iam_validator.core.check_registry import create_default_registry
+from iam_validator.mcp.server import get_check_details, get_issue_guidance
+
+
+async def test_every_registered_check_has_complete_guidance():
+    """get_issue_guidance must return non-empty fields for every registered check."""
+    registry = create_default_registry()
+    incomplete: dict[str, list[str]] = {}
+    for check in registry.get_all_checks():
+        result = await get_issue_guidance(check.check_id)
+        missing: list[str] = []
+        if not result.get("description"):
+            missing.append("description")
+        if result.get("default_severity") is None:
+            missing.append("default_severity")
+        if not result.get("fix_steps"):
+            missing.append("fix_steps")
+        if not result.get("related"):
+            missing.append("related")
+        if missing:
+            incomplete[check.check_id] = missing
+    assert not incomplete, f"Incomplete guidance: {incomplete}"
+
+
+async def test_unknown_check_returns_fallback():
+    """The check_id-not-registered path must emit the catalogue pointer."""
+    result = await get_issue_guidance("nonexistent_check_xyz")
+    assert result["description"].startswith("Unknown check")
+    assert "iam://checks" in result["related"]
+
+
+async def test_curated_examples_use_correct_key():
+    """Regression: ensure 'related' key is read (not 'related_tools')."""
+    result = await get_issue_guidance("wildcard_action")
+    assert result["related"] == [
+        "suggest_actions",
+        "query_service_actions",
+        "iam://templates",
+    ]
+
+
+async def test_get_check_details_for_registered_check():
+    """get_check_details returns description and severity from the registry."""
+    result = await get_check_details("wildcard_action")
+    assert result["check_id"] == "wildcard_action"
+    assert result["description"]
+    assert result["default_severity"] is not None
+    assert result["example_violation"] == {
+        "Effect": "Allow",
+        "Action": "*",
+        "Resource": "*",
+    }
+
+
+async def test_get_check_details_for_unknown_check():
+    """Unknown check returns shape-stable response with description='Check not found'."""
+    result = await get_check_details("nonexistent_check_xyz")
+    assert result["description"] == "Check not found"
+    assert result["default_severity"] is None
+    assert result["example_violation"] is None
+
+
+@pytest.mark.parametrize(
+    "check_id",
+    [
+        "wildcard_action",
+        "wildcard_resource",
+        "full_wildcard",
+        "service_wildcard",
+        "sensitive_action",
+        "action_validation",
+        "policy_structure",
+        "action_condition_enforcement",
+        "not_action_not_resource",
+        "sid_uniqueness",
+        "principal_validation",
+        "trust_policy_validation",
+    ],
+)
+async def test_curated_entry_returns_example_pair(check_id: str):
+    """All 12 curated entries must surface example_before AND example_after."""
+    result = await get_issue_guidance(check_id)
+    assert result["example_before"] is not None, f"missing example_before for {check_id}"
+    assert result["example_after"] is not None, f"missing example_after for {check_id}"

--- a/tests/mcp/test_constants_alignment.py
+++ b/tests/mcp/test_constants_alignment.py
@@ -1,0 +1,24 @@
+"""Guard rails: MCP must source shared literals from core/constants."""
+
+from iam_validator.core import constants
+from iam_validator.mcp import server
+
+
+def test_base_instructions_uses_current_version():
+    assert constants.IAM_POLICY_VERSION_CURRENT in server.BASE_INSTRUCTIONS
+
+
+def test_fix_policy_uses_centralized_versions():
+    """Server source must use the constants, not raw "2012-10-17" literals."""
+    src_path = server.__file__.replace(".pyc", ".py")
+    with open(src_path) as f:
+        text = f.read()
+
+    assert "IAM_POLICY_VERSION_CURRENT" in text
+    assert "IAM_POLICY_VERSIONS_VALID" in text
+    assert '"2012-10-17"' not in text, "Raw policy version literal must come from constants.IAM_POLICY_VERSION_CURRENT"
+
+
+def test_iam_policy_versions_valid_contains_both():
+    assert constants.IAM_POLICY_VERSION_CURRENT in constants.IAM_POLICY_VERSIONS_VALID
+    assert constants.IAM_POLICY_VERSION_LEGACY in constants.IAM_POLICY_VERSIONS_VALID

--- a/tests/mcp/test_profiles.py
+++ b/tests/mcp/test_profiles.py
@@ -1,0 +1,104 @@
+"""Tag-based ``--profile`` gating tests for the MCP server."""
+
+import pytest
+
+from iam_validator.mcp.server import (
+    apply_profile,
+    get_active_profile,
+    mcp,
+    set_active_profile,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile():
+    """Each test starts and ends with the full profile so state never leaks."""
+    apply_profile("full")
+    set_active_profile("full")
+    yield
+    apply_profile("full")
+    set_active_profile("full")
+
+
+async def test_validate_only_profile_hides_generation_tools():
+    apply_profile("validate-only")
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "validate_policy" in names
+    assert "generate_policy_from_template" not in names
+    assert "build_minimal_policy" not in names
+
+
+async def test_validate_and_query_profile_includes_query_tools():
+    apply_profile("validate-and-query")
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "validate_policy" in names
+    assert "query_action_details" in names
+    assert "generate_policy_from_template" not in names
+    # analyze tag is separate
+    assert "aws_access_analyzer_validate" not in names
+
+
+async def test_no_generation_profile():
+    apply_profile("no-generation")
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "validate_policy" in names
+    assert "generate_policy_from_template" not in names
+    assert "fix_policy_issues" in names  # `fix` tag preserved
+
+
+async def test_read_only_profile_hides_destructive_tools():
+    apply_profile("read-only")
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    # Mutating tools must be gone
+    assert "set_organization_config" not in names
+    assert "set_custom_instructions" not in names
+    assert "clear_organization_config" not in names
+    assert "load_organization_config_from_yaml" not in names
+    # Read tools must still be available
+    assert "validate_policy" in names
+    assert "get_organization_config" in names
+
+
+async def test_full_profile_restores_everything_after_validate_only():
+    apply_profile("validate-only")
+    apply_profile("full")
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "generate_policy_from_template" in names
+    assert "build_minimal_policy" in names
+    assert "set_organization_config" in names
+
+
+async def test_apply_profile_is_not_an_mcp_tool():
+    """Internal helper must not leak into the tool catalog."""
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "apply_profile" not in names
+    assert "set_active_profile" not in names
+
+
+async def test_get_active_profile_reflects_state():
+    apply_profile("validate-only")
+    set_active_profile("validate-only")
+    result = await get_active_profile()
+    assert result["profile"] == "validate-only"
+    assert "validate_policy" in result["tool_names"]
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(ValueError, match="Unknown profile"):
+        apply_profile("bogus")
+
+
+async def test_list_checks_demoted_to_resource_not_tool():
+    """list_checks must not appear as a tool — only as iam://checks resource."""
+    enabled = await mcp.list_tools()
+    names = {t.name for t in enabled}
+    assert "list_checks" not in names
+    assert "list_templates" not in names
+    assert "list_sensitive_actions" not in names
+    assert "get_check_details" not in names

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -70,21 +70,29 @@ class TestServerTools:
 
     @pytest.mark.asyncio
     async def test_generation_tools_registered(self):
-        """Generation tools should be registered."""
+        """Generation tools should be registered.
+
+        Note: list_templates was demoted to the iam://templates resource in
+        v1.20.0 — it must NOT appear as a tool.
+        """
         tool_names = [t.name for t in await mcp.list_tools()]
         assert "generate_policy_from_template" in tool_names
         assert "build_minimal_policy" in tool_names
         assert "suggest_actions" in tool_names
-        assert "list_templates" in tool_names
+        assert "list_templates" not in tool_names
 
     @pytest.mark.asyncio
     async def test_query_tools_registered(self):
-        """Query tools should be registered."""
+        """Query tools should be registered.
+
+        Note: list_checks was demoted to the iam://checks resource in v1.20.0 —
+        it must NOT appear as a tool.
+        """
         tool_names = [t.name for t in await mcp.list_tools()]
         assert "query_service_actions" in tool_names
         assert "query_action_details" in tool_names
         assert "expand_wildcard_action" in tool_names
-        assert "list_checks" in tool_names
+        assert "list_checks" not in tool_names
 
     @pytest.mark.asyncio
     async def test_org_config_tools_registered(self):

--- a/tests/mcp/test_transport.py
+++ b/tests/mcp/test_transport.py
@@ -1,0 +1,150 @@
+"""Transport-layer integration tests using the in-process FastMCP Client.
+
+Round-trips the MCP protocol against the actual server instance to catch:
+- tool registration regressions
+- annotation/tag drift
+- response-shape changes
+- resource catalog drift
+"""
+
+import pytest
+from fastmcp.client import Client
+
+from iam_validator.mcp.server import apply_profile, mcp
+
+
+@pytest.fixture(autouse=True)
+def _full_profile():
+    apply_profile("full")
+    yield
+    apply_profile("full")
+
+
+async def test_validate_policy_round_trip():
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "validate_policy",
+            {
+                "policy": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": "s3:GetObject",
+                            "Resource": "arn:aws:s3:::b/*",
+                        }
+                    ],
+                }
+            },
+        )
+        assert result.is_error is False
+        assert result.structured_content is not None
+        assert "issues" in result.structured_content
+
+
+async def test_resources_listed():
+    async with Client(mcp) as client:
+        resources = await client.list_resources()
+        uris = {str(r.uri) for r in resources}
+        assert "iam://templates" in uris
+        assert "iam://checks" in uris
+        assert "iam://config-schema" in uris
+
+
+async def test_resource_templates_listed():
+    """Parameterized resources (Task 6g) must register as resource templates."""
+    async with Client(mcp) as client:
+        templates = await client.list_resource_templates()
+        uris = {str(t.uriTemplate) for t in templates}
+        assert "iam://sensitive-actions/{category}" in uris
+        assert "iam://checks/{check_id}" in uris
+
+
+async def test_check_details_resource_round_trip():
+    """Fetching iam://checks/{check_id} returns registry-driven JSON for a real check."""
+    import json
+
+    async with Client(mcp) as client:
+        result = await client.read_resource("iam://checks/wildcard_action")
+        assert result, "expected non-empty content"
+        # FastMCP returns a list of TextResourceContents; first contains JSON.
+        text = result[0].text if hasattr(result[0], "text") else str(result[0])
+        payload = json.loads(text)
+        assert payload["check_id"] == "wildcard_action"
+        assert payload["description"]
+        assert payload["default_severity"] is not None
+        assert payload["example_violation"] is not None
+
+
+async def test_sensitive_actions_resource_round_trip():
+    """Fetching iam://sensitive-actions/{category} returns the category's actions."""
+    import json
+
+    async with Client(mcp) as client:
+        result = await client.read_resource("iam://sensitive-actions/credential_exposure")
+        text = result[0].text if hasattr(result[0], "text") else str(result[0])
+        payload = json.loads(text)
+        assert payload["category"] == "credential_exposure"
+        assert isinstance(payload["actions"], list)
+        assert len(payload["actions"]) > 0
+
+
+async def test_unknown_check_id_resource_returns_not_found_shape():
+    """iam://checks/{unknown} returns the registry's 'Check not found' shape."""
+    import json
+
+    async with Client(mcp) as client:
+        result = await client.read_resource("iam://checks/nonexistent_xyz")
+        text = result[0].text if hasattr(result[0], "text") else str(result[0])
+        payload = json.loads(text)
+        assert payload["description"] == "Check not found"
+
+
+async def test_tool_annotations_round_trip():
+    """Verify ToolAnnotations survive the protocol."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        by_name = {t.name: t for t in tools}
+        assert by_name["validate_policy"].annotations.readOnlyHint is True
+        assert by_name["set_organization_config"].annotations.destructiveHint is False
+        assert by_name["aws_access_analyzer_validate"].annotations.openWorldHint is True
+
+
+async def test_validate_only_profile_exposes_minimal_set():
+    apply_profile("validate-only")
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert "validate_policy" in names
+        assert "generate_policy_from_template" not in names
+
+
+async def test_build_arn_raises_tool_error_for_bad_partition():
+    """Input-validation errors surface as protocol errors, not structured valid=False.
+
+    FastMCP's Client.call_tool defaults to raise_on_error=True; we opt out so we
+    can inspect the structured result.
+    """
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "build_arn",
+            {
+                "service": "s3",
+                "resource_type": "bucket",
+                "partition": "bogus",
+            },
+            raise_on_error=False,
+        )
+        assert result.is_error is True
+        text = (result.content[0].text if result.content else "").lower()
+        assert "partition" in text
+
+
+async def test_demoted_resources_no_longer_registered_as_tools():
+    """list_templates/list_checks/list_sensitive_actions/get_check_details = resources, not tools."""
+    async with Client(mcp) as client:
+        names = {t.name for t in await client.list_tools()}
+        assert "list_templates" not in names
+        assert "list_checks" not in names
+        assert "list_sensitive_actions" not in names
+        assert "get_check_details" not in names

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ mcp = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.28.0" },
     { name = "botocore", specifier = ">=1.40.55" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.14.1" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2,<4" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0" },


### PR DESCRIPTION
Bumps `1.19.1 → 1.20.0`. Two interrelated feature streams ship together: a comprehensive MCP overhaul + production-readiness audit, and the `full_wildcard` supersedes feature for automatic suppression of
redundant findings.

## Summary

- 🎯 **Accuracy**: every registered check now has registry-driven guidance; `build_arn` consults the live AWS service reference; `explain_policy` uses authoritative `access_level` (not name-prefix heuristics);
`compare_policies` uses canonical statement signatures (no phantom diffs from re-ordered Sid-less statements)
- 🔌 **CLI parity**: `--custom-checks-dir`, `--aws-services-dir`, and a new `aws_access_analyzer_validate` tool (boto3 + `asyncio.to_thread` + cached sessions per `(region, profile)`)
- 💸 **Token efficiency**: tag-based `--profile` gating. `validate-only` ships at **32%** of `full`'s catalog size (~1.5K tokens vs ~5K)
- 🛡️  **Hardening**: clean `ToolError` for malformed input (no Pydantic stacktrace through MCP); 30s timeout on Access Analyzer; partition→region defaulting; argparse mutex on instructions flags
- ✨ **`full_wildcard` supersedes**: bare `Allow Action:* Resource:*` statements suppress all redundant findings on the same statement (configurable via `suppress_superseded_findings`)

## A) MCP overhaul + production-readiness pass

### Accuracy

| Tool | Before | After |
| --- | --- | --- |
| `get_issue_guidance` / `get_check_details` | hardcoded for 5–6 of 22 checks | registry-driven for all 22; 12 with curated examples in `mcp/check_metadata.py` |
| `build_arn` | hardcoded 9-service map | live AWS service reference (every service); multi-placeholder templates (e.g. EKS access-entry with 5+ tokens) via `placeholders` dict |
| `explain_policy` | `Get*/Put*` prefix heuristic | authoritative `access_level` (Read/Write/List/Tagging/Permissions management) from the service ref. Surfaces `NotAction` / `NotResource` / `Principal:*` /
`NotPrincipal` as explicit security concerns |
| `compare_policies` | `f"stmt_{idx}"` matching → false-positive effect changes | canonical statement signatures (effect + sorted actions/resources/principals + canonical-JSON conditions). Diffs `Not*` fields
and condition keys independently |
| `quick_validate` | missed `full_wildcard` in `wildcards_detected` | full wildcard set in lockstep with the registry |
| `fix_policy_issues` | only `Action` case fix | also normalizes `NotAction` |
| `aws_access_analyzer_validate` | `region="us-east-1"` always (broke for `aws-cn`/`aws-us-gov`) | partition→region defaulting via `core/constants.PARTITION_DEFAULT_REGION`; rejects bad partition; 30s timeout |
| Malformed input | Pydantic stacktrace through MCP | clean `ToolError("Malformed IAM policy: …")` |

### CLI parity

- `--custom-checks-dir` / `--aws-services-dir` flags forwarded to `validate_policies()` via `SessionConfigManager`
- `--instructions` / `--instructions-file` are now an argparse mutex group (previously `--instructions` was silently ignored if both were supplied)
- `aws_access_analyzer_validate` tool — boto3 wrapped in `asyncio.to_thread`; lifespan caches sessions per `(region, profile)` to amortise the ~50 ms session-construction cost

### Token efficiency

- Single-axis tag taxonomy (`validate` / `query` / `generation` / `fix` / `orgconfig` / `analyze` / `mutating`) + `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) on every
 tool
- `--profile {full, validate-only, validate-and-query, no-generation, read-only}` CLI flag; `--list-profiles` prints the taxonomy and exits
- `list_templates` / `list_checks` / `list_sensitive_actions` / `get_check_details` **demoted from tools to resources** (see Compatibility)
- `BASE_INSTRUCTIONS` slimmed from ~2.6 KB to ~700 chars (per-tool guardrails relocated to individual docstrings)

| Profile | Tools | Total chars | % full |
| --- | --- | --- | --- |
| `full` | 33 | 5028 | 100% |
| `validate-only` | 5 | 1609 | **32%** |
| `validate-and-query` | 13 | 2173 | 43% |
| `no-generation` | 28 | 4434 | 88% |
| `read-only` | 28 | 4572 | 90% |

### Hardening

- Centralized `IAM_POLICY_VERSION_CURRENT` / `IAM_POLICY_VERSION_LEGACY` / `IAM_POLICY_VERSIONS_VALID` and `PARTITION_DEFAULT_REGION` in `core/constants.py`. Guardrail tests block raw `"2012-10-17"` literals
re-appearing
- Single-call query tools (`query_service_actions`, `query_action_details`, `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`) reuse the lifespan-managed `AWSServiceFetcher`
- `validate_policies_batch` gains `max_concurrency` (default 10) gated via `asyncio.Semaphore`
- `issue_to_dict()` helper — single source of truth for the verbose vs lean issue projection across `validate_policy`, `validate_policies_batch`, `generate_policy_from_template`, `build_minimal_policy`,
`fix_policy_issues`
- FastMCP minimum bumped from `>=2.14.1` to `>=3.2,<4` — we rely on v3 `enable(only=True)` semantics for tag-based gating

## B) `full_wildcard` supersedes — automatic suppression of redundant findings

- `suppress_superseded_findings` setting (default `true`). When a bare `Allow Action:* Resource:*` statement is detected, a single `critical` `full_wildcard` finding is surfaced and all redundant
statement-/policy-level findings for that same statement are suppressed (including custom checks). Sibling statements are unaffected
- `Statement.is_full_wildcard_allow()` predicate
- `PolicyCheck.supersedes` / `matches()` extension points (zero-cost defaults for existing checks)

## Compatibility

- Default MCP profile is `full` — existing Claude Desktop / Cursor configs see no behavioural change
- `--profile` requires a server restart — MCP clients cache tool catalogs per session
- `build_arn(resource_name=...)` is **deprecated** and emits a warning. Prefer `placeholders={...}`. Removal target: v1.21.0
- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details` are **demoted from tools to resources**. MCP clients that previously called these tools must switch to fetching `iam://templates`,
 `iam://checks`, `iam://sensitive-actions/{category}`, `iam://checks/{check_id}`
- FastMCP minimum bumped to `>=3.2,<4`. Users on `fastmcp<3` must upgrade via `uv sync --extra mcp`
- **Breaking (noise reduction)**: existing PR comments anchored to suppressed check IDs become orphans on the next run and are cleaned up automatically. Set `suppress_superseded_findings: false` to restore all
findings

## Test plan

- [x] `uv run ruff format --check .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run pytest -m "not benchmark and not slow"` — **1480 passed, 23 skipped**
- [x] 241 MCP-specific tests pass (incl. 19 new accuracy tests, 7 transport round-trip tests, 9 profile gating tests)
- [x] `mkdocs build --strict` clean
- [x] `iam-validator-mcp --help` shows new flags
- [x] `iam-validator-mcp --list-profiles` prints taxonomy and exits
- [x] Manual smoke test: connect from Claude Desktop with `--profile validate-only`, validate a policy
- [x] Manual smoke test: connect with `--custom-checks-dir examples/custom_checks`, trigger a custom check
- [ ] Manual smoke test: `aws_access_analyzer_validate` against a real AWS account (requires credentials)

## Files changed

  ```
  34 files changed, ~3600 insertions, ~1000 deletions

  NEW:
    iam_validator/mcp/check_metadata.py       — curated examples for 12 checks
    iam_validator/mcp/tools/analyze.py        — Access Analyzer wrapper
    tests/mcp/test_accuracy_fixes.py          — 19 accuracy/hardening tests
    tests/mcp/test_analyze.py                 — Access Analyzer + cached session tests
    tests/mcp/test_build_arn.py               — placeholder dict + deprecation tests
    tests/mcp/test_check_metadata.py          — registry coverage tests
    tests/mcp/test_constants_alignment.py     — guardrail tests
    tests/mcp/test_profiles.py                — tag-based gating tests
    tests/mcp/test_transport.py               — FastMCP Client round-trip tests
    tests/core/test_full_wildcard_suppression.py — supersedes feature tests
  ```