### PR TITLE
chore: finalize 1.20.0 CHANGELOG — release date + compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to IAM Policy Validator are documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.20.0] - Unreleased
+## [1.20.0] - 2026-05-01
 
 ### Added
 
@@ -723,6 +723,7 @@ _First release._
 
 ---
 
+[1.20.0]: https://github.com/boogy/iam-policy-validator/compare/v1.19.1...v1.20.0
 [1.19.1]: https://github.com/boogy/iam-policy-validator/compare/v1.19.0...v1.19.1
 [1.19.0]: https://github.com/boogy/iam-policy-validator/compare/v1.18.2...v1.19.0
 [1.18.2]: https://github.com/boogy/iam-policy-validator/compare/v1.18.1...v1.18.2


### PR DESCRIPTION
Finalizes the v1.20.0 release notes ahead of tagging.

- Set release date: `## [1.20.0] - 2026-05-01`
- Add `[1.20.0]` compare link (v1.19.1...v1.20.0)

Mirrors the pattern used for 1.19.0 (7470c90). After this merges, I'll create
and push the signed `v1.20.0` tag from main.