### PR TITLE
fix(github): scope PR comment markers per run to fix parallel-run overwrites (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,120 +2,89 @@
 
 All notable changes to IAM Policy Validator are documented in this file.
 
-The format is based on [Common Changelog](https://common-changelog.org/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.21.0]
+
+### Added
+
+- `--comment-tag <TAG>` flag on `validate`, `analyze`, and `post-to-pr` commands, plus matching `comment-tag` GitHub Action input and `comment_tag:` config setting. When set, PR summary, review,
+  analyzer, and ignored-findings HTML markers are suffixed with `:<TAG>` so multiple validator runs on the same PR (e.g. one per policy type) maintain independent comment threads instead of
+  overwriting each other (#103).
+- `iam_validator.core.constants.scoped_marker(base, tag)` helper and `COMMENT_TAG_PATTERN` regex (`[A-Za-z0-9._-]{1,32}`) — single source of truth for tag validation and marker scoping.
+- `PRCommenter(..., comment_tag=...)`, `IgnoredFindingsStore(..., comment_tag=...)`, `IgnoreCommandProcessor(..., comment_tag=...)`, and `filter_ignored_findings(..., comment_tag=...)` constructor /
+  function parameters.
+- `ValidationIssue.to_pr_comment(..., review_identifier=...)` parameter so producer and consumer of inline review comments use the same scoped marker.
+
+### Fixed
+
+- PR comments overwriting each other when validator runs in parallel for different policy types (e.g. POLICY + ROLE). Pre-fix, every run shared the same hardcoded HTML markers (`SUMMARY_IDENTIFIER`,
+  `REVIEW_IDENTIFIER`, `ANALYZER_IDENTIFIER`, `IGNORED_FINDINGS_IDENTIFIER`) and the second run's `update_or_create_*` flow PATCHed the first run's canonical comment. Setting distinct `--comment-tag`
+  values per run scopes each run's markers so independent comment threads coexist on the PR (#103).
+
+### Compatibility
+
+- Backward compatible: when `--comment-tag` / `comment_tag:` is unset (the default), the legacy markers are produced byte-for-byte and `IgnoredFindingsStore` continues to load comments stored under
+  the pre-1.21.0 un-scoped marker. Existing PR comments and stored ignores remain matchable without any user action.
 
 ## [1.20.0] - 2026-05-01
 
 ### Added
 
-- `suppress_superseded_findings` setting (default `true`): when a bare
-  `Allow Action:* Resource:*` statement is detected, a single `critical` finding from
-  `full_wildcard` is surfaced and all redundant statement-level and policy-level
-  findings for that statement are suppressed — including custom checks. Sibling
-  statements are unaffected. Set to `false` to restore the previous behaviour.
-- `Statement.is_full_wildcard_allow()` predicate and `PolicyCheck.supersedes` /
-  `PolicyCheck.matches()` extension points (zero-cost defaults for existing checks).
-- Centralized `IAM_POLICY_VERSION_CURRENT` / `IAM_POLICY_VERSION_LEGACY` /
-  `IAM_POLICY_VERSIONS_VALID` in `iam_validator/core/constants.py` so MCP, fix tools,
-  and templates source the IAM policy language version from one place.
-- `iam_validator/mcp/check_metadata.py` — curated examples and fix steps for 12
-  built-in checks. MCP `get_issue_guidance` and `get_check_details` now return
-  registry-driven defaults for any registered check (previously hardcoded for
-  5–6 checks).
-- MCP `--custom-checks-dir` and `--aws-services-dir` flags (CLI parity). Paths
-  are stored on `SessionConfigManager` and forwarded to `validate_policies()`
-  by the validation tools.
-- MCP `aws_access_analyzer_validate` tool — wraps AWS Access Analyzer
-  ValidatePolicy in `asyncio.to_thread`. Lifespan caches `boto3.Session`
-  instances per `(region, profile)` to amortise the ~50 ms session-construction
-  cost across calls.
-- `AccessAnalyzerValidator(session=...)` keyword argument so MCP can pass a
-  shared boto3 session instead of reconstructing one per call.
-- MCP `--profile {full,validate-only,validate-and-query,no-generation,read-only}`
-  flag for token-efficient sessions (FastMCP tag-based gating). `--list-profiles`
-  prints the taxonomy and exits.
-- MCP `get_active_profile` tool — introspect the active profile and the tools
-  it currently exposes.
-- MCP `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
-  `openWorldHint`) on every registered tool so MCP clients can reason about
-  side-effects without parsing names.
-- Parameterised resources `iam://sensitive-actions/{category}` and
-  `iam://checks/{check_id}` (replace the demoted tools — see Compatibility).
-- FastMCP in-process `Client` transport tests (`tests/mcp/test_transport.py`)
-  for protocol-level coverage of tool registration, annotations, profiles,
-  and tool errors.
+- `suppress_superseded_findings` setting (default `true`): when a bare `Allow Action:* Resource:*` statement is detected, a single `critical` finding from `full_wildcard` is surfaced and all redundant
+  statement-level and policy-level findings for that statement are suppressed — including custom checks. Sibling statements are unaffected. Set to `false` to restore the previous behaviour.
+- `Statement.is_full_wildcard_allow()` predicate and `PolicyCheck.supersedes` / `PolicyCheck.matches()` extension points (zero-cost defaults for existing checks).
+- Centralized `IAM_POLICY_VERSION_CURRENT` / `IAM_POLICY_VERSION_LEGACY` / `IAM_POLICY_VERSIONS_VALID` in `iam_validator/core/constants.py` so MCP, fix tools, and templates source the IAM policy
+  language version from one place.
+- `iam_validator/mcp/check_metadata.py` — curated examples and fix steps for 12 built-in checks. MCP `get_issue_guidance` and `get_check_details` now return registry-driven defaults for any registered
+  check (previously hardcoded for 5–6 checks).
+- MCP `--custom-checks-dir` and `--aws-services-dir` flags (CLI parity). Paths are stored on `SessionConfigManager` and forwarded to `validate_policies()` by the validation tools.
+- MCP `aws_access_analyzer_validate` tool — wraps AWS Access Analyzer ValidatePolicy in `asyncio.to_thread`. Lifespan caches `boto3.Session` instances per `(region, profile)` to amortise the ~50 ms
+  session-construction cost across calls.
+- `AccessAnalyzerValidator(session=...)` keyword argument so MCP can pass a shared boto3 session instead of reconstructing one per call.
+- MCP `--profile {full,validate-only,validate-and-query,no-generation,read-only}` flag for token-efficient sessions (FastMCP tag-based gating). `--list-profiles` prints the taxonomy and exits.
+- MCP `get_active_profile` tool — introspect the active profile and the tools it currently exposes.
+- MCP `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) on every registered tool so MCP clients can reason about side-effects without parsing names.
+- Parameterised resources `iam://sensitive-actions/{category}` and `iam://checks/{check_id}` (replace the demoted tools — see Compatibility).
+- FastMCP in-process `Client` transport tests (`tests/mcp/test_transport.py`) for protocol-level coverage of tool registration, annotations, profiles, and tool errors.
 
 ### Changed
 
-- MCP `build_arn` validates the `partition` argument against `ARN_PARTITION_REGEX`
-  and rejects unknown partitions instead of silently accepting them. Supported
-  partitions: `aws`, `aws-cn`, `aws-us-gov`, `aws-eusc`, `aws-iso`, `aws-iso-b`,
-  `aws-iso-e`, `aws-iso-f`.
-- MCP `get_issue_guidance` / `get_check_details` now source description and
-  default severity from the check registry. Curated examples / fix steps live in
-  `iam_validator/mcp/check_metadata.py`. The `related_tools` field has been
-  renamed to `related` (covers both tools and resource URIs).
-- MCP `build_arn` now consults the live AWS service reference (cached) instead
-  of a hardcoded 9-service map. Supports all partitions in `ARN_PARTITION_REGEX`
-  (incl. `aws-eusc`, `aws-iso*`) and multi-placeholder ARN templates via a new
-  `placeholders` dict argument. Returns `{arn, valid, notes, format_template,
-  unfilled_placeholders}`. The `resource_name` argument is deprecated (removal
+- MCP `build_arn` validates the `partition` argument against `ARN_PARTITION_REGEX` and rejects unknown partitions instead of silently accepting them. Supported partitions: `aws`, `aws-cn`,
+  `aws-us-gov`, `aws-eusc`, `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`.
+- MCP `get_issue_guidance` / `get_check_details` now source description and default severity from the check registry. Curated examples / fix steps live in `iam_validator/mcp/check_metadata.py`. The
+  `related_tools` field has been renamed to `related` (covers both tools and resource URIs).
+- MCP `build_arn` now consults the live AWS service reference (cached) instead of a hardcoded 9-service map. Supports all partitions in `ARN_PARTITION_REGEX` (incl. `aws-eusc`, `aws-iso*`) and
+  multi-placeholder ARN templates via a new `placeholders` dict argument. Returns `{arn, valid, notes, format_template, unfilled_placeholders}`. The `resource_name` argument is deprecated (removal
   target v1.21.0) — pass `placeholders={...}` instead.
-- Single-call MCP query tools (`query_service_actions`, `query_action_details`,
-  `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`) now
-  reuse the lifespan-managed `AWSServiceFetcher` instead of constructing a new
-  one per call. Fewer HTTP connections, warmer cache. `validate_policy` /
-  `validate_policies_batch` continue to construct their fetcher inside
+- Single-call MCP query tools (`query_service_actions`, `query_action_details`, `expand_wildcard_action`, `query_condition_keys`, `query_arn_formats`) now reuse the lifespan-managed
+  `AWSServiceFetcher` instead of constructing a new one per call. Fewer HTTP connections, warmer cache. `validate_policy` / `validate_policies_batch` continue to construct their fetcher inside
   `validate_policies()` — see follow-up issue for fetcher reuse there.
-- `validate_policies_batch` accepts a `max_concurrency` parameter (default 10)
-  and uses an `asyncio.Semaphore` to cap parallel validations.
+- `validate_policies_batch` accepts a `max_concurrency` parameter (default 10) and uses an `asyncio.Semaphore` to cap parallel validations.
 - `get_shared_fetcher` log noise demoted from WARNING to DEBUG.
-- FastMCP minimum bumped from `>=2.14.1` to `>=3.2,<4` — we now rely on v3
-  `enable(only=True)` semantics for tag-based gating.
-- MCP `BASE_INSTRUCTIONS` slimmed from ~2.6 KB to ~700 chars: per-tool
-  guardrails relocated to individual tool docstrings; the server-level
-  instructions retain only Core Principles, Absolute Rules, the Validation
-  Loop Prevention guardrail, and resource pointers.
-- MCP `explain_policy` now sources access-level classification from the live
-  AWS service reference (Read/Write/List/Tagging/Permissions management)
-  instead of a name-prefix heuristic. Surfaces `NotAction`/`NotResource`/
-  `Principal:*`/`NotPrincipal` as explicit security concerns. Effect comparison
-  is case-insensitive.
-- MCP `compare_policies` now uses canonical statement signatures (effect +
-  sorted actions/resources/principals + canonical-JSON conditions) instead of
-  positional indexing. Reports added/removed `NotAction`, `NotResource`,
-  `Principal`, `NotPrincipal`, and condition keys independently. No more
-  phantom diffs from re-ordering Sid-less statements.
-- MCP `aws_access_analyzer_validate` adds a `partition` argument and defaults
-  `region` to the canonical region per partition (e.g. `aws-cn` → `cn-north-1`,
-  `aws-us-gov` → `us-gov-west-1`). Adds `timeout_seconds` (default 30s) so a
-  hung AWS endpoint cannot block the MCP server. Centralized in
-  `core/constants.PARTITION_DEFAULT_REGION`.
-- MCP `fix_policy_issues` action-case normalization now also handles
-  `NotAction` (previously only `Action`). `unfixed_issues` always returns a
-  list; `unfixed_count` is exposed separately for clients that want the count.
-- MCP `quick_validate` `wildcards_detected` now correctly fires for
-  `full_wildcard` issues (previously missed; only the three lower-severity
-  wildcard checks were in the set).
-- MCP DRY: extracted `issue_to_dict()` helper in `mcp/tools/validation.py`.
-  `validate_policy`, `validate_policies_batch`, `generate_policy_from_template`,
-  `build_minimal_policy`, and `fix_policy_issues` all use it — single source of
-  truth for the verbose-vs-lean issue projection.
+- FastMCP minimum bumped from `>=2.14.1` to `>=3.2,<4` — we now rely on v3 `enable(only=True)` semantics for tag-based gating.
+- MCP `BASE_INSTRUCTIONS` slimmed from ~2.6 KB to ~700 chars: per-tool guardrails relocated to individual tool docstrings; the server-level instructions retain only Core Principles, Absolute Rules,
+  the Validation Loop Prevention guardrail, and resource pointers.
+- MCP `explain_policy` now sources access-level classification from the live AWS service reference (Read/Write/List/Tagging/Permissions management) instead of a name-prefix heuristic. Surfaces
+  `NotAction`/`NotResource`/ `Principal:*`/`NotPrincipal` as explicit security concerns. Effect comparison is case-insensitive.
+- MCP `compare_policies` now uses canonical statement signatures (effect + sorted actions/resources/principals + canonical-JSON conditions) instead of positional indexing. Reports added/removed
+  `NotAction`, `NotResource`, `Principal`, `NotPrincipal`, and condition keys independently. No more phantom diffs from re-ordering Sid-less statements.
+- MCP `aws_access_analyzer_validate` adds a `partition` argument and defaults `region` to the canonical region per partition (e.g. `aws-cn` → `cn-north-1`, `aws-us-gov` → `us-gov-west-1`). Adds
+  `timeout_seconds` (default 30s) so a hung AWS endpoint cannot block the MCP server. Centralized in `core/constants.PARTITION_DEFAULT_REGION`.
+- MCP `fix_policy_issues` action-case normalization now also handles `NotAction` (previously only `Action`). `unfixed_issues` always returns a list; `unfixed_count` is exposed separately for clients
+  that want the count.
+- MCP `quick_validate` `wildcards_detected` now correctly fires for `full_wildcard` issues (previously missed; only the three lower-severity wildcard checks were in the set).
+- MCP DRY: extracted `issue_to_dict()` helper in `mcp/tools/validation.py`. `validate_policy`, `validate_policies_batch`, `generate_policy_from_template`, `build_minimal_policy`, and
+  `fix_policy_issues` all use it — single source of truth for the verbose-vs-lean issue projection.
 
 ### Fixed (P0 — accuracy)
 
-- MCP `validate_policy` (and every wrapper that calls it) now wraps malformed
-  input in a clean `ToolError` instead of letting Pydantic's `ValidationError`
-  stack trace leak through the MCP protocol.
-- MCP `--instructions` and `--instructions-file` are now in an argparse
-  mutually-exclusive group. Previously `--instructions` was silently ignored
-  if both were supplied.
+- MCP `validate_policy` (and every wrapper that calls it) now wraps malformed input in a clean `ToolError` instead of letting Pydantic's `ValidationError` stack trace leak through the MCP protocol.
+- MCP `--instructions` and `--instructions-file` are now in an argparse mutually-exclusive group. Previously `--instructions` was silently ignored if both were supplied.
 
 ### Removed (demoted to resources)
 
-- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details`
-  are no longer registered as MCP tools. Fetch them via the resource URIs:
+- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details` are no longer registered as MCP tools. Fetch them via the resource URIs:
   - `iam://templates`
   - `iam://checks`
   - `iam://sensitive-actions/{category}`
@@ -133,23 +102,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compatibility
 
-- Default MCP profile is `full` — existing Claude Desktop / Cursor configs see
-  no behavioural change unless they explicitly pass `--profile`.
-- `--profile` requires a server restart to take effect — MCP clients cache
-  tool catalogs per session.
-- `build_arn(resource_name=...)` is **deprecated** and emits a warning. Prefer
-  `placeholders={...}`. Removal target: v1.21.0.
-- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details`
-  are **demoted from tools to resources**. MCP clients that previously called
-  these tools must switch to fetching the corresponding resource URI.
-- FastMCP minimum bumped to `>=3.2,<4`. Users on `fastmcp<3` must upgrade
-  via `uv sync --extra mcp`.
+- Default MCP profile is `full` — existing Claude Desktop / Cursor configs see no behavioural change unless they explicitly pass `--profile`.
+- `--profile` requires a server restart to take effect — MCP clients cache tool catalogs per session.
+- `build_arn(resource_name=...)` is **deprecated** and emits a warning. Prefer `placeholders={...}`. Removal target: v1.21.0.
+- `list_templates`, `list_checks`, `list_sensitive_actions`, `get_check_details` are **demoted from tools to resources**. MCP clients that previously called these tools must switch to fetching the
+  corresponding resource URI.
+- FastMCP minimum bumped to `>=3.2,<4`. Users on `fastmcp<3` must upgrade via `uv sync --extra mcp`.
 
 ### Notes
 
-- **Breaking (noise reduction):** existing PR comments anchored to the suppressed
-  check IDs become orphans on the next run and are cleaned up automatically. Set
-  `suppress_superseded_findings: false` to restore all findings.
+- **Breaking (noise reduction):** existing PR comments anchored to the suppressed check IDs become orphans on the next run and are cleaned up automatically. Set `suppress_superseded_findings: false`
+  to restore all findings.
 
 ---
 
@@ -157,18 +120,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reuse PR comments to minimize timeline noise — summary and inline review comments now update existing comments in place by id, post only the surplus, and delete only stale leftovers. Same part count across runs produces zero `POST`/`DELETE` calls
-- Centralize HTML comment markers in `iam_validator/core/constants.py` (`ANALYZER_IDENTIFIER`, `ISSUE_TYPE_MARKER_FORMAT/PATTERN`, `FINDING_ID_MARKER_FORMAT`, `FINDING_ID_STRICT/LOOSE_PATTERN`) and route every producer/parser through them. Default identifier params on `update_or_create_comment` / `post_multipart_comments` now resolve to `SUMMARY_IDENTIFIER` instead of an orphan literal
-- Centralize GitHub comment-size limits: add `GITHUB_COMMENT_HARD_LIMIT = 65536` and use the existing `GITHUB_MAX_COMMENT_LENGTH` / `GITHUB_COMMENT_SPLIT_LIMIT` from the call sites that previously inlined literals
-- Extract `ARN_PARTITION_REGEX` and source it from `DEFAULT_ARN_VALIDATION_PATTERN` and the trust-policy SAML/OIDC provider patterns so all AWS partitions (`aws`, `aws-cn`, `aws-us-gov`, `aws-eusc`, `aws-iso*`) validate consistently
+- Reuse PR comments to minimize timeline noise — summary and inline review comments now update existing comments in place by id, post only the surplus, and delete only stale leftovers. Same part count
+  across runs produces zero `POST`/`DELETE` calls
+- Centralize HTML comment markers in `iam_validator/core/constants.py` (`ANALYZER_IDENTIFIER`, `ISSUE_TYPE_MARKER_FORMAT/PATTERN`, `FINDING_ID_MARKER_FORMAT`, `FINDING_ID_STRICT/LOOSE_PATTERN`) and
+  route every producer/parser through them. Default identifier params on `update_or_create_comment` / `post_multipart_comments` now resolve to `SUMMARY_IDENTIFIER` instead of an orphan literal
+- Centralize GitHub comment-size limits: add `GITHUB_COMMENT_HARD_LIMIT = 65536` and use the existing `GITHUB_MAX_COMMENT_LENGTH` / `GITHUB_COMMENT_SPLIT_LIMIT` from the call sites that previously
+  inlined literals
+- Extract `ARN_PARTITION_REGEX` and source it from `DEFAULT_ARN_VALIDATION_PATTERN` and the trust-policy SAML/OIDC provider patterns so all AWS partitions (`aws`, `aws-cn`, `aws-us-gov`, `aws-eusc`,
+  `aws-iso*`) validate consistently
 
 ### Fixed
 
-- Fix `action_resource_matching` rejecting `s3vectors` `VectorBucket` ARNs (and any future service whose resource-type name contains `bucket` and whose pattern uses `bucket/${Name}`). The no-slash rule now keys on the ARN pattern itself, not the resource-type name
-- Fix the PR summary comment becoming stale on busy PRs (lookup wasn't paginated) and after multi-part → single-part transitions (orphans left behind). Both paths now share `_sync_comments_with_identifier`, which paginates lookup, updates oldest-first, and deletes only the surplus
+- Fix `action_resource_matching` rejecting `s3vectors` `VectorBucket` ARNs (and any future service whose resource-type name contains `bucket` and whose pattern uses `bucket/${Name}`). The no-slash
+  rule now keys on the ARN pattern itself, not the resource-type name
+- Fix the PR summary comment becoming stale on busy PRs (lookup wasn't paginated) and after multi-part → single-part transitions (orphans left behind). Both paths now share
+  `_sync_comments_with_identifier`, which paginates lookup, updates oldest-first, and deletes only the surplus
 - Fix trust-policy SAML/OIDC validation rejecting GovCloud, China, and ISO partitions — the provider patterns previously hardcoded `arn:aws:`
-- Fix `get_pr_files()` conflating API failure with an empty PR — both returned `[]`, causing the inline-review-comment cleanup phase to silently skip aggressive deletion on a transient 5xx. It now returns `None` on failure and `[]` only for genuinely empty PRs
-- Fix `_sync_comments_with_identifier` reporting `success=False` when an orphan delete returned 404 — the canonical comment was already updated, so the user-visible state is correct. 404 / transient orphan-delete errors now log a warning without failing the overall operation
+- Fix `get_pr_files()` conflating API failure with an empty PR — both returned `[]`, causing the inline-review-comment cleanup phase to silently skip aggressive deletion on a transient 5xx. It now
+  returns `None` on failure and `[]` only for genuinely empty PRs
+- Fix `_sync_comments_with_identifier` reporting `success=False` when an orphan delete returned 404 — the canonical comment was already updated, so the user-visible state is correct. 404 / transient
+  orphan-delete errors now log a warning without failing the overall operation
 
 ---
 
@@ -176,51 +147,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Claude Code skill at `skills/iam-policy-validator/` with `.claude-plugin/` marketplace manifest — users can install a CLI-based Claude Code plugin via `/plugin marketplace add boogy/iam-policy-validator` and `/plugin install iam-policy-validator@iam-policy-validator`, providing a CLI-based alternative to the MCP server. See [Claude Code Skill](https://boogy.github.io/iam-policy-validator/integrations/claude-code-skill/)
-- Add `ValidationReport.policies_with_errors` and `ValidationReport.policies_with_findings` computed properties to express "structurally invalid" vs. "has findings" separately from the `fail_on_severities`-gated `invalid_policies` counter
-- Add per-file policy-type auto-detection when `--policy-type` is omitted — each policy's type is resolved via a first-match-wins priority chain (`policy_types:` glob mapping in config → content auto-detection → fallback to `IDENTITY_POLICY`). Trust policies and resource policies are now detected automatically; SCP/RCP still require an explicit flag or glob mapping because they share the identity-policy shape. See the [Policy Type Resolution](https://boogy.github.io/iam-policy-validator/user-guide/configuration/#policy-type-resolution) documentation
-- Add `policy_types:` YAML config entry — a list of `{pattern, type}` entries that maps file globs to `PolicyType` values (e.g., `**/scp/*.json` → `SERVICE_CONTROL_POLICY`). Consulted only when `--policy-type` is not provided
-- Add `policy_type` keyword argument to `iam_validator.sdk.shortcuts.validate_file`, `validate_directory`, `validate_json`, and `quick_validate` so Python SDK callers get the same explicit-or-auto semantics as the CLI
-- Add machine-greppable per-policy debug log line in the orchestrator — runs with `--log-level debug` / `--verbose` emit exactly one `policy_type=<TYPE> source=cli-flag|config-glob|auto-detect|default file=<path>` line per policy (the `config-glob` source also includes `pattern='...'`), making misresolution trivial to audit
+- Add Claude Code skill at `skills/iam-policy-validator/` with `.claude-plugin/` marketplace manifest — users can install a CLI-based Claude Code plugin via
+  `/plugin marketplace add boogy/iam-policy-validator` and `/plugin install iam-policy-validator@iam-policy-validator`, providing a CLI-based alternative to the MCP server. See
+  [Claude Code Skill](https://boogy.github.io/iam-policy-validator/integrations/claude-code-skill/)
+- Add `ValidationReport.policies_with_errors` and `ValidationReport.policies_with_findings` computed properties to express "structurally invalid" vs. "has findings" separately from the
+  `fail_on_severities`-gated `invalid_policies` counter
+- Add per-file policy-type auto-detection when `--policy-type` is omitted — each policy's type is resolved via a first-match-wins priority chain (`policy_types:` glob mapping in config → content
+  auto-detection → fallback to `IDENTITY_POLICY`). Trust policies and resource policies are now detected automatically; SCP/RCP still require an explicit flag or glob mapping because they share the
+  identity-policy shape. See the [Policy Type Resolution](https://boogy.github.io/iam-policy-validator/user-guide/configuration/#policy-type-resolution) documentation
+- Add `policy_types:` YAML config entry — a list of `{pattern, type}` entries that maps file globs to `PolicyType` values (e.g., `**/scp/*.json` → `SERVICE_CONTROL_POLICY`). Consulted only when
+  `--policy-type` is not provided
+- Add `policy_type` keyword argument to `iam_validator.sdk.shortcuts.validate_file`, `validate_directory`, `validate_json`, and `quick_validate` so Python SDK callers get the same explicit-or-auto
+  semantics as the CLI
+- Add machine-greppable per-policy debug log line in the orchestrator — runs with `--log-level debug` / `--verbose` emit exactly one
+  `policy_type=<TYPE> source=cli-flag|config-glob|auto-detect|default file=<path>` line per policy (the `config-glob` source also includes `pattern='...'`), making misresolution trivial to audit
 
 ### Changed
 
-- Clarify PR summary terminology — replace the "Valid Policies" / "Invalid Policies" rows with "Policies with Errors (AWS-invalid)" and "Policies with Findings" so a policy flagged only for security or best-practice issues is no longer mislabeled as invalid. The same wording now applies to the GitHub Actions step summary, Rich console output, and the enhanced / CSV / HTML / markdown formatters
-- **CSV output schema change**: the `Valid Policies (IAM)`, `Invalid Policies (IAM)`, and `Policies with Security Findings` rows have been replaced by `Policies with Errors (AWS-invalid)` and `Policies with Findings`. Downstream CSV consumers must update column expectations
+- Clarify PR summary terminology — replace the "Valid Policies" / "Invalid Policies" rows with "Policies with Errors (AWS-invalid)" and "Policies with Findings" so a policy flagged only for security
+  or best-practice issues is no longer mislabeled as invalid. The same wording now applies to the GitHub Actions step summary, Rich console output, and the enhanced / CSV / HTML / markdown formatters
+- **CSV output schema change**: the `Valid Policies (IAM)`, `Invalid Policies (IAM)`, and `Policies with Security Findings` rows have been replaced by `Policies with Errors (AWS-invalid)` and
+  `Policies with Findings`. Downstream CSV consumers must update column expectations
 - `ValidationReport.get_summary()` string format changed (now reports `clean` / `with errors` / `with findings` instead of `valid` / `invalid`). Code parsing this human-readable summary must update
-- Reclassify `action_condition_enforcement` default severity from `error` to `high` — missing an organizational condition (MFA, IP, tags) is a security concern rather than an AWS-rejectable structural error. The check now appears under "Policies with Findings" instead of "Policies with Errors (AWS-invalid)"; users who rely on the previous severity can restore it via `checks.action_condition_enforcement.severity: error` in config
-- Expose `policies_with_errors` and `policies_with_findings` as Pydantic `@computed_field`s so they appear in `ValidationReport.model_dump()` and the JSON formatter output, matching the terminology used by every other formatter
-- Expand `RCP_SUPPORTED_SERVICES` to reflect the current AWS Resource Control Policy service list (per [AWS Organizations docs](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_rcps.html)) — adds `cognito-idp`, `cognito-identity`, `dynamodb`, `ecr`, `aoss` (OpenSearch Serverless), and `logs` (CloudWatch Logs) alongside the existing `s3`, `sts`, `sqs`, `kms`, `secretsmanager`. The `policy_type_validation` check no longer emits `unsupported_rcp_service` false positives for policies targeting these services. Note: RCPs cover Amazon OpenSearch **Serverless** (`aoss`) but not the classic Amazon OpenSearch Service (`es`), and do not apply to `kms:RetireGrant` or AWS-managed KMS keys
-- Change `--policy-type` default from `IDENTITY_POLICY` to auto-resolution. Pipelines that previously relied on the implicit default still behave identically for identity-only policies; directories mixing identity, trust, and resource policies now get the correct type per file without extra flags. The `cli-flag` path is unchanged — supplying `--policy-type` still forces that value on every policy in the run
-- Extend `iam_validator.checks.policy_structure.detect_policy_type()` to return `TRUST_POLICY` when the strict `is_trust_policy()` heuristic matches (Principal + exact `sts:AssumeRole*` action + `Effect: Allow` + no specific resource ARNs). Previous behavior returned `RESOURCE_POLICY` for trust-shaped policies and required an explicit flag to distinguish them
-- Align the MCP `validate_policy` tool's auto-detection with the canonical CLI detector — `iam_validator.mcp.tools.validation._detect_policy_type` now delegates to `iam_validator.checks.policy_structure.detect_policy_type`, so a trust policy posted via MCP is now classified as `trust` using the same strict rules as the CLI (prior MCP logic was more permissive)
-- Refresh `uv.lock` with `uv lock --upgrade` to pick up the newest versions compatible with the existing `>=` constraints in `pyproject.toml`. Notable jumps across majors: `fastmcp` 2.x → 3.2.4, `rich` 14.x → 15.0.0, `starlette` 0.52 → 1.0.0 (transitive), `pydantic` 2.12.5 → 2.13.3, `mypy` 1.19 → 1.20, `ruff` 0.15.0 → 0.15.11, `mcp` 1.26 → 1.27, plus the Q1 2026 ecosystem renames pulled in as transitives (`griffe` → `griffelib` by pawamoy, `mkdocs` → `properdocs` by Tom Christie, and `uncalled-for` as fastmcp's new async-DI dependency). Pure refresh — no version pins in `pyproject.toml` were changed, so anyone installing via pip with `>=` constraints gets the same resolution
-- Update `tests/mcp/test_server_integration.py` to use FastMCP 3.x public async APIs (`await mcp.list_tools()`, `await mcp.list_resources()`) instead of the 2.x internal `_tool_manager._tools` / `_resource_manager._resources` dicts that no longer exist. Affects tests only; the MCP server code itself was already using supported decorators (`@mcp.tool`, `@mcp.resource`) and needed no change
-- Restructure `.github/workflows/release.yml` for GitHub immutable releases. The release is now created as a **draft** with all assets attached, the assets are verified, PyPI is published (with `uv publish --check-url https://pypi.org/simple/` for idempotent retries), and only then is the draft promoted to a published (immutable) release. Three guard rails fail the job early: (1) a previously-published release for the tag blocks re-tagging; (2) a PyPI version that already exists with no draft release blocks re-tagging (PyPI versions are permanent); (3) the build must produce both wheel and sdist before the draft is created. If any step between "create draft" and "publish release" fails, the workflow can be safely re-run — the draft is editable and every mutating step is idempotent
-- Re-enable rolling major (`v1`) and minor (`v1.19`) tag updates after a stable release. These are plain git refs with no GitHub Release attached, so they remain movable under immutable releases (which only freezes tags tied to a published Release). Skipped for `rc`/`beta`/`alpha` tags so pre-releases cannot promote the rolling references. The signed, version-specific `v<X.Y.Z>` tag stays authoritative
+- Reclassify `action_condition_enforcement` default severity from `error` to `high` — missing an organizational condition (MFA, IP, tags) is a security concern rather than an AWS-rejectable structural
+  error. The check now appears under "Policies with Findings" instead of "Policies with Errors (AWS-invalid)"; users who rely on the previous severity can restore it via
+  `checks.action_condition_enforcement.severity: error` in config
+- Expose `policies_with_errors` and `policies_with_findings` as Pydantic `@computed_field`s so they appear in `ValidationReport.model_dump()` and the JSON formatter output, matching the terminology
+  used by every other formatter
+- Expand `RCP_SUPPORTED_SERVICES` to reflect the current AWS Resource Control Policy service list (per
+  [AWS Organizations docs](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_rcps.html)) — adds `cognito-idp`, `cognito-identity`, `dynamodb`, `ecr`, `aoss` (OpenSearch
+  Serverless), and `logs` (CloudWatch Logs) alongside the existing `s3`, `sts`, `sqs`, `kms`, `secretsmanager`. The `policy_type_validation` check no longer emits `unsupported_rcp_service` false
+  positives for policies targeting these services. Note: RCPs cover Amazon OpenSearch **Serverless** (`aoss`) but not the classic Amazon OpenSearch Service (`es`), and do not apply to
+  `kms:RetireGrant` or AWS-managed KMS keys
+- Change `--policy-type` default from `IDENTITY_POLICY` to auto-resolution. Pipelines that previously relied on the implicit default still behave identically for identity-only policies; directories
+  mixing identity, trust, and resource policies now get the correct type per file without extra flags. The `cli-flag` path is unchanged — supplying `--policy-type` still forces that value on every
+  policy in the run
+- Extend `iam_validator.checks.policy_structure.detect_policy_type()` to return `TRUST_POLICY` when the strict `is_trust_policy()` heuristic matches (Principal + exact `sts:AssumeRole*` action +
+  `Effect: Allow` + no specific resource ARNs). Previous behavior returned `RESOURCE_POLICY` for trust-shaped policies and required an explicit flag to distinguish them
+- Align the MCP `validate_policy` tool's auto-detection with the canonical CLI detector — `iam_validator.mcp.tools.validation._detect_policy_type` now delegates to
+  `iam_validator.checks.policy_structure.detect_policy_type`, so a trust policy posted via MCP is now classified as `trust` using the same strict rules as the CLI (prior MCP logic was more permissive)
+- Refresh `uv.lock` with `uv lock --upgrade` to pick up the newest versions compatible with the existing `>=` constraints in `pyproject.toml`. Notable jumps across majors: `fastmcp` 2.x → 3.2.4,
+  `rich` 14.x → 15.0.0, `starlette` 0.52 → 1.0.0 (transitive), `pydantic` 2.12.5 → 2.13.3, `mypy` 1.19 → 1.20, `ruff` 0.15.0 → 0.15.11, `mcp` 1.26 → 1.27, plus the Q1 2026 ecosystem renames pulled in
+  as transitives (`griffe` → `griffelib` by pawamoy, `mkdocs` → `properdocs` by Tom Christie, and `uncalled-for` as fastmcp's new async-DI dependency). Pure refresh — no version pins in
+  `pyproject.toml` were changed, so anyone installing via pip with `>=` constraints gets the same resolution
+- Update `tests/mcp/test_server_integration.py` to use FastMCP 3.x public async APIs (`await mcp.list_tools()`, `await mcp.list_resources()`) instead of the 2.x internal `_tool_manager._tools` /
+  `_resource_manager._resources` dicts that no longer exist. Affects tests only; the MCP server code itself was already using supported decorators (`@mcp.tool`, `@mcp.resource`) and needed no change
+- Restructure `.github/workflows/release.yml` for GitHub immutable releases. The release is now created as a **draft** with all assets attached, the assets are verified, PyPI is published (with
+  `uv publish --check-url https://pypi.org/simple/` for idempotent retries), and only then is the draft promoted to a published (immutable) release. Three guard rails fail the job early: (1) a
+  previously-published release for the tag blocks re-tagging; (2) a PyPI version that already exists with no draft release blocks re-tagging (PyPI versions are permanent); (3) the build must produce
+  both wheel and sdist before the draft is created. If any step between "create draft" and "publish release" fails, the workflow can be safely re-run — the draft is editable and every mutating step is
+  idempotent
+- Re-enable rolling major (`v1`) and minor (`v1.19`) tag updates after a stable release. These are plain git refs with no GitHub Release attached, so they remain movable under immutable releases
+  (which only freezes tags tied to a published Release). Skipped for `rc`/`beta`/`alpha` tags so pre-releases cannot promote the rolling references. The signed, version-specific `v<X.Y.Z>` tag stays
+  authoritative
 
 ### Fixed
 
-- Fix `ValidationReport.policies_with_findings` double-counting policies whose only issues were structural errors — "findings" now counts only policies with at least one non-`error` severity issue (`warning` / `info` / `critical` / `high` / `medium` / `low`), aligning with the display split between errors (AWS-invalid) and findings (security / best-practice). Policies with both kinds of issues are counted in both properties
-- Fix `clean` policy count in the Rich console report and `get_summary()` — compute directly from policies with no issues instead of subtracting `policies_with_findings` (which would have marked error-only policies as clean after the `policies_with_findings` fix)
-- Fix GitHub PR comment hiding the entire "Detailed Findings" section (and printing "All Policies Valid / no issues found") when `invalid_policies == 0` but `total_issues > 0` — happens with the default `fail_on_severities=["error","critical"]` on a policy with only `high`/`medium`/`low`/`warning` issues. The detail section is now gated on `total_issues > 0` so all findings are rendered
-- Fix `ValidationReport.get_summary()` reporting "N clean" (and omitting any error count) for legacy callers that build a report with only scalar counters and no `results` list — falls back to `total_policies - invalid_policies` so a failing run isn't mis-reported as fully clean
-- Fix `policy_size` check ignoring the runtime policy type — trust policies, SCPs, and RCPs were silently measured against the 6,144-byte managed-policy limit regardless of `--policy-type`. The check now maps the runtime policy type (`IDENTITY_POLICY`/`RESOURCE_POLICY`/`TRUST_POLICY`/`SERVICE_CONTROL_POLICY`/`RESOURCE_CONTROL_POLICY`) to the appropriate AWS limit, and adds the three previously-missing limits: `inline_role_trust` (2,048 bytes), `scp` (5,120 bytes), `rcp` (5,120 bytes). An explicit `policy_type` in YAML config still takes priority
-- Fix `policy_size` default config hardcoding `policy_type: "managed"` — this blocked the runtime `--policy-type` kwarg from ever reaching the check because my priority rule treated the default as an explicit user choice. Removed from `defaults.py` so the runtime type flows through by default; users who need an override (e.g., pinning `inline_user` when `--policy-type` is `IDENTITY_POLICY`) can still set `checks.policy_size.config.policy_type` in their YAML
-- Fix `policy_size` measuring character count instead of UTF-8 byte length — AWS counts bytes, so policies with non-ASCII characters in SIDs or condition values were previously under-counted. Now measured via `len(policy_string.encode("utf-8"))`
-- Fix `policy_size` re-serializing through Pydantic (`model_dump`) rather than measuring what AWS would actually receive — the check now prefers the `raw_policy_dict` when it is passed through the orchestrator, falling back to `model_dump` only when unavailable
-- Fix `_log_resolved_policy_type` debug log leaking absolute file paths and tripping CodeQL `py/clear-text-logging-sensitive-data` on config-derived values — log only the file basename via `Path(policy_file).name`, whitelist `resolved_type` against a closed-set allowlist, branch on the `source` value so every emitted log record uses a compile-time literal for `source=…` (cli-flag / config-glob / auto-detect / default / unknown), and replace the raw `pattern` glob with `pattern_present=true pattern_len=<n>` so no user-controlled string from the YAML config flows into the log sink. `--log-level debug` callers who previously grepped the literal glob out of the log line should grep their own `iam-validator.yaml` instead
-- Fix implicit string concatenation in `MarkdownFormatter` summary list — join the policy-count rows into single f-string literals so CodeQL no longer flags `py/implicit-string-concatenation-in-list` on the "Policies with Errors" / "Policies with Findings" rows
-- Fix `LabelManager` removing a shared label when one of its mapped severities is absent — if `severity_labels` maps multiple severities to the same label (e.g., both `error` and `warning` → `iam-issue`) and only one of them is found, the "severity-not-found" side of the mapping previously scheduled the shared label for removal, and because removes ran after adds the label ended up deleted despite still being warranted. `labels_to_remove` now subtracts `labels_to_apply` before intersecting with the current PR labels, so a shared label stays as long as any of its mapped severities is still found
-- Fix per-file streaming mode racing on PR labels — `_post_file_review` previously called `post_findings_to_pr` with the default `manage_labels=True`, so each mini-report (which only sees one file's severities) would add the label for that file's severities, then immediately remove the same label when the next label-free file was processed. Per-file review posting now passes `manage_labels=False`, and `_run_final_review_cleanup` runs label management once against the aggregated full report (gated on `severity_labels` being configured)
-- Fix `condition_key_validation` emitting cascading `invalid_condition_key` findings for non-existent actions — when a statement named an action that doesn't exist in AWS (e.g. the bogus `apigateway:TagResource`), the check still tried to validate each condition key against it and reported "key X is not supported by resources used by action Y" even though Y itself was invalid. Non-existent actions are now filtered out via `validate_actions_batch` before condition-key validation runs, so only the authoritative `invalid_action` finding from `action_validation` is reported. The bare `*` wildcard and service-wildcard patterns that match at least one real action are preserved
+- Fix `ValidationReport.policies_with_findings` double-counting policies whose only issues were structural errors — "findings" now counts only policies with at least one non-`error` severity issue
+  (`warning` / `info` / `critical` / `high` / `medium` / `low`), aligning with the display split between errors (AWS-invalid) and findings (security / best-practice). Policies with both kinds of
+  issues are counted in both properties
+- Fix `clean` policy count in the Rich console report and `get_summary()` — compute directly from policies with no issues instead of subtracting `policies_with_findings` (which would have marked
+  error-only policies as clean after the `policies_with_findings` fix)
+- Fix GitHub PR comment hiding the entire "Detailed Findings" section (and printing "All Policies Valid / no issues found") when `invalid_policies == 0` but `total_issues > 0` — happens with the
+  default `fail_on_severities=["error","critical"]` on a policy with only `high`/`medium`/`low`/`warning` issues. The detail section is now gated on `total_issues > 0` so all findings are rendered
+- Fix `ValidationReport.get_summary()` reporting "N clean" (and omitting any error count) for legacy callers that build a report with only scalar counters and no `results` list — falls back to
+  `total_policies - invalid_policies` so a failing run isn't mis-reported as fully clean
+- Fix `policy_size` check ignoring the runtime policy type — trust policies, SCPs, and RCPs were silently measured against the 6,144-byte managed-policy limit regardless of `--policy-type`. The check
+  now maps the runtime policy type (`IDENTITY_POLICY`/`RESOURCE_POLICY`/`TRUST_POLICY`/`SERVICE_CONTROL_POLICY`/`RESOURCE_CONTROL_POLICY`) to the appropriate AWS limit, and adds the three
+  previously-missing limits: `inline_role_trust` (2,048 bytes), `scp` (5,120 bytes), `rcp` (5,120 bytes). An explicit `policy_type` in YAML config still takes priority
+- Fix `policy_size` default config hardcoding `policy_type: "managed"` — this blocked the runtime `--policy-type` kwarg from ever reaching the check because my priority rule treated the default as an
+  explicit user choice. Removed from `defaults.py` so the runtime type flows through by default; users who need an override (e.g., pinning `inline_user` when `--policy-type` is `IDENTITY_POLICY`) can
+  still set `checks.policy_size.config.policy_type` in their YAML
+- Fix `policy_size` measuring character count instead of UTF-8 byte length — AWS counts bytes, so policies with non-ASCII characters in SIDs or condition values were previously under-counted. Now
+  measured via `len(policy_string.encode("utf-8"))`
+- Fix `policy_size` re-serializing through Pydantic (`model_dump`) rather than measuring what AWS would actually receive — the check now prefers the `raw_policy_dict` when it is passed through the
+  orchestrator, falling back to `model_dump` only when unavailable
+- Fix `_log_resolved_policy_type` debug log leaking absolute file paths and tripping CodeQL `py/clear-text-logging-sensitive-data` on config-derived values — log only the file basename via
+  `Path(policy_file).name`, whitelist `resolved_type` against a closed-set allowlist, branch on the `source` value so every emitted log record uses a compile-time literal for `source=…` (cli-flag /
+  config-glob / auto-detect / default / unknown), and replace the raw `pattern` glob with `pattern_present=true pattern_len=<n>` so no user-controlled string from the YAML config flows into the log
+  sink. `--log-level debug` callers who previously grepped the literal glob out of the log line should grep their own `iam-validator.yaml` instead
+- Fix implicit string concatenation in `MarkdownFormatter` summary list — join the policy-count rows into single f-string literals so CodeQL no longer flags `py/implicit-string-concatenation-in-list`
+  on the "Policies with Errors" / "Policies with Findings" rows
+- Fix `LabelManager` removing a shared label when one of its mapped severities is absent — if `severity_labels` maps multiple severities to the same label (e.g., both `error` and `warning` →
+  `iam-issue`) and only one of them is found, the "severity-not-found" side of the mapping previously scheduled the shared label for removal, and because removes ran after adds the label ended up
+  deleted despite still being warranted. `labels_to_remove` now subtracts `labels_to_apply` before intersecting with the current PR labels, so a shared label stays as long as any of its mapped
+  severities is still found
+- Fix per-file streaming mode racing on PR labels — `_post_file_review` previously called `post_findings_to_pr` with the default `manage_labels=True`, so each mini-report (which only sees one file's
+  severities) would add the label for that file's severities, then immediately remove the same label when the next label-free file was processed. Per-file review posting now passes
+  `manage_labels=False`, and `_run_final_review_cleanup` runs label management once against the aggregated full report (gated on `severity_labels` being configured)
+- Fix `condition_key_validation` emitting cascading `invalid_condition_key` findings for non-existent actions — when a statement named an action that doesn't exist in AWS (e.g. the bogus
+  `apigateway:TagResource`), the check still tried to validate each condition key against it and reported "key X is not supported by resources used by action Y" even though Y itself was invalid.
+  Non-existent actions are now filtered out via `validate_actions_batch` before condition-key validation runs, so only the authoritative `invalid_action` finding from `action_validation` is reported.
+  The bare `*` wildcard and service-wildcard patterns that match at least one real action are preserved
 
 ## [1.18.2] - 2026-03-24
 
 ### Fixed
 
-- Fix `condition_key_validation` generating one PR comment per invalid condition key — aggregate keys that share the same action and base pattern (e.g., `aws:RequestTag/owner`, `aws:RequestTag/jira`, `aws:RequestTag/env`) into a single finding listing all affected keys
-- Fix `set_operator_validation` false positive on `aws:ResourceOrgPaths` — classify it as a multivalued condition key (matching `aws:PrincipalOrgPaths`), and update type from `String` to `ArrayOfString` in global condition key metadata ([#87])
+- Fix `condition_key_validation` generating one PR comment per invalid condition key — aggregate keys that share the same action and base pattern (e.g., `aws:RequestTag/owner`, `aws:RequestTag/jira`,
+  `aws:RequestTag/env`) into a single finding listing all affected keys
+- Fix `set_operator_validation` false positive on `aws:ResourceOrgPaths` — classify it as a multivalued condition key (matching `aws:PrincipalOrgPaths`), and update type from `String` to
+  `ArrayOfString` in global condition key metadata ([#87])
 
 [#87]: https://github.com/boogy/iam-policy-validator/pull/87
 
@@ -234,7 +261,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `service_wildcard` reporting `high` severity for service wildcards with ABAC tag conditions (`aws:ResourceTag/*` = `${aws:PrincipalTag/*}`) — severity is now reduced to `low` (configurable via `abac_mitigated_severity`) when tag-based ownership constraints restrict the blast radius
+- Fix `service_wildcard` reporting `high` severity for service wildcards with ABAC tag conditions (`aws:ResourceTag/*` = `${aws:PrincipalTag/*}`) — severity is now reduced to `low` (configurable via
+  `abac_mitigated_severity`) when tag-based ownership constraints restrict the blast radius
 - Fix `service_wildcard` ABAC detection not recognizing `ForAllValues:`/`ForAnyValue:` set operator prefixes and `IfExists` suffix on condition operators
 - Fix `service_wildcard` ABAC detection not explicitly excluding negated operators (`StringNotEquals`, `StringNotLike`) which do not restrict access
 
@@ -257,8 +285,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `condition_key_in_list` false positive on tag keys containing `/` (e.g., `aws:ResourceTag/team/project-owner`) — use pattern prefix length instead of `rfind("/")` which split at the wrong `/`
 - Fix `condition_type_mismatch` and `set_operator_validation` failing to resolve types for compound tag keys — replace exact `in` lookups on pattern dicts with `find_matching_condition_key()`
-- Fix `set_operator_validation` false positive on multivalued service condition keys — look up `Types` metadata from AWS service definitions (`ArrayOfString` etc.) instead of relying solely on hardcoded allowlist
-- Fix `wildcard_resource` false positive when ABAC tag conditions scope `Resource: "*"` — unify detection to cover `aws:ResourceTag/*`, `aws:RequestTag/*`, `aws:TagKeys`, `s3:ExistingObjectTag/*`, and any service-specific tag condition key, validated against AWS service definitions
+- Fix `set_operator_validation` false positive on multivalued service condition keys — look up `Types` metadata from AWS service definitions (`ArrayOfString` etc.) instead of relying solely on
+  hardcoded allowlist
+- Fix `wildcard_resource` false positive when ABAC tag conditions scope `Resource: "*"` — unify detection to cover `aws:ResourceTag/*`, `aws:RequestTag/*`, `aws:TagKeys`, `s3:ExistingObjectTag/*`, and
+  any service-specific tag condition key, validated against AWS service definitions
 - Fix off-diff PR comments posting duplicates on re-runs — deduplicate via fingerprint, skip unchanged comments, update modified ones
 - Fix off-diff PR comment silently lost when `update_review_comment` fails — fall back to summary table
 - Fix `CheckDocumentation` breaking custom check loading when `short_description` field is missing — make optional with `kw_only=True` to prevent silent positional argument swapping
@@ -285,7 +315,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add outdated policy version warning for `Version` `2008-10-17` ([#79])
 - Add implicit grant analysis and remediation suggestions in `not_action_not_resource` ([#79])
 - Add `--has-condition-key` filter and `--show-condition-keys`/`--show-arn-format`/`--show-resource-type` flags to `query` subcommands ([#79])
-- Add SDK improvements: TypedDicts for query results, `filter_issues_by_check_id`/`filter_issues_by_severity`, `str | dict` in `validate_json()`, ARN utility exports, usage examples and test suite ([#79])
+- Add SDK improvements: TypedDicts for query results, `filter_issues_by_check_id`/`filter_issues_by_severity`, `str | dict` in `validate_json()`, ARN utility exports, usage examples and test suite
+  ([#79])
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,10 @@ docs/                         # MkDocs site — see docs/CLAUDE.md
 literals. Add a constant there before introducing any of these inline:
 
 - HTML comment markers (`SUMMARY_IDENTIFIER`, `REVIEW_IDENTIFIER`,
-  `IGNORED_FINDINGS_IDENTIFIER`, `ANALYZER_IDENTIFIER`, `BOT_IDENTIFIER`)
+  `IGNORED_FINDINGS_IDENTIFIER`, `ANALYZER_IDENTIFIER`, `BOT_IDENTIFIER`).
+  When emitting or matching one of these for a tagged run, route through
+  `scoped_marker(base, comment_tag)` (validates the tag against
+  `COMMENT_TAG_PATTERN`) — never splice the suffix manually.
 - Body-part markers (`ISSUE_TYPE_MARKER_FORMAT/PATTERN`, `FINDING_ID_MARKER_FORMAT`,
   `FINDING_ID_STRICT_PATTERN` for the canonical 16-char hash, `FINDING_ID_LOOSE_PATTERN`
   for legacy ids)

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ iam-validator validate --path policies/ --aws-services-dir ./aws-services
 - **Line-specific feedback**: Inline comments on policy files with exact line numbers
 - **Smart cleanup**: Updates existing comments, removes stale ones
 - **Severity-based reviews**: Auto-approve or request changes based on findings
+- **Parallel-run safe**: Pass a `comment-tag` per matrix job (e.g. one
+  per policy type) so independent runs keep independent comment threads
+  on the same PR instead of overwriting each other
 
 **Multiple output formats:** Console, JSON, SARIF (GitHub Code Scanning), Markdown, HTML, CSV
 
@@ -324,6 +327,7 @@ iam-validator validate --path policies/ --aws-services-dir ./aws-services
     create-review: true # Inline PR comments
     github-summary: true # Actions summary tab
     config-file: .iam-validator.yaml # fail_on_severity set in config
+    comment-tag: identity # Required only when running >1 validator on the same PR
 ```
 
 ---

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,13 @@ inputs:
     required: false
     default: "summary_only"
 
+  comment-tag:
+    description: >
+      Optional run scope (1-32 chars, [A-Za-z0-9._-]) appended to PR summary, review, analyzer, and ignored-findings markers. Use a different tag per parallel run on the same PR (e.g. 'policy',
+      'role', 'scp') so comments do not overwrite each other.
+    required: false
+    default: ""
+
   allow-owner-ignore:
     description: "Allow CODEOWNERS to ignore findings by replying 'ignore' to review comments"
     required: false
@@ -133,7 +140,8 @@ inputs:
     default: "false"
 
   public-access-resource-type:
-    description: "Resource type(s) for public access check. Use 'all' to check all 29 types, or specify space-separated types. Options: all, AWS::S3::Bucket, AWS::Lambda::Function, AWS::KMS::Key, AWS::SNS::Topic, AWS::SQS::Queue, etc."
+    description: "Resource type(s) for public access check. Use 'all' to check all 29 types, or specify space-separated types. Options: all, AWS::S3::Bucket, AWS::Lambda::Function, AWS::KMS::Key,
+      AWS::SNS::Topic, AWS::SQS::Queue, etc."
     required: false
     default: "AWS::S3::Bucket"
 
@@ -144,7 +152,8 @@ inputs:
     default: ""
 
   aws-services-dir:
-    description: "Path to directory containing pre-downloaded AWS service definitions for offline mode (relative to repository root). Use 'iam-validator download-services' to create this directory. When specified, disables automatic caching and API calls."
+    description: "Path to directory containing pre-downloaded AWS service definitions for offline mode (relative to repository root). Use 'iam-validator download-services' to create this directory. When
+      specified, disables automatic caching and API calls."
     required: false
     default: ""
 
@@ -504,6 +513,12 @@ runs:
         # Add off-diff comment mode (only add flag when not the default)
         if [ -n "${{ inputs.off-diff-comment-mode }}" ] && [ "${{ inputs.off-diff-comment-mode }}" != "summary_only" ]; then
           ARGS="$ARGS --off-diff-comment-mode ${{ inputs.off-diff-comment-mode }}"
+        fi
+
+        # Add comment-tag (scope marker for parallel runs on the same PR)
+        # Validated downstream by the CLI; only enforce non-empty here.
+        if [ -n "${{ inputs.comment-tag }}" ]; then
+          ARGS="$ARGS --comment-tag ${{ inputs.comment-tag }}"
         fi
 
         # Create temp file for JSON metrics extraction

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -45,13 +45,14 @@ jobs:
 
 ### GitHub Integration
 
-| Input                | Description                                              | Default               |
-| -------------------- | -------------------------------------------------------- | --------------------- |
-| `post-comment`       | Post validation results as PR comment                    | `true`                |
-| `create-review`      | Create line-specific review comments on PR files         | `true`                |
-| `allow-owner-ignore` | Allow CODEOWNERS to ignore findings by replying 'ignore' | `true`                |
-| `github-summary`     | Write summary to GitHub Actions job summary              | `false`               |
-| `github-token`       | GitHub token for posting comments and reviews            | `${{ github.token }}` |
+| Input                | Description                                                                          | Default               |
+| -------------------- | ------------------------------------------------------------------------------------ | --------------------- |
+| `post-comment`       | Post validation results as PR comment                                                | `true`                |
+| `create-review`      | Create line-specific review comments on PR files                                     | `true`                |
+| `allow-owner-ignore` | Allow CODEOWNERS to ignore findings by replying 'ignore'                             | `true`                |
+| `github-summary`     | Write summary to GitHub Actions job summary                                          | `false`               |
+| `github-token`       | GitHub token for posting comments and reviews                                        | `${{ github.token }}` |
+| `comment-tag`        | Run scope tag (1-32 chars, `[A-Za-z0-9._-]`) for parallel runs on the same PR        | (unset)               |
 
 ### Output Options
 
@@ -254,7 +255,9 @@ Validate policies from different directories:
 
 ### Different Policy Types (Matrix Strategy)
 
-Validate different policy types in parallel:
+Validate different policy types in parallel. Pass a unique `comment-tag`
+per matrix entry so each run posts its own PR summary, review thread,
+and ignored-findings store instead of overwriting siblings (issue #103).
 
 ```yaml
 name: Validate All Policy Types
@@ -272,19 +275,35 @@ jobs:
         include:
           - path: ./identity-policies/
             type: IDENTITY_POLICY
+            tag: identity
           - path: ./trust-policies/
             type: TRUST_POLICY
+            tag: trust
           - path: ./resource-policies/
             type: RESOURCE_POLICY
+            tag: resource
           - path: ./scps/
             type: SERVICE_CONTROL_POLICY
+            tag: scp
     steps:
       - uses: actions/checkout@v4
       - uses: boogy/iam-policy-validator@v1
         with:
           path: ${{ matrix.path }}
           policy-type: ${{ matrix.type }}
+          comment-tag: ${{ matrix.tag }}
 ```
+
+!!! tip "Why `comment-tag` is required for parallel runs"
+
+    The validator updates the same canonical PR comment on every run so
+    repeated pushes don't spam the timeline. Without a `comment-tag`,
+    every parallel matrix job targets the same comment — the second
+    job overwrites the first. Set a stable, distinct tag per scope
+    (`identity`, `trust`, `${{ matrix.tag }}`, `${{ github.job }}`)
+    and each job updates its own thread on subsequent runs.
+
+    Tags must match `[A-Za-z0-9._-]{1,32}`.
 
 ### Large Repositories (Streaming Mode)
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -69,13 +69,14 @@ iam-validator validate [OPTIONS]
 
 **GitHub Integration:**
 
-| Option                 | Description                                              | Default |
-| ---------------------- | -------------------------------------------------------- | ------- |
-| `--github-comment`     | Post summary comment to PR conversation                  | `false` |
-| `--github-review`      | Create line-specific review comments on PR files         | `false` |
-| `--github-summary`     | Write summary to GitHub Actions job summary              | `false` |
-| `--allow-owner-ignore` | Allow CODEOWNERS to ignore findings by replying 'ignore' | `true`  |
-| `--no-owner-ignore`    | Disable CODEOWNERS ignore feature                        | `false` |
+| Option                 | Description                                                                | Default |
+| ---------------------- | -------------------------------------------------------------------------- | ------- |
+| `--github-comment`     | Post summary comment to PR conversation                                    | `false` |
+| `--github-review`      | Create line-specific review comments on PR files                           | `false` |
+| `--github-summary`     | Write summary to GitHub Actions job summary                                | `false` |
+| `--allow-owner-ignore` | Allow CODEOWNERS to ignore findings by replying 'ignore'                   | `true`  |
+| `--no-owner-ignore`    | Disable CODEOWNERS ignore feature                                          | `false` |
+| `--comment-tag`        | Run scope tag (1-32 chars, `[A-Za-z0-9._-]`) for parallel runs on same PR  | unset   |
 
 **CI Mode:**
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -349,6 +349,13 @@ settings:
     critical: "iam-security-critical"
     high: "iam-security-high"
 
+  # Optional run scope tag (1-32 chars, [A-Za-z0-9._-]) appended to PR
+  # summary, review, analyzer, and ignored-findings markers. Set this
+  # when you run the validator multiple times against the same PR (e.g.
+  # one run per policy type) so each run keeps its own comment thread
+  # instead of overwriting the others. Unset by default.
+  comment_tag: null
+
   # Custom checks
   custom_checks_dir: null # Auto-discover checks from directory
 

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/commands/analyze.py
+++ b/iam_validator/commands/analyze.py
@@ -231,6 +231,17 @@ Examples:
         )
 
         parser.add_argument(
+            "--comment-tag",
+            default=None,
+            metavar="TAG",
+            help="Optional run scope (1-32 chars, [A-Za-z0-9._-]) for PR "
+            "summary, review, analyzer, and ignored-findings comments. "
+            "When set, the HTML markers are suffixed with ':<TAG>' so "
+            "multiple analyze/validate runs on the same PR maintain "
+            "independent comment threads instead of overwriting each other.",
+        )
+
+        parser.add_argument(
             "--verbose",
             "-v",
             action="store_true",
@@ -278,7 +289,9 @@ Examples:
             # Post to GitHub if configured
             if args.github_comment:
                 async with GitHubIntegration() as github:
-                    success = await self._post_to_github(github, report, formatter)
+                    success = await self._post_to_github(
+                        github, report, formatter, comment_tag=getattr(args, "comment_tag", None)
+                    )
                     if not success:
                         logging.error("Failed to post Access Analyzer results to GitHub PR")
 
@@ -412,6 +425,7 @@ Examples:
             off_diff_mode = getattr(args, "off_diff_comment_mode", None) or config.get_setting(
                 "off_diff_comment_mode", "summary_only"
             )
+            comment_tag = getattr(args, "comment_tag", None) or config.get_setting("comment_tag", None)
 
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
@@ -421,6 +435,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_tag=comment_tag,
                 )
                 success = await commenter.post_findings_to_pr(
                     validation_report,
@@ -441,8 +456,18 @@ Examples:
         github: GitHubIntegration,
         report: AccessAnalyzerReport,
         formatter: AccessAnalyzerReportFormatter,
+        comment_tag: str | None = None,
     ) -> bool:
-        """Post Access Analyzer results to GitHub PR."""
+        """Post Access Analyzer results to GitHub PR.
+
+        Args:
+            github: GitHub integration instance.
+            report: Access Analyzer findings.
+            formatter: Markdown formatter for the report.
+            comment_tag: Optional run scope; when set, the analyzer marker is
+                suffixed via :func:`scoped_marker` so concurrent analyze runs
+                on the same PR keep independent comment threads.
+        """
         if not github.is_configured():
             logging.error(
                 "GitHub integration not configured. "
@@ -454,8 +479,9 @@ Examples:
         # Generate markdown comment (single part for now)
         markdown_content = formatter.generate_markdown_report(report)
 
-        # Add identifier for updating existing comments
-        identifier = constants.ANALYZER_IDENTIFIER
+        # Add identifier for updating existing comments. Scoped via the
+        # optional ``comment_tag`` so parallel analyze runs do not collide.
+        identifier = constants.scoped_marker(constants.ANALYZER_IDENTIFIER, comment_tag)
 
         # Check if content is too large for single comment
         if len(markdown_content) > constants.GITHUB_COMMENT_SPLIT_LIMIT:

--- a/iam_validator/commands/completion.py
+++ b/iam_validator/commands/completion.py
@@ -282,17 +282,17 @@ _iam_validator_completion() {{
             return 0
             ;;
         validate)
-            opts="--path -p --stdin --format -f --output -o --no-recursive --fail-on-warnings --policy-type -t --github-comment --github-review --github-summary --verbose -v --config -c --custom-checks-dir --aws-services-dir --stream --batch-size --summary --severity-breakdown --allow-owner-ignore --no-owner-ignore --ci --ci-output --off-diff-comment-mode"
+            opts="--path -p --stdin --format -f --output -o --no-recursive --fail-on-warnings --policy-type -t --github-comment --github-review --github-summary --verbose -v --config -c --custom-checks-dir --aws-services-dir --stream --batch-size --summary --severity-breakdown --allow-owner-ignore --no-owner-ignore --ci --ci-output --off-diff-comment-mode --comment-tag"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
         post-to-pr)
-            opts="--report -r --create-review --no-review --add-summary --no-summary --config -c --off-diff-comment-mode"
+            opts="--report -r --create-review --no-review --add-summary --no-summary --config -c --off-diff-comment-mode --comment-tag"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
         analyze)
-            opts="--path -p --policy-type -t --region --profile --format -f --output -o --no-recursive --fail-on-warnings --github-comment --github-review --github-summary --run-all-checks --check-access-not-granted --check-access-resources --check-no-new-access --check-no-public-access --public-access-resource-type --off-diff-comment-mode --verbose -v"
+            opts="--path -p --policy-type -t --region --profile --format -f --output -o --no-recursive --fail-on-warnings --github-comment --github-review --github-summary --run-all-checks --check-access-not-granted --check-access-resources --check-no-new-access --check-no-public-access --public-access-resource-type --off-diff-comment-mode --comment-tag --verbose -v"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             return 0
             ;;
@@ -441,7 +441,8 @@ _iam_validator() {{
                         '--no-owner-ignore[Disable CODEOWNERS ignore feature]' \\
                         '--ci[CI mode - print enhanced output, write JSON to file]' \\
                         '--ci-output[Output file for JSON report in CI mode]:file:_files' \\
-                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)'
+                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)' \\
+                        '--comment-tag[Run scope tag for PR comment markers (1-32 chars, [A-Za-z0-9._-])]:tag:'
                     ;;
                 post-to-pr)
                     _arguments \\
@@ -451,7 +452,8 @@ _iam_validator() {{
                         '--add-summary[Add summary comment]' \\
                         '--no-summary[Do not add summary comment]' \\
                         '(--config -c)'{{--config,-c}}'[Configuration file]:file:_files' \\
-                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)'
+                        '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)' \\
+                        '--comment-tag[Run scope tag for PR comment markers]:tag:'
                     ;;
                 analyze)
                     _arguments \\
@@ -474,6 +476,7 @@ _iam_validator() {{
                         '--check-no-public-access[Check that resource policy does not allow public access]' \\
                         '*--public-access-resource-type[Resource type for public access check]:resource type:' \\
                         '--off-diff-comment-mode[How to handle findings on unchanged lines]:mode:(summary_only individual modified_statements_only)' \\
+                        '--comment-tag[Run scope tag for PR comment markers (1-32 chars, [A-Za-z0-9._-])]:tag:' \\
                         '(--verbose -v)'{{--verbose,-v}}'[Enable verbose logging]'
                     ;;
                 cache)

--- a/iam_validator/commands/post_to_pr.py
+++ b/iam_validator/commands/post_to_pr.py
@@ -84,6 +84,16 @@ Examples:
             "'modified_statements_only' posts only for modified statements",
         )
 
+        parser.add_argument(
+            "--comment-tag",
+            default=None,
+            metavar="TAG",
+            help="Optional run scope (1-32 chars, [A-Za-z0-9._-]) for PR "
+            "summary, review, and ignored-findings comments. When set, "
+            "the markers are suffixed with ':<TAG>' so multiple runs on "
+            "the same PR maintain independent comment threads.",
+        )
+
     async def execute(self, args: argparse.Namespace) -> int:
         """Execute the post-to-pr command."""
         success = await post_report_to_pr(
@@ -92,6 +102,7 @@ Examples:
             add_summary=args.add_summary,
             config_path=getattr(args, "config", None),
             off_diff_comment_mode=getattr(args, "off_diff_comment_mode", None),
+            comment_tag=getattr(args, "comment_tag", None),
         )
 
         return 0 if success else 1

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -28,6 +28,18 @@ def _resolve_off_diff_mode(args: argparse.Namespace, config) -> str:
     return getattr(args, "off_diff_comment_mode", None) or config.get_setting("off_diff_comment_mode", "summary_only")
 
 
+def _resolve_comment_tag(args: argparse.Namespace, config) -> str | None:
+    """Resolve the PR comment tag from CLI args or config.
+
+    Priority: CLI ``--comment-tag`` > config ``comment_tag`` > unset.
+    The tag scopes PR comment markers so multiple validator runs on the
+    same PR (e.g. one per policy type) keep independent comment threads.
+    Returns ``None`` when neither source provides a value, preserving the
+    legacy un-scoped marker behaviour.
+    """
+    return getattr(args, "comment_tag", None) or config.get_setting("comment_tag", None)
+
+
 class ValidateCommand(Command):
     """Command to validate IAM policies."""
 
@@ -246,6 +258,17 @@ Examples:
         )
 
         parser.add_argument(
+            "--comment-tag",
+            default=None,
+            metavar="TAG",
+            help="Optional run scope (1-32 chars, [A-Za-z0-9._-]) for PR "
+            "summary, review, and ignored-findings comments. When set, the "
+            "HTML markers are suffixed with ':<TAG>' so multiple validator "
+            "runs on the same PR (e.g. one per policy type) maintain "
+            "independent comment threads instead of overwriting each other.",
+        )
+
+        parser.add_argument(
             "--ci",
             action="store_true",
             help="CI mode: print enhanced console output for visibility in job logs, "
@@ -385,6 +408,7 @@ Examples:
 
             # Get off-diff comment mode (CLI override > config > default)
             off_diff_mode = _resolve_off_diff_mode(args, config)
+            comment_tag = _resolve_comment_tag(args, config)
 
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
@@ -394,6 +418,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_tag=comment_tag,
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -541,6 +566,7 @@ Examples:
 
             # Get off-diff comment mode (CLI override > config > default)
             off_diff_mode = _resolve_off_diff_mode(args, config)
+            comment_tag = _resolve_comment_tag(args, config)
 
             async with GitHubIntegration() as github:
                 commenter = PRCommenter(
@@ -550,6 +576,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_tag=comment_tag,
                 )
                 success = await commenter.post_findings_to_pr(
                     report,
@@ -611,6 +638,7 @@ Examples:
 
                 # Get off-diff comment mode (CLI override > config > default)
                 off_diff_mode = _resolve_off_diff_mode(args, config)
+                comment_tag = _resolve_comment_tag(args, config)
 
                 # In streaming mode, don't cleanup comments (we want to keep earlier files)
                 # Cleanup will happen once at the end
@@ -621,6 +649,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_tag=comment_tag,
                 )
 
                 # Create a mini-report for just this file
@@ -721,6 +750,7 @@ Examples:
 
                 # Get off-diff comment mode (CLI override > config > default)
                 off_diff_mode = _resolve_off_diff_mode(args, config)
+                comment_tag = _resolve_comment_tag(args, config)
 
                 # Create commenter WITH cleanup enabled for the final pass
                 commenter = PRCommenter(
@@ -731,6 +761,7 @@ Examples:
                     enable_codeowners_ignore=enable_ignore,
                     allowed_ignore_users=allowed_users,
                     off_diff_comment_mode=off_diff_mode,
+                    comment_tag=comment_tag,
                 )
 
                 # Create a full report with all results

--- a/iam_validator/core/config/config_loader.py
+++ b/iam_validator/core/config/config_loader.py
@@ -19,7 +19,11 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from iam_validator.core.check_registry import CheckConfig, CheckRegistry, PolicyCheck
 from iam_validator.core.config.defaults import get_default_config
-from iam_validator.core.constants import DEFAULT_CONFIG_FILENAMES
+from iam_validator.core.constants import (
+    _COMMENT_TAG_RE,
+    COMMENT_TAG_PATTERN,
+    DEFAULT_CONFIG_FILENAMES,
+)
 from iam_validator.core.models import PolicyType
 
 # Valid PolicyType literal values (derived from the Literal in models.py so we
@@ -163,6 +167,7 @@ class SettingsSchema(BaseModel):
     documentation: DocumentationSettingsSchema = DocumentationSettingsSchema()
     hide_severities: list[str] | None = None  # Global severity filtering
     off_diff_comment_mode: str = "summary_only"
+    comment_tag: str | None = None
 
     @field_validator("off_diff_comment_mode")
     @classmethod
@@ -170,6 +175,19 @@ class SettingsSchema(BaseModel):
         valid_modes = {"summary_only", "individual", "modified_statements_only"}
         if v not in valid_modes:
             raise ValueError(f"Invalid off_diff_comment_mode: {v}. Must be one of: {sorted(valid_modes)}")
+        return v
+
+    @field_validator("comment_tag")
+    @classmethod
+    def validate_comment_tag(cls, v: str | None) -> str | None:
+        # ``None`` and empty string disable scoping (legacy markers).
+        if not v:
+            return None
+        if not _COMMENT_TAG_RE.fullmatch(v):
+            raise ValueError(
+                f"Invalid comment_tag: {v!r}. Must match {COMMENT_TAG_PATTERN} "
+                "(letters, digits, '.', '_', '-', 1-32 chars)."
+            )
         return v
 
     @field_validator("fail_on_severity")

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -128,6 +128,11 @@ DEFAULT_CONFIG = {
         # individual: Post each as an individual review comment
         # modified_statements_only: Individual comments for modified statements only
         "off_diff_comment_mode": "summary_only",
+        # Optional run scope tag (1-32 chars, [A-Za-z0-9._-]) appended to the
+        # PR summary, review, ignored-findings, and analyzer markers. Allows
+        # multiple runs on the same PR (e.g. one per policy type) to keep
+        # independent comment threads. None preserves legacy un-scoped markers.
+        "comment_tag": None,
         # Suppress redundant findings for statements already flagged by full_wildcard.
         "suppress_superseded_findings": True,
     },

--- a/iam_validator/core/constants.py
+++ b/iam_validator/core/constants.py
@@ -10,6 +10,8 @@ References:
 - AWS ARN Format: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
 """
 
+import re
+
 # ============================================================================
 # ARN Validation
 # ============================================================================
@@ -161,6 +163,63 @@ SUMMARY_IDENTIFIER = "<!-- iam-policy-validator-summary -->"
 REVIEW_IDENTIFIER = "<!-- iam-policy-validator-review -->"
 IGNORED_FINDINGS_IDENTIFIER = "<!-- iam-policy-validator-ignored-findings -->"
 ANALYZER_IDENTIFIER = "<!-- iam-access-analyzer-validator -->"
+
+# Tag scoping for the markers above. When the user runs the validator
+# multiple times against the same PR (e.g. one run per policy type),
+# every run must address its own canonical comment instead of overwriting
+# the others. `scoped_marker(base, tag)` rewrites the marker to embed
+# the tag, e.g. `<!-- iam-policy-validator-summary:role -->`. With no
+# tag the marker is unchanged, preserving the existing comment lifecycle
+# and matching legacy comments stored before the tagging feature shipped.
+#
+# Tag charset is intentionally narrow so it is safe to splice into an
+# HTML comment, into the `body in identifier` substring matching used by
+# `_sync_comments_with_identifier`, and into shell command lines coming
+# from the GitHub Action's `comment-tag` input.
+COMMENT_TAG_PATTERN = r"^[A-Za-z0-9._-]{1,32}$"
+# Pre-compiled once at module load — `scoped_marker` is hot-pathed during
+# every PRCommenter / IgnoredFindingsStore construction, and the config
+# loader's `validate_comment_tag` reuses the same regex.
+_COMMENT_TAG_RE = re.compile(COMMENT_TAG_PATTERN)
+
+
+def scoped_marker(base: str, tag: str | None) -> str:
+    """Return ``base`` with ``tag`` spliced before the closing ``-->``.
+
+    With ``tag`` ``None`` or empty the base marker is returned unchanged
+    so existing PR comments and tests keep working without modification.
+
+    Args:
+        base: One of the module-level identifier constants
+            (``SUMMARY_IDENTIFIER``, ``REVIEW_IDENTIFIER``,
+            ``IGNORED_FINDINGS_IDENTIFIER``, ``ANALYZER_IDENTIFIER``)
+            or any string ending in ``-->``.
+        tag: Optional run scope. Must match :data:`COMMENT_TAG_PATTERN`
+            (letters, digits, ``.``, ``_``, ``-``; 1-32 chars).
+            ``None`` and ``""`` are accepted and result in the base
+            marker being returned unchanged.
+
+    Returns:
+        The scoped marker, e.g.
+        ``"<!-- iam-policy-validator-summary:role -->"``.
+
+    Raises:
+        ValueError: When ``tag`` is non-empty but does not match
+            :data:`COMMENT_TAG_PATTERN`.
+    """
+    if not tag:
+        return base
+    if not _COMMENT_TAG_RE.fullmatch(tag):
+        raise ValueError(
+            f"Invalid comment tag: {tag!r}. Must match {COMMENT_TAG_PATTERN} "
+            "(letters, digits, '.', '_', '-', 1-32 chars)."
+        )
+    if not base.endswith(" -->"):
+        # Defensive: every identifier in this module ends with " -->",
+        # but stay correct if a caller passes a hand-rolled marker.
+        return f"{base}:{tag}"
+    return f"{base[:-4]}:{tag} -->"
+
 
 # Structural markers embedded inside review-comment bodies. Centralized so
 # producers (body-builders in models.py) and consumers (parsers in

--- a/iam_validator/core/ignore_processor.py
+++ b/iam_validator/core/ignore_processor.py
@@ -44,6 +44,7 @@ class IgnoreCommandProcessor:
         github: GitHubIntegration,
         allowed_users: list[str] | None = None,
         post_denial_feedback: bool = False,
+        comment_tag: str | None = None,
     ) -> None:
         """Initialize the processor.
 
@@ -52,11 +53,14 @@ class IgnoreCommandProcessor:
             allowed_users: Fallback list of users who can ignore findings
                           (used when CODEOWNERS is not available)
             post_denial_feedback: Whether to post visible replies on denied ignores
+            comment_tag: Optional run scope; forwarded to
+                :class:`IgnoredFindingsStore` so each tagged run maintains
+                its own ignore store instead of trampling sibling runs.
         """
         self.github = github
         self.allowed_users = allowed_users or []
         self.post_denial_feedback = post_denial_feedback
-        self.store = IgnoredFindingsStore(github)
+        self.store = IgnoredFindingsStore(github, comment_tag=comment_tag)
         self._codeowners_parser: CodeOwnersParser | None = None
         self._codeowners_loaded = False
         # Cache for authorization results: (username, file_path) -> bool
@@ -271,6 +275,7 @@ class IgnoreCommandProcessor:
 async def filter_ignored_findings(
     github: GitHubIntegration,
     findings: list[tuple[str, Any]],  # List of (file_path, ValidationIssue)
+    comment_tag: str | None = None,
 ) -> tuple[list[tuple[str, Any]], frozenset[str]]:
     """Filter out ignored findings from a list.
 
@@ -280,13 +285,17 @@ async def filter_ignored_findings(
     Args:
         github: GitHub integration instance
         findings: List of (file_path, issue) tuples
+        comment_tag: Optional run scope; forwarded to
+            :class:`IgnoredFindingsStore` so callers running in a tagged
+            scope read the tag-specific ignore store rather than the
+            un-scoped legacy store.
 
     Returns:
         Tuple of (filtered_findings, ignored_ids)
     """
     from iam_validator.core.finding_fingerprint import FindingFingerprint
 
-    store = IgnoredFindingsStore(github)
+    store = IgnoredFindingsStore(github, comment_tag=comment_tag)
     ignored_ids = await store.get_ignored_ids()
 
     if not ignored_ids:

--- a/iam_validator/core/ignored_findings.py
+++ b/iam_validator/core/ignored_findings.py
@@ -106,15 +106,20 @@ class IgnoredFindingsStore:
         ```
     """
 
-    def __init__(self, github: GitHubIntegration) -> None:
+    def __init__(self, github: GitHubIntegration, comment_tag: str | None = None) -> None:
         """Initialize the store.
 
         Args:
             github: GitHub integration instance
+            comment_tag: Optional run scope. When set, the storage marker is
+                scoped via :func:`iam_validator.core.constants.scoped_marker`
+                so concurrent runs (e.g. one per policy type) maintain
+                independent ignore stores instead of overwriting each other.
         """
         self.github = github
         self._cache: dict[str, IgnoredFinding] | None = None
         self._comment_id: int | None = None
+        self._marker = constants.scoped_marker(constants.IGNORED_FINDINGS_IDENTIFIER, comment_tag)
 
     async def load(self) -> dict[str, IgnoredFinding]:
         """Load ignored findings from PR comment.
@@ -269,7 +274,7 @@ class IgnoredFindingsStore:
             if not isinstance(comment, dict):
                 continue
             body = comment.get("body", "")
-            if constants.IGNORED_FINDINGS_IDENTIFIER in str(body):
+            if self._marker in str(body):
                 return comment
 
         return None
@@ -317,7 +322,7 @@ class IgnoredFindingsStore:
 
         json_str = json.dumps(data, indent=2, sort_keys=True)
 
-        return f"""{constants.IGNORED_FINDINGS_IDENTIFIER}
+        return f"""{self._marker}
 <!-- DO NOT EDIT: This comment tracks ignored validation findings -->
 <!-- Last updated: {now} -->
 <!-- Findings can be ignored by CODEOWNERS replying "ignore" to validation comments -->

--- a/iam_validator/core/models.py
+++ b/iam_validator/core/models.py
@@ -248,12 +248,25 @@ class ValidationIssue(BaseModel):
         """Check if this issue uses IAM validity severity levels (error/warning/info)."""
         return self.severity in {"error", "warning", "info"}
 
-    def to_pr_comment(self, include_identifier: bool = True, file_path: str = "") -> str:
+    def to_pr_comment(
+        self,
+        include_identifier: bool = True,
+        file_path: str = "",
+        review_identifier: str | None = None,
+    ) -> str:
         """Format issue as a PR comment.
 
         Args:
             include_identifier: Whether to include bot identifier (for cleanup)
             file_path: Relative path to the policy file (for finding ID)
+            review_identifier: HTML marker embedded at the top of the body so
+                the GitHub integration's ``identifier in body`` lookups can
+                find this comment again on subsequent runs. Defaults to the
+                un-scoped :data:`iam_validator.core.constants.REVIEW_IDENTIFIER`.
+                Pass ``PRCommenter.REVIEW_IDENTIFIER`` (which carries the
+                optional ``comment_tag`` scope) so producer and consumer
+                stay in lockstep when the validator runs in parallel for
+                multiple policy types on the same PR.
 
         Returns:
             Formatted comment string
@@ -278,7 +291,7 @@ class ValidationIssue(BaseModel):
 
         # Add identifier for bot comment cleanup (HTML comment - not visible to users)
         if include_identifier:
-            parts.append(f"{constants.REVIEW_IDENTIFIER}\n")
+            parts.append(f"{review_identifier or constants.REVIEW_IDENTIFIER}\n")
             parts.append(f"{constants.BOT_IDENTIFIER}\n")
             # Add issue type identifier to allow multiple issues at same line
             parts.append(constants.ISSUE_TYPE_MARKER_FORMAT.format(issue_type=self.issue_type) + "\n")

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -12,6 +12,7 @@ from iam_validator.core.constants import (
     BOT_IDENTIFIER,
     REVIEW_IDENTIFIER,
     SUMMARY_IDENTIFIER,
+    scoped_marker,
 )
 from iam_validator.core.diff_parser import DiffParser
 from iam_validator.core.label_manager import LabelManager
@@ -57,7 +58,9 @@ class ContextIssue:
 class PRCommenter:
     """Posts validation findings as PR comments."""
 
-    # Load identifiers from constants module for consistency
+    # Module-level defaults preserved as class attrs for backward compatibility
+    # with code that reads ``PRCommenter.SUMMARY_IDENTIFIER`` etc. The instance
+    # attributes set in ``__init__`` shadow these and carry the optional tag.
     BOT_IDENTIFIER = BOT_IDENTIFIER
     SUMMARY_IDENTIFIER = SUMMARY_IDENTIFIER
     REVIEW_IDENTIFIER = REVIEW_IDENTIFIER
@@ -71,6 +74,7 @@ class PRCommenter:
         enable_codeowners_ignore: bool = True,
         allowed_ignore_users: list[str] | None = None,
         off_diff_comment_mode: str = "summary_only",
+        comment_tag: str | None = None,
     ):
         """Initialize PR commenter.
 
@@ -93,6 +97,13 @@ class PRCommenter:
                                   "summary_only" (default): All off-diff issues in summary only.
                                   "individual": Post each as an individual review comment.
                                   "modified_statements_only": Individual comments for modified statements only.
+            comment_tag: Optional run scope (e.g. ``"role"``, ``"policy"``).
+                When set, the summary, review, and ignored-findings markers
+                are scoped via :func:`scoped_marker` so multiple runs on the
+                same PR (e.g. one per policy type executed in parallel) keep
+                independent comment threads instead of overwriting each
+                other's comments. ``None`` preserves the legacy markers,
+                making the feature fully opt-in and backward compatible.
         """
         self.github = github
         self.cleanup_old_comments = cleanup_old_comments
@@ -101,6 +112,11 @@ class PRCommenter:
         self.enable_codeowners_ignore = enable_codeowners_ignore
         self.allowed_ignore_users = allowed_ignore_users or []
         self.off_diff_comment_mode = off_diff_comment_mode
+        self.comment_tag = comment_tag
+        # Resolve scoped identifiers once. With no tag these equal the
+        # module-level defaults exactly — see scoped_marker contract.
+        self.SUMMARY_IDENTIFIER = scoped_marker(SUMMARY_IDENTIFIER, comment_tag)
+        self.REVIEW_IDENTIFIER = scoped_marker(REVIEW_IDENTIFIER, comment_tag)
         # Track issues in modified statements that are on unchanged lines
         self._context_issues: list[ContextIssue] = []
         # Track ignored finding IDs for the current run
@@ -390,7 +406,10 @@ class PRCommenter:
                             {
                                 "path": relative_path,
                                 "line": comment_line,
-                                "body": issue.to_pr_comment(file_path=relative_path),
+                                "body": issue.to_pr_comment(
+                                    file_path=relative_path,
+                                    review_identifier=self.REVIEW_IDENTIFIER,
+                                ),
                             }
                         )
                         logger.debug(
@@ -410,7 +429,10 @@ class PRCommenter:
                         {
                             "path": relative_path,
                             "line": line_number,
-                            "body": issue.to_pr_comment(file_path=relative_path),
+                            "body": issue.to_pr_comment(
+                                file_path=relative_path,
+                                review_identifier=self.REVIEW_IDENTIFIER,
+                            ),
                         }
                     )
                     logger.debug(
@@ -555,7 +577,10 @@ class PRCommenter:
 
         for ctx_issue in off_diff_issues:
             fp_hash = FindingFingerprint.from_issue(ctx_issue.issue, ctx_issue.file_path).to_hash()
-            body = ctx_issue.issue.to_pr_comment(file_path=ctx_issue.file_path)
+            body = ctx_issue.issue.to_pr_comment(
+                file_path=ctx_issue.file_path,
+                review_identifier=self.REVIEW_IDENTIFIER,
+            )
             body += (
                 f"\n\n> **Note:** This finding is on line {ctx_issue.line_number}, which was not modified in this PR."
             )
@@ -828,6 +853,7 @@ class PRCommenter:
         processor = IgnoreCommandProcessor(
             github=self.github,
             allowed_users=self.allowed_ignore_users,
+            comment_tag=self.comment_tag,
         )
         ignored_count = await processor.process_pending_ignores()
         if ignored_count > 0:
@@ -842,7 +868,7 @@ class PRCommenter:
             IgnoredFindingsStore,
         )
 
-        store = IgnoredFindingsStore(self.github)
+        store = IgnoredFindingsStore(self.github, comment_tag=self.comment_tag)
         # Load full ignored findings for display in summary
         self._ignored_findings = await store.load()
         # Also get just the IDs for fast lookup
@@ -907,6 +933,7 @@ async def post_report_to_pr(
     add_summary: bool = True,
     config_path: str | None = None,
     off_diff_comment_mode: str | None = None,
+    comment_tag: str | None = None,
 ) -> bool:
     """Post a JSON report to a PR.
 
@@ -916,6 +943,8 @@ async def post_report_to_pr(
         add_summary: Whether to add summary comment
         config_path: Optional path to config file (to get fail_on_severity)
         off_diff_comment_mode: How to handle findings on unchanged lines (overrides config)
+        comment_tag: Optional run scope; CLI override takes precedence over the
+            ``comment_tag`` config setting. See :class:`PRCommenter` for details.
 
     Returns:
         True if successful, False otherwise
@@ -944,6 +973,10 @@ async def post_report_to_pr(
         # Get off-diff comment mode (CLI override > config > default)
         off_diff_mode = off_diff_comment_mode or config.get_setting("off_diff_comment_mode", "summary_only")
 
+        # Comment tag (CLI override > config > unset). ``None`` keeps the
+        # legacy markers, so the default behaviour is unchanged.
+        resolved_tag = comment_tag or config.get_setting("comment_tag", None)
+
         # Post to PR
         async with GitHubIntegration() as github:
             commenter = PRCommenter(
@@ -953,6 +986,7 @@ async def post_report_to_pr(
                 enable_codeowners_ignore=enable_codeowners_ignore,
                 allowed_ignore_users=allowed_ignore_users,
                 off_diff_comment_mode=off_diff_mode,
+                comment_tag=resolved_tag,
             )
             return await commenter.post_findings_to_pr(
                 report,

--- a/iam_validator/integrations/CLAUDE.md
+++ b/iam_validator/integrations/CLAUDE.md
@@ -53,6 +53,14 @@ and `test_summary_comment_staleness.py`.
 All HTML comment markers come from `iam_validator.core.constants` — never hardcode
 them in either production or tests.
 
+When the caller passes a `comment_tag` (issue #103, parallel runs on the
+same PR), the marker is rewritten via `constants.scoped_marker(base, tag)`
+before any lookup or write. Resolve identifiers per-instance in
+`__init__` (see `PRCommenter.SUMMARY_IDENTIFIER` / `REVIEW_IDENTIFIER`) and
+forward the tag to `IgnoredFindingsStore` / `IgnoreCommandProcessor` —
+otherwise the storage helpers and the commenter will read different
+canonical comments and the bug from issue #103 returns.
+
 ---
 
 ## `ms_teams.py`

--- a/tests/core/test_constants_scoped_marker.py
+++ b/tests/core/test_constants_scoped_marker.py
@@ -1,0 +1,118 @@
+"""Tests for ``scoped_marker`` and ``COMMENT_TAG_PATTERN``.
+
+These constants underpin the parallel-run support for PR comments
+(issue #103). The behaviour pinned here is contract-level:
+
+* an empty / missing tag returns the base marker byte-for-byte —
+  this is what keeps existing PR comments and ignore-storage matchable
+  after the upgrade.
+* a valid tag is spliced before the closing ``-->`` so cleanup logic
+  that does ``identifier in body`` continues to find the scoped marker.
+* invalid tags raise instead of silently corrupting the marker.
+"""
+
+import re
+
+import pytest
+
+from iam_validator.core.constants import (
+    ANALYZER_IDENTIFIER,
+    COMMENT_TAG_PATTERN,
+    IGNORED_FINDINGS_IDENTIFIER,
+    REVIEW_IDENTIFIER,
+    SUMMARY_IDENTIFIER,
+    scoped_marker,
+)
+
+
+class TestScopedMarkerNoTag:
+    """No tag → base marker is preserved exactly (backward compatibility).
+
+    The implementation short-circuits on falsy tags before inspecting
+    ``base``, so one representative marker is enough to pin the contract.
+    """
+
+    @pytest.mark.parametrize("tag", [None, ""])
+    def test_returns_base_unchanged(self, tag):
+        assert scoped_marker(SUMMARY_IDENTIFIER, tag) == SUMMARY_IDENTIFIER
+
+
+class TestScopedMarkerWithTag:
+    """Valid tag → ``:<tag>`` spliced before the closing ``-->``."""
+
+    @pytest.mark.parametrize(
+        "base, tag, expected",
+        [
+            (SUMMARY_IDENTIFIER, "role", "<!-- iam-policy-validator-summary:role -->"),
+            (REVIEW_IDENTIFIER, "policy", "<!-- iam-policy-validator-review:policy -->"),
+            (
+                IGNORED_FINDINGS_IDENTIFIER,
+                "scp",
+                "<!-- iam-policy-validator-ignored-findings:scp -->",
+            ),
+            (ANALYZER_IDENTIFIER, "rcp", "<!-- iam-access-analyzer-validator:rcp -->"),
+        ],
+    )
+    def test_inserts_tag_before_closing_arrow(self, base, tag, expected):
+        assert scoped_marker(base, tag) == expected
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "a",  # 1 char minimum
+            "Aa1._-",  # full charset sample
+            "a" * 32,  # 32 char maximum
+            "policy.role-1_2",
+        ],
+    )
+    def test_accepts_full_charset(self, tag):
+        result = scoped_marker(SUMMARY_IDENTIFIER, tag)
+        assert result.endswith(" -->")
+        assert f":{tag} -->" in result
+
+    def test_scoped_does_not_match_unscoped_substring(self):
+        """Critical regression: if the scoped marker still contained the base
+        marker as a substring, every "find by identifier" lookup would still
+        match across runs and the bug would not be fixed.
+        """
+        scoped = scoped_marker(SUMMARY_IDENTIFIER, "policy")
+        # The base marker must NOT appear inside the scoped marker, otherwise
+        # `identifier in body` lookups would still cross-match.
+        assert SUMMARY_IDENTIFIER not in scoped
+
+
+class TestScopedMarkerRejectsInvalid:
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "has space",  # whitespace
+            "with/slash",
+            "with\\backslash",
+            "with:colon",
+            "with;semi",
+            "with-->arrow",  # would terminate the HTML comment
+            "<script>",  # HTML injection
+            "a" * 33,  # over the 32-char limit
+            "tag with newline\n",
+            "tag\twithtab",
+        ],
+    )
+    def test_rejects_unsafe_or_oversized(self, tag):
+        with pytest.raises(ValueError, match="Invalid comment tag"):
+            scoped_marker(SUMMARY_IDENTIFIER, tag)
+
+    def test_pattern_compiles_and_is_anchored(self):
+        # Anchors matter: an unanchored regex would happily accept
+        # "ok\nrm -rf /" because it contains a valid prefix.
+        compiled = re.compile(COMMENT_TAG_PATTERN)
+        assert compiled.fullmatch("policy") is not None
+        assert compiled.fullmatch("policy\n") is None
+        assert compiled.fullmatch("") is None
+
+
+class TestScopedMarkerNonStandardBase:
+    """Defensive path for callers that pass a marker not ending in `-->`."""
+
+    def test_appends_when_no_closing_arrow(self):
+        # Hand-rolled marker without `-->` — fall back to suffix mode.
+        assert scoped_marker("<!-- something", "tag") == "<!-- something:tag"

--- a/tests/integrations/test_parallel_runs.py
+++ b/tests/integrations/test_parallel_runs.py
@@ -1,0 +1,542 @@
+"""Tests for parallel-run support via ``comment_tag`` (issue #103).
+
+When the validator runs more than once on the same PR (e.g. one run for
+identity policies and another for trust policies, in parallel), each run
+must address its own canonical comment instead of overwriting the other.
+The fix is a scoped HTML marker; this file pins the contract.
+
+Scope:
+
+- ``_sync_comments_with_identifier`` only matches comments whose body
+  contains the *exact* scoped identifier — comments tagged ``policy``
+  must not match a lookup for ``role``.
+- ``update_or_create_review_comments`` honours the same scoping for
+  inline review comments.
+- ``IgnoredFindingsStore`` with distinct ``comment_tag`` values reads
+  and writes distinct hidden storage comments.
+- A ``PRCommenter`` constructed without a tag is byte-identical to
+  pre-tag behaviour (regression guard for the un-tagged path).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from iam_validator.core.constants import (
+    IGNORED_FINDINGS_IDENTIFIER,
+    REVIEW_IDENTIFIER,
+    SUMMARY_IDENTIFIER,
+    scoped_marker,
+)
+from iam_validator.core.ignored_findings import IgnoredFinding, IgnoredFindingsStore
+from iam_validator.core.pr_commenter import PRCommenter
+from iam_validator.integrations.github_integration import GitHubIntegration
+
+
+@pytest.fixture
+def gh():
+    with patch.dict(
+        "os.environ",
+        {
+            "GITHUB_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_PR_NUMBER": "123",
+        },
+    ):
+        return GitHubIntegration()
+
+
+# ---------------------------------------------------------------------------
+# PRCommenter — identifier resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPRCommenterIdentifierResolution:
+    @pytest.mark.parametrize("tag", [None, ""])
+    def test_no_or_empty_tag_keeps_legacy_markers(self, tag):
+        # Empty string must behave exactly like ``None`` so users wiring
+        # the GitHub Action input through to the CLI without checking
+        # emptiness don't accidentally scope every run with an empty tag.
+        commenter = PRCommenter(comment_tag=tag)
+        assert commenter.SUMMARY_IDENTIFIER == SUMMARY_IDENTIFIER
+        assert commenter.REVIEW_IDENTIFIER == REVIEW_IDENTIFIER
+
+    def test_tag_scopes_both_identifiers(self):
+        commenter = PRCommenter(comment_tag="role")
+        assert commenter.SUMMARY_IDENTIFIER == scoped_marker(SUMMARY_IDENTIFIER, "role")
+        assert commenter.REVIEW_IDENTIFIER == scoped_marker(REVIEW_IDENTIFIER, "role")
+        assert commenter.SUMMARY_IDENTIFIER != SUMMARY_IDENTIFIER
+        assert commenter.REVIEW_IDENTIFIER != REVIEW_IDENTIFIER
+
+    def test_invalid_tag_raises(self):
+        with pytest.raises(ValueError, match="Invalid comment tag"):
+            PRCommenter(comment_tag="has space")
+
+
+# ---------------------------------------------------------------------------
+# Summary comment lifecycle — scoped identifiers must not collide
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryParallelRuns:
+    """Two runs with different tags must NOT see each other's comments.
+
+    Substring-level isolation (``identifier in body`` lookups) is pinned
+    by ``test_constants_scoped_marker.test_scoped_does_not_match_unscoped_substring``
+    and existing ``test_summary_comment_staleness`` tests; this class
+    exercises the end-to-end ``post_multipart_comments`` flow.
+    """
+
+    @pytest.mark.asyncio
+    async def test_role_run_does_not_overwrite_policy_summary(self, gh):
+        """Bug from issue #103 reproduced and fixed.
+
+        Pre-fix: two runs share ``SUMMARY_IDENTIFIER``; the second run's
+        ``post_multipart_comments`` matches the first's comment and PATCHes
+        it. Post-fix: scoped markers split the lookups so each run only
+        touches its own comment id.
+        """
+        policy_marker = scoped_marker(SUMMARY_IDENTIFIER, "policy")
+        role_marker = scoped_marker(SUMMARY_IDENTIFIER, "role")
+
+        # Existing: policy run's summary lives on the PR.
+        existing = [
+            {"id": 100, "body": policy_marker + "\npolicy summary", "created_at": "2026-04-01T10:00:00Z"},
+        ]
+        with (
+            patch.object(gh, "_make_paginated_request", AsyncMock(return_value=existing)),
+            patch.object(gh, "post_comment", AsyncMock(return_value=True)) as mock_post,
+            patch.object(gh, "_update_comment", AsyncMock(return_value=True)) as mock_update,
+            patch.object(gh, "_make_request", AsyncMock(return_value={})) as mock_req,
+        ):
+            # Role run posts under its own marker.
+            ok = await gh.post_multipart_comments(["role summary updated"], role_marker)
+
+        assert ok is True
+        # Critical: the role run must NOT have updated the policy run's id=100.
+        mock_update.assert_not_awaited()
+        # It must have POSTed a brand-new comment under the role marker.
+        mock_post.assert_awaited_once()
+        new_body = mock_post.await_args.args[0]
+        assert role_marker in new_body
+        assert "role summary updated" in new_body
+        # And it must NOT have deleted the policy run's comment as an "orphan".
+        delete_calls = [c for c in mock_req.await_args_list if c.args and c.args[0] == "DELETE"]
+        assert delete_calls == []
+
+    @pytest.mark.asyncio
+    async def test_rerun_same_tag_updates_in_place(self, gh):
+        """Within the same scope, the existing in-place update behaviour
+        must keep working — that's the property we don't want to lose by
+        introducing scoping."""
+        policy_marker = scoped_marker(SUMMARY_IDENTIFIER, "policy")
+        existing = [
+            {"id": 100, "body": policy_marker + "\nold body", "created_at": "2026-04-01T10:00:00Z"},
+        ]
+        with (
+            patch.object(gh, "_make_paginated_request", AsyncMock(return_value=existing)),
+            patch.object(gh, "post_comment", AsyncMock(return_value=True)) as mock_post,
+            patch.object(gh, "_update_comment", AsyncMock(return_value=True)) as mock_update,
+            patch.object(gh, "_make_request", AsyncMock(return_value={})),
+        ):
+            ok = await gh.post_multipart_comments(["new body"], policy_marker)
+
+        assert ok is True
+        mock_update.assert_awaited_once()
+        assert mock_update.await_args.args[0] == 100
+        mock_post.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Inline review comments — fingerprint lookups are scoped
+# ---------------------------------------------------------------------------
+
+
+class TestReviewParallelRuns:
+    @pytest.mark.asyncio
+    async def test_fingerprint_index_filtered_by_scoped_marker(self, gh):
+        """``_get_bot_comments_by_fingerprint`` must only return rows whose
+        body contains the exact scoped identifier. Rows tagged for another
+        run leak across runs without this filter and trigger spurious
+        ``update_review_comment`` calls."""
+        policy_marker = scoped_marker(REVIEW_IDENTIFIER, "policy")
+        role_marker = scoped_marker(REVIEW_IDENTIFIER, "role")
+        finding_id = "a" * 16  # canonical 16-char hex hash
+
+        comments = [
+            {
+                "id": 1,
+                "body": f"{policy_marker}\n<!-- finding-id: {finding_id} -->\npolicy",
+                "path": "policy.json",
+                "line": 5,
+            },
+            {
+                "id": 2,
+                "body": f"{role_marker}\n<!-- finding-id: {finding_id} -->\nrole",
+                "path": "trust.json",
+                "line": 3,
+            },
+        ]
+        with patch.object(gh, "get_review_comments", AsyncMock(return_value=comments)):
+            policy_idx = await gh._get_bot_comments_by_fingerprint(policy_marker)
+            role_idx = await gh._get_bot_comments_by_fingerprint(role_marker)
+
+        # Same fingerprint hash, but different scoped runs index different
+        # comment ids — the role run will not "claim" the policy run's row.
+        assert policy_idx[finding_id]["id"] == 1
+        assert role_idx[finding_id]["id"] == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end producer/consumer contract — bodies POSTed to GitHub must
+# carry the scoped REVIEW_IDENTIFIER so subsequent runs can find them.
+# ---------------------------------------------------------------------------
+
+
+class TestReviewBodyEndToEnd:
+    """Regression guard for issue #103.
+
+    Pre-fix, ``ValidationIssue.to_pr_comment`` hard-coded the un-scoped
+    ``REVIEW_IDENTIFIER`` into every inline review comment body. A
+    ``PRCommenter(comment_tag="role")`` therefore POSTed bodies with the
+    un-scoped marker, while looking up existing comments by the scoped
+    marker. The lookup missed every time, so each rerun POSTed a fresh
+    duplicate of every comment.
+
+    The fix: ``to_pr_comment`` accepts ``review_identifier`` and the
+    three call sites in ``PRCommenter`` thread ``self.REVIEW_IDENTIFIER``
+    through. This test exercises the producer end-to-end via the real
+    ``_post_off_diff_comments`` path (no synthetic body fabrication).
+    """
+
+    @pytest.mark.asyncio
+    async def test_off_diff_body_carries_scoped_review_identifier(self):
+        from iam_validator.core.models import ValidationIssue
+        from iam_validator.core.pr_commenter import ContextIssue
+
+        scoped = scoped_marker(REVIEW_IDENTIFIER, "role")
+        github = AsyncMock()
+        github.get_pr_info = AsyncMock(return_value={"head": {"sha": "deadbeef"}})
+        github._get_bot_comments_by_fingerprint = AsyncMock(return_value={})
+        github.create_review_comment = AsyncMock(return_value=True)
+        github.create_file_level_comment = AsyncMock(return_value=False)
+
+        commenter = PRCommenter(github=github, comment_tag="role")
+        issue = ValidationIssue(
+            policy_file="role.json",
+            statement_index=0,
+            severity="warning",
+            issue_type="overly_broad_action",
+            message="Action should be more specific",
+            action="s3:*",
+            line_number=7,
+            check_id="wildcard_action",
+        )
+        ctx = ContextIssue("role.json", 0, 7, issue)
+
+        await commenter._post_off_diff_comments([ctx])
+
+        github.create_review_comment.assert_awaited_once()
+        # Signature: create_review_comment(commit_id, file_path, line, body)
+        body = github.create_review_comment.await_args.args[3]
+        # Producer/consumer contract: the body MUST carry the scoped marker
+        # so the next run's `_get_bot_comments_by_fingerprint(scoped)`
+        # lookup actually finds it.
+        assert scoped in body, (
+            f"Body did not include scoped marker {scoped!r}. "
+            "This is the issue #103 regression — the inline comment body "
+            "must carry the same identifier the lookup will search for. "
+            f"Body was:\n{body[:200]}..."
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_tag_body_uses_legacy_marker(self):
+        """Backward-compat regression: untagged commenter must still emit
+        the un-scoped REVIEW_IDENTIFIER — no accidental scoping."""
+        from iam_validator.core.models import ValidationIssue
+        from iam_validator.core.pr_commenter import ContextIssue
+
+        github = AsyncMock()
+        github.get_pr_info = AsyncMock(return_value={"head": {"sha": "deadbeef"}})
+        github._get_bot_comments_by_fingerprint = AsyncMock(return_value={})
+        github.create_review_comment = AsyncMock(return_value=True)
+        github.create_file_level_comment = AsyncMock(return_value=False)
+
+        commenter = PRCommenter(github=github)  # no tag
+        issue = ValidationIssue(
+            policy_file="p.json",
+            statement_index=0,
+            severity="warning",
+            issue_type="x",
+            message="m",
+            check_id="c",
+        )
+        ctx = ContextIssue("p.json", 0, 5, issue)
+
+        await commenter._post_off_diff_comments([ctx])
+
+        body = github.create_review_comment.await_args.args[3]
+        assert REVIEW_IDENTIFIER in body
+        # And no accidental ":-->" or partial scope tail.
+        assert ":-->" not in body
+
+    @pytest.mark.asyncio
+    async def test_in_diff_inline_body_carries_scoped_review_identifier(self, tmp_path):
+        """E2E for the IN-DIFF inline path (``pr_commenter.py:412`` for
+        statement-level findings). Removing ``review_identifier=...`` from
+        that call site would let a tagged run POST inline comments under
+        the un-scoped marker, and the lookup ``identifier in body`` in
+        ``_get_bot_comments_by_fingerprint`` would never match → duplicates
+        on every rerun. ``test_off_diff_body_carries_...`` only covers the
+        off-diff path; this test covers the most common on-diff path.
+        """
+        import os
+        from unittest import mock as umock
+
+        from iam_validator.core.models import (
+            PolicyValidationResult,
+            ValidationIssue,
+            ValidationReport,
+        )
+
+        scoped = scoped_marker(REVIEW_IDENTIFIER, "role")
+
+        policy_file = tmp_path / "role.json"
+        policy_file.write_text(
+            "{\n"
+            '  "Version": "2012-10-17",\n'
+            '  "Statement": [\n'
+            "    {\n"
+            '      "Sid": "Demo",\n'
+            '      "Effect": "Allow",\n'
+            '      "Action": "s3:*",\n'
+            '      "Resource": "*"\n'
+            "    }\n"
+            "  ]\n"
+            "}\n"
+        )
+
+        github = AsyncMock()
+        github.is_configured = lambda: True
+        github.get_pr_files = AsyncMock(
+            return_value=[
+                {
+                    "filename": policy_file.name,
+                    "status": "modified",
+                    # The "+" line is line 7 in the new file (Action).
+                    "patch": (
+                        "@@ -4,5 +4,5 @@\n"
+                        "     {\n"
+                        '       "Sid": "Demo",\n'
+                        '       "Effect": "Allow",\n'
+                        '-      "Action": "s3:GetObject",\n'
+                        '+      "Action": "s3:*",\n'
+                    ),
+                }
+            ]
+        )
+        github.update_or_create_review_comments = AsyncMock(return_value=True)
+
+        issue = ValidationIssue(
+            policy_file=str(policy_file),
+            statement_index=0,
+            severity="warning",
+            issue_type="overly_broad_action",
+            message="Action is overly broad",
+            action="s3:*",
+            line_number=7,
+            check_id="wildcard_action",
+        )
+        report = ValidationReport(
+            results=[
+                PolicyValidationResult(
+                    policy_file=str(policy_file),
+                    is_valid=False,
+                    issues=[issue],
+                    policy_type="IDENTITY_POLICY",
+                )
+            ],
+            total_policies=1,
+            valid_policies=0,
+            invalid_policies=1,
+            valid_count=0,
+            invalid_count=1,
+            total_issues=1,
+            policies_with_security_issues=1,
+            validity_issues=0,
+            security_issues=1,
+        )
+
+        commenter = PRCommenter(github=github, comment_tag="role", cleanup_old_comments=False)
+        with umock.patch.dict(os.environ, {"GITHUB_WORKSPACE": str(tmp_path)}):
+            ok = await commenter._post_review_comments(report)
+        assert ok is True
+
+        github.update_or_create_review_comments.assert_called_once()
+        kwargs = github.update_or_create_review_comments.call_args.kwargs
+        comments = kwargs["comments"]
+        assert len(comments) == 1, f"Expected 1 inline comment, got {len(comments)}"
+        body = comments[0]["body"]
+        # Producer/consumer contract: the body POSTed for an in-diff line
+        # must carry the SAME scoped marker the consumer will look up by.
+        assert scoped in body, (
+            f"In-diff inline body did not include scoped marker {scoped!r}. "
+            "Removing review_identifier=self.REVIEW_IDENTIFIER from "
+            "pr_commenter.py:_post_review_comments would put the un-scoped "
+            "marker in the body and break duplicate-suppression for tagged runs."
+            f"\nBody was:\n{body[:200]}..."
+        )
+        # Cleanup-side check: the identifier passed to the cleanup API is
+        # also scoped (so producer/consumer use the same key).
+        assert kwargs["identifier"] == scoped
+
+
+# ---------------------------------------------------------------------------
+# Ignored findings storage — scoping isolates the JSON stores
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoredFindingsScoped:
+    @pytest.mark.asyncio
+    async def test_finds_only_own_storage_comment(self):
+        """Two stores with different tags must read distinct payloads even
+        when both storage comments coexist on the same PR."""
+        policy_marker = scoped_marker(IGNORED_FINDINGS_IDENTIFIER, "policy")
+        role_marker = scoped_marker(IGNORED_FINDINGS_IDENTIFIER, "role")
+
+        # Different ignored finding under each scope.
+        policy_body = (
+            policy_marker
+            + "\n```json\n"
+            + '{"version": 1, "ignored_findings": [{"finding_id": "policyhash0000000", '
+            + '"file_path": "p.json", "check_id": "c", "issue_type": "t", '
+            + '"ignored_by": "u", "ignored_at": "2026-04-01T00:00:00Z"}]}\n```\n'
+        )
+        role_body = (
+            role_marker
+            + "\n```json\n"
+            + '{"version": 1, "ignored_findings": [{"finding_id": "rolehash0000000000", '
+            + '"file_path": "r.json", "check_id": "c", "issue_type": "t", '
+            + '"ignored_by": "u", "ignored_at": "2026-04-01T00:00:00Z"}]}\n```\n'
+        )
+        comments = [
+            {"id": 10, "body": policy_body},
+            {"id": 11, "body": role_body},
+        ]
+
+        github = AsyncMock()
+        github.get_issue_comments = AsyncMock(return_value=comments)
+
+        policy_store = IgnoredFindingsStore(github, comment_tag="policy")
+        role_store = IgnoredFindingsStore(github, comment_tag="role")
+
+        policy_loaded = await policy_store.load()
+        role_loaded = await role_store.load()
+
+        assert "policyhash0000000" in policy_loaded
+        assert "rolehash0000000000" not in policy_loaded
+        assert "rolehash0000000000" in role_loaded
+        assert "policyhash0000000" not in role_loaded
+
+    @pytest.mark.asyncio
+    async def test_no_tag_finds_legacy_un_scoped_storage(self):
+        """Critical regression guard: existing storage comments stored
+        under the un-scoped marker before this feature shipped must still
+        be loadable by stores constructed without a tag."""
+        comments = [
+            {
+                "id": 1,
+                "body": (
+                    IGNORED_FINDINGS_IDENTIFIER
+                    + "\n```json\n"
+                    + '{"version": 1, "ignored_findings": [{"finding_id": "legacyhash0000000", '
+                    + '"file_path": "p.json", "check_id": "c", "issue_type": "t", '
+                    + '"ignored_by": "u", "ignored_at": "2026-04-01T00:00:00Z"}]}\n```\n'
+                ),
+            }
+        ]
+        github = AsyncMock()
+        github.get_issue_comments = AsyncMock(return_value=comments)
+
+        store = IgnoredFindingsStore(github)  # no comment_tag
+        loaded = await store.load()
+        assert "legacyhash0000000" in loaded
+
+    @pytest.mark.asyncio
+    async def test_pr_commenter_loads_from_tagged_store(self):
+        """Plumbing regression guard.
+
+        ``PRCommenter._load_ignored_findings`` must construct
+        ``IgnoredFindingsStore(self.github, comment_tag=self.comment_tag)``
+        — not just ``IgnoredFindingsStore(self.github)``. If someone drops
+        the ``comment_tag=`` kwarg, the commenter would read ignored
+        findings from the wrong (un-tagged) store and silently drop
+        scope-specific ignores. None of the unit-level store tests catch
+        this; this test pins the integration.
+
+        The PR has BOTH an un-tagged storage comment (with `legacyhash...`)
+        AND a role-tagged storage comment (with `rolehash...`). A
+        ``PRCommenter(comment_tag="role")`` must load only the role one.
+        """
+        legacy_body = (
+            IGNORED_FINDINGS_IDENTIFIER
+            + "\n```json\n"
+            + '{"version": 1, "ignored_findings": [{"finding_id": "legacyhash0000000", '
+            + '"file_path": "p.json", "check_id": "c", "issue_type": "t", '
+            + '"ignored_by": "u", "ignored_at": "2026-04-01T00:00:00Z"}]}\n```\n'
+        )
+        role_marker = scoped_marker(IGNORED_FINDINGS_IDENTIFIER, "role")
+        role_body = (
+            role_marker
+            + "\n```json\n"
+            + '{"version": 1, "ignored_findings": [{"finding_id": "rolehash00000000", '
+            + '"file_path": "r.json", "check_id": "c", "issue_type": "t", '
+            + '"ignored_by": "u", "ignored_at": "2026-04-01T00:00:00Z"}]}\n```\n'
+        )
+
+        github = AsyncMock()
+        github.get_issue_comments = AsyncMock(
+            return_value=[
+                {"id": 1, "body": legacy_body},
+                {"id": 2, "body": role_body},
+            ]
+        )
+
+        commenter = PRCommenter(github=github, comment_tag="role")
+        await commenter._load_ignored_findings()
+
+        # The role-tagged commenter must see ONLY the role store. If the
+        # plumbing is broken (no comment_tag forwarded), it would load the
+        # legacy store and `legacyhash...` would appear here.
+        assert "rolehash00000000" in commenter._ignored_finding_ids
+        assert "legacyhash0000000" not in commenter._ignored_finding_ids
+
+    @pytest.mark.asyncio
+    async def test_save_writes_scoped_marker(self):
+        """The persisted comment body must carry the scoped marker so the
+        next run's ``load()`` can find it."""
+        github = AsyncMock()
+        github.get_issue_comments = AsyncMock(return_value=[])
+        github.post_comment = AsyncMock(return_value=True)
+
+        store = IgnoredFindingsStore(github, comment_tag="role")
+        store._cache = {
+            "f" * 16: IgnoredFinding(
+                finding_id="f" * 16,
+                file_path="r.json",
+                check_id="c",
+                issue_type="t",
+                ignored_by="u",
+                ignored_at="2026-04-01T00:00:00Z",
+            )
+        }
+        # Save calls ``_find_storage_comment`` after posting; mock it to
+        # avoid a second ``get_issue_comments`` round-trip.
+        with patch.object(store, "_find_storage_comment", AsyncMock(return_value=None)):
+            ok = await store.save()
+        assert ok is True
+
+        body = github.post_comment.await_args.args[0]
+        assert scoped_marker(IGNORED_FINDINGS_IDENTIFIER, "role") in body
+        # The bare un-scoped marker must not appear standalone.
+        assert IGNORED_FINDINGS_IDENTIFIER not in body.replace(scoped_marker(IGNORED_FINDINGS_IDENTIFIER, "role"), "")


### PR DESCRIPTION
## Summary

Closes #103. Multiple validator runs on the same PR (e.g. one job per policy type) currently overwrite each other's comments because all four HTML markers (`SUMMARY_IDENTIFIER`, `REVIEW_IDENTIFIER`,
`ANALYZER_IDENTIFIER`, `IGNORED_FINDINGS_IDENTIFIER`) are hardcoded — the second run's `update_or_create_*` flow PATCHes the first run's canonical comment.

This PR introduces a `--comment-tag <TAG>` opt-in flag (with matching `comment-tag` GitHub Action input and `comment_tag:` config setting) that scopes every marker to `:<TAG>` so each run maintains its own
thread.

## Approach

- **Centralised marker rewrite** in `iam_validator/core/constants.py::scoped_marker(base, tag)`, validated against `COMMENT_TAG_PATTERN = ^[A-Za-z0-9._-]{1,32}$`. Same regex enforced on the config side via a
Pydantic field validator. Single source of truth — no inline `replace(" -->", ...)` scattered across call sites.
- **All four markers scoped, not just two**: summary, review, analyzer, **and ignored-findings**. Skipping the ignored-findings store would let two tagged runs trample each other's ignore lists.
- **Producer/consumer parity**: `ValidationIssue.to_pr_comment(review_identifier=...)` accepts the scoped marker so inline review bodies carry the same identifier the lookup will search by. Without this fix,
tagged runs would POST under the un-scoped marker and re-create every comment on every rerun (silent duplicate-comment bug).
- **Backward compatible**: with no tag, every marker is byte-identical to pre-1.21.0 output, and `IgnoredFindingsStore` continues to load comments stored under the legacy un-scoped marker. Existing PR comments
and stored ignores remain matchable without user action.

## Files changed

- `iam_validator/core/constants.py` — `scoped_marker` helper + `COMMENT_TAG_PATTERN`
- `iam_validator/core/pr_commenter.py` — `comment_tag` constructor arg, scoped instance markers, threaded into `IgnoredFindingsStore` / `IgnoreCommandProcessor`
- `iam_validator/core/models.py` — `ValidationIssue.to_pr_comment(review_identifier=...)`
- `iam_validator/core/ignored_findings.py` + `iam_validator/core/ignore_processor.py` — tag plumbed
- `iam_validator/commands/{validate,analyze,post_to_pr,completion}.py` — `--comment-tag` flag + bash/zsh completion
- `iam_validator/core/config/{config_loader,defaults}.py` — `settings.comment_tag` with Pydantic validation
- `action.yaml` — `comment-tag` input wired to `--comment-tag`
- Docs: `README.md`, `docs/user-guide/{cli-reference,configuration}.md`, `docs/integrations/github-actions.md` (matrix example), `CLAUDE.md`, `iam_validator/integrations/CLAUDE.md`
- `iam_validator/__version__.py` → `1.21.0`, `CHANGELOG.md` entry under 1.21.0
- `tests/core/test_constants_scoped_marker.py` (23 tests) and `tests/integrations/test_parallel_runs.py` (14 tests)

## Test plan

- [x] `uv run pytest tests/core/test_constants_scoped_marker.py tests/integrations/test_parallel_runs.py` → 37 passed
- [x] Full fast suite `uv run pytest -m "not benchmark and not slow and not integration"` → 1517 passed, 23 skipped
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [ ] Manual: kick a workflow with two matrix jobs (`identity` + `trust`), confirm two distinct PR comments persist across reruns

## Usage

```yaml
- uses: boogy/iam-policy-validator@v1
  with:
    path: ${{ matrix.path }}
    policy-type: ${{ matrix.type }}
    comment-tag: ${{ matrix.tag }} # 'identity', 'trust', etc.
```