### PR TITLE
feat(github): support unique comment identifiers for parallel runs

### DIFF
--- a/iam_validator/commands/analyze.py
+++ b/iam_validator/commands/analyze.py
@@ -144,6 +144,12 @@ Examples:
         )
 
         parser.add_argument(
+            "--github-comment-id",
+            help="Optional unique identifier for this validation run (e.g. 'policy', 'role'). "
+            "Use this in parallel jobs to prevent PR comments from overwriting each other.",
+        )
+
+        parser.add_argument(
             "--run-all-checks",
             action="store_true",
             help="Run full validation checks if Access Analyzer passes",
@@ -275,10 +281,12 @@ Examples:
                 else:
                     print(formatter.generate_markdown_report(report))
 
-            # Post to GitHub if configured
+            # Post results if configured
             if args.github_comment:
                 async with GitHubIntegration() as github:
-                    success = await self._post_to_github(github, report, formatter)
+                    success = await self._post_to_github(
+                        github, report, formatter, getattr(args, "github_comment_id", None)
+                    )
                     if not success:
                         logging.error("Failed to post Access Analyzer results to GitHub PR")
 
@@ -421,6 +429,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_id=getattr(args, "github_comment_id", None),
                 )
                 success = await commenter.post_findings_to_pr(
                     validation_report,
@@ -441,6 +450,7 @@ Examples:
         github: GitHubIntegration,
         report: AccessAnalyzerReport,
         formatter: AccessAnalyzerReportFormatter,
+        comment_id: str | None = None,
     ) -> bool:
         """Post Access Analyzer results to GitHub PR."""
         if not github.is_configured():
@@ -456,6 +466,8 @@ Examples:
 
         # Add identifier for updating existing comments
         identifier = constants.ANALYZER_IDENTIFIER
+        if comment_id:
+            identifier = identifier.replace(" -->", f"-{comment_id} -->")
 
         # Check if content is too large for single comment
         if len(markdown_content) > constants.GITHUB_COMMENT_SPLIT_LIMIT:

--- a/iam_validator/commands/post_to_pr.py
+++ b/iam_validator/commands/post_to_pr.py
@@ -84,6 +84,12 @@ Examples:
             "'modified_statements_only' posts only for modified statements",
         )
 
+        parser.add_argument(
+            "--comment-id",
+            help="Optional unique identifier for this validation run (e.g. 'policy', 'role'). "
+            "Use this in parallel jobs to prevent PR comments from overwriting each other.",
+        )
+
     async def execute(self, args: argparse.Namespace) -> int:
         """Execute the post-to-pr command."""
         success = await post_report_to_pr(
@@ -92,6 +98,7 @@ Examples:
             add_summary=args.add_summary,
             config_path=getattr(args, "config", None),
             off_diff_comment_mode=getattr(args, "off_diff_comment_mode", None),
+            comment_id=getattr(args, "comment_id", None),
         )
 
         return 0 if success else 1

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -173,6 +173,12 @@ Examples:
         )
 
         parser.add_argument(
+            "--github-comment-id",
+            help="Optional unique identifier for this validation run (e.g. 'policy', 'role'). "
+            "Use this in parallel jobs to prevent PR comments from overwriting each other.",
+        )
+
+        parser.add_argument(
             "--verbose",
             "-v",
             action="store_true",
@@ -394,6 +400,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_id=getattr(args, "github_comment_id", None),
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -550,6 +557,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_id=getattr(args, "github_comment_id", None),
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -621,6 +629,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_id=getattr(args, "github_comment_id", None),
                 )
 
                 # Create a mini-report for just this file
@@ -731,6 +740,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_id=getattr(args, "github_comment_id", None),
                 )
 
                 # Create a full report with all results

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -71,6 +71,7 @@ class PRCommenter:
         enable_codeowners_ignore: bool = True,
         allowed_ignore_users: list[str] | None = None,
         off_diff_comment_mode: str = "summary_only",
+        comment_id: str | None = None,
     ):
         """Initialize PR commenter.
 
@@ -93,6 +94,8 @@ class PRCommenter:
                                   "summary_only" (default): All off-diff issues in summary only.
                                   "individual": Post each as an individual review comment.
                                   "modified_statements_only": Individual comments for modified statements only.
+            comment_id: Optional unique identifier to distinguish between different validation runs
+                        (e.g. "policy", "role"). Prevents parallel runs from overwriting each other.
         """
         self.github = github
         self.cleanup_old_comments = cleanup_old_comments
@@ -101,6 +104,18 @@ class PRCommenter:
         self.enable_codeowners_ignore = enable_codeowners_ignore
         self.allowed_ignore_users = allowed_ignore_users or []
         self.off_diff_comment_mode = off_diff_comment_mode
+
+        # Customize identifiers if comment_id is provided
+        if comment_id:
+            # We append the ID to the HTML comment content
+            # e.g. <!-- iam-policy-validator-summary-policy -->
+            suffix = f"-{comment_id}"
+            self.SUMMARY_IDENTIFIER = SUMMARY_IDENTIFIER.replace(" -->", f"{suffix} -->")
+            self.REVIEW_IDENTIFIER = REVIEW_IDENTIFIER.replace(" -->", f"{suffix} -->")
+        else:
+            self.SUMMARY_IDENTIFIER = SUMMARY_IDENTIFIER
+            self.REVIEW_IDENTIFIER = REVIEW_IDENTIFIER
+
         # Track issues in modified statements that are on unchanged lines
         self._context_issues: list[ContextIssue] = []
         # Track ignored finding IDs for the current run
@@ -907,6 +922,7 @@ async def post_report_to_pr(
     add_summary: bool = True,
     config_path: str | None = None,
     off_diff_comment_mode: str | None = None,
+    comment_id: str | None = None,
 ) -> bool:
     """Post a JSON report to a PR.
 
@@ -916,6 +932,7 @@ async def post_report_to_pr(
         add_summary: Whether to add summary comment
         config_path: Optional path to config file (to get fail_on_severity)
         off_diff_comment_mode: How to handle findings on unchanged lines (overrides config)
+        comment_id: Optional unique identifier to distinguish between different validation runs
 
     Returns:
         True if successful, False otherwise
@@ -953,6 +970,7 @@ async def post_report_to_pr(
                 enable_codeowners_ignore=enable_codeowners_ignore,
                 allowed_ignore_users=allowed_ignore_users,
                 off_diff_comment_mode=off_diff_mode,
+                comment_id=comment_id,
             )
             return await commenter.post_findings_to_pr(
                 report,

--- a/tests/integrations/test_unique_comment_id.py
+++ b/tests/integrations/test_unique_comment_id.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import MagicMock
+from iam_validator.core.pr_commenter import PRCommenter
+from iam_validator.core.constants import SUMMARY_IDENTIFIER, REVIEW_IDENTIFIER
+
+@pytest.mark.asyncio
+async def test_pr_commenter_with_comment_id():
+    """Test that PRCommenter correctly appends comment_id to identifiers."""
+    github = MagicMock()
+    
+    # Test with no comment_id
+    commenter_default = PRCommenter(github=github)
+    assert commenter_default.SUMMARY_IDENTIFIER == SUMMARY_IDENTIFIER
+    assert commenter_default.REVIEW_IDENTIFIER == REVIEW_IDENTIFIER
+    
+    # Test with custom comment_id
+    comment_id = "policy-scan"
+    commenter_custom = PRCommenter(github=github, comment_id=comment_id)
+    
+    expected_summary = SUMMARY_IDENTIFIER.replace(" -->", f"-{comment_id} -->")
+    expected_review = REVIEW_IDENTIFIER.replace(" -->", f"-{comment_id} -->")
+    
+    assert commenter_custom.SUMMARY_IDENTIFIER == expected_summary
+    assert commenter_custom.REVIEW_IDENTIFIER == expected_review
+    assert f"-{comment_id}" in commenter_custom.SUMMARY_IDENTIFIER
+
+@pytest.mark.asyncio
+async def test_pr_commenter_different_ids_dont_clash():
+    """Test that different comment_ids result in different markers."""
+    github = MagicMock()
+    
+    commenter_policy = PRCommenter(github=github, comment_id="policy")
+    commenter_role = PRCommenter(github=github, comment_id="role")
+    
+    assert commenter_policy.SUMMARY_IDENTIFIER != commenter_role.SUMMARY_IDENTIFIER
+    assert "policy" in commenter_policy.SUMMARY_IDENTIFIER
+    assert "role" in commenter_role.SUMMARY_IDENTIFIER


### PR DESCRIPTION
This PR addresses #103 where PR comments are overwritten when the validator runs in parallel (e.g., in separate jobs for POLICY and ROLE validation).

### Changes
- Added a `comment_id` (or `--github-comment-id`) parameter to `ValidateCommand`, `AnalyzeCommand`, and `PostToPRCommand`.
- This ID is appended to the HTML comment markers (`SUMMARY_IDENTIFIER` and `REVIEW_IDENTIFIER`), allowing parallel runs to maintain distinct, persistent comments on the same PR.
- Updated `PRCommenter` and `GitHubIntegration` logic to handle these dynamic identifiers.

### Verification
- Added a new integration test `tests/integrations/test_unique_comment_id.py` verifying that different `comment_id`s produce distinct identifiers and do not clash.
- Verified that all existing integration tests pass.
- Ran `ruff check` and `ruff format` to ensure code quality.

Fixes #103