### PR TITLE
docs(skill): improve iam-policy-validator for adoption, accuracy, and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,6 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- `iam-policy-validator` skill (`skills/iam-policy-validator/`): added `argument-hint`, a deep querying reference (actions/conditions/ARNs and the action↔condition intersection), and a JSON-export → verify → PR-comment handoff reference so a second agent reviews findings before posting instead of the validator commenting directly.
-- `iam-policy-validator` skill: made portable and agent-friendly — trimmed `SKILL.md` to under 100 lines, rewrote the description as a single capability + "Use when" trigger sentence, and formalized explicit producer/poster agent roles for the PR handoff (the validator never posts). The skill is now self-contained (CLI via `uvx` + `python3` only; no dependency on the validator source tree).
-
-### Added
-
-- `skills/iam-policy-validator/scripts/render_pr_comments.py`: stdlib-only renderer that turns validator JSON findings into ready-to-post PR-comment markdown (matching `ValidationIssue.to_pr_comment()`), with `--format json` for downstream posting agents and `--min-severity` filtering. Lets a poster agent post identical comments without re-implementing the layout.
-
 ## [1.21.0] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 ### Changed
 
 - `iam-policy-validator` skill (`skills/iam-policy-validator/`): added `argument-hint`, a deep querying reference (actions/conditions/ARNs and the action↔condition intersection), and a JSON-export → verify → PR-comment handoff reference so a second agent reviews findings before posting instead of the validator commenting directly.
+- `iam-policy-validator` skill: made portable and agent-friendly — trimmed `SKILL.md` to under 100 lines, rewrote the description as a single capability + "Use when" trigger sentence, and formalized explicit producer/poster agent roles for the PR handoff (the validator never posts). The skill is now self-contained (CLI via `uvx` + `python3` only; no dependency on the validator source tree).
+
+### Added
+
+- `skills/iam-policy-validator/scripts/render_pr_comments.py`: stdlib-only renderer that turns validator JSON findings into ready-to-post PR-comment markdown (matching `ValidationIssue.to_pr_comment()`), with `--format json` for downstream posting agents and `--min-severity` filtering. Lets a poster agent post identical comments without re-implementing the layout.
 
 ## [1.21.0] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `iam-policy-validator` skill (`skills/iam-policy-validator/`): added `argument-hint`, a deep querying reference (actions/conditions/ARNs and the action↔condition intersection), and a JSON-export → verify → PR-comment handoff reference so a second agent reviews findings before posting instead of the validator commenting directly.
+
 ## [1.21.0] - 2026-05-01
 
 ### Added

--- a/skills/iam-policy-validator/SKILL.md
+++ b/skills/iam-policy-validator/SKILL.md
@@ -6,13 +6,39 @@ argument-hint: "[validate|query|analyze] <policy-path|dir> [--config <file>] [--
 
 # IAM Policy Validator (CLI)
 
-Validate AWS IAM policies against 22 built-in checks and query AWS service definitions with the `iam-validator` CLI. Self-contained: needs only the CLI (run via `uvx`, no install) plus `python3` for the bundled comment renderer.
+Validate AWS IAM policies against 22 built-in checks and query AWS service definitions. Self-contained: needs only the CLI (`uvx`, no install) plus Python 3.10+.
 
 Home: https://github.com/boogy/iam-policy-validator · Docs: https://boogy.github.io/iam-policy-validator/
 
-## Invocation arguments
+## What do you need to do?
 
-`[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]`
+| Goal                                | Command                                                        |
+| ----------------------------------- | -------------------------------------------------------------- |
+| Validate a policy file or directory | `iam-validator validate --path <path>`                         |
+| Validate and post findings to a PR  | `validate --format json` -> verify -> `post-to-pr` (see below) |
+| Query AWS actions, ARNs, conditions | `iam-validator query action\|arn\|condition --service <svc>`   |
+| Run AWS IAM Access Analyzer         | `iam-validator analyze --path <path>`                          |
+| Manage the AWS service cache        | `iam-validator cache info\|clear\|refresh\|prefetch`           |
+| Pre-download for offline/CI         | `iam-validator sync-services --output-dir ./aws_services/`     |
+| Generate shell completions          | `iam-validator completion bash\|zsh`                           |
+
+## Quickstart
+
+```bash
+# Scan one file (no install needed)
+uvx iam-policy-validator validate --path policy.json
+
+# Scan a directory recursively
+uvx iam-policy-validator validate --path ./policies/
+
+# Trust policy (auto-detect works, but explicit is safer)
+uvx iam-policy-validator validate --path trust.json --policy-type TRUST_POLICY
+
+# JSON output for scripting or PR handoff
+uvx iam-policy-validator validate --path ./policies/ --format json --output findings.json
+```
+
+## Invocation arguments
 
 | Skill argument         | Maps to CLI                                                                      |
 | ---------------------- | -------------------------------------------------------------------------------- |
@@ -22,7 +48,7 @@ Home: https://github.com/boogy/iam-policy-validator · Docs: https://boogy.githu
 | `--config <file>`      | `--config <file>` (forwarded verbatim; YAML)                                     |
 | `--export-json <file>` | `--format json --output <file>`, then hand off — do NOT post                     |
 
-Defaults: no verb → `validate`. With `--export-json`, follow the PR handoff below and never post comments with the validator.
+Defaults: no verb -> `validate`. With `--export-json`, follow the PR handoff and never post comments directly.
 
 ## Install / run
 
@@ -34,51 +60,69 @@ iam-validator --version
 
 Do not install the `[mcp]` extra — this skill is CLI-only.
 
-## Validate
+## PR workflow (two options)
+
+### Option 1: Native `post-to-pr` (simpler)
 
 ```bash
-iam-validator validate --path ./policies/                          # recursive
-iam-validator validate --path trust.json --policy-type TRUST_POLICY
-iam-validator validate --path ./policies/ --config iam-validator.yaml
-iam-validator validate --path policy.json --format sarif --output results.sarif
+iam-validator validate --path ./policies/ --format json --output report.json
+iam-validator post-to-pr --report report.json
 ```
 
-Policy types: `IDENTITY_POLICY` (default), `RESOURCE_POLICY`, `TRUST_POLICY`, `SERVICE_CONTROL_POLICY`, `RESOURCE_CONTROL_POLICY` — auto-detected when `--policy-type` is omitted. Exit `0` on success, non-zero on errors; add `--fail-on-warnings` for strict CI.
+Posts all findings. Good for CI where you trust the validator's output. See [references/ci-integration.md](references/ci-integration.md).
 
-Common targets: wildcards (`full_wildcard`, `wildcard_action`, `wildcard_resource`, `service_wildcard`); privilege escalation (`sensitive_action`, 490+ actions); confused deputy on trust policies (`trust_policy_validation`). See [references/checks.md](references/checks.md).
-
-## Agent-to-agent PR workflow (don't post directly)
-
-Two roles. The **producer** validates, verifies, and exports JSON. The **poster** renders and posts. The validator never comments itself.
+### Option 2: JSON handoff with verification (recommended for agents)
 
 ```bash
-# Producer: export findings only — no --github-* flags, no post-to-pr
+# 1. Export findings
 iam-validator validate --path ./policies/ --format json --output findings.json
 
-# Poster: deterministic render → ready-to-post comment objects
+# 2. Verify each finding with query (see verification-protocol.md)
+iam-validator query action --name <svc:Action> --has-condition-key <key>
+
+# 3. Render verified findings
 python3 scripts/render_pr_comments.py findings.json --format json > comments.json
+
+# 4. Post from a separate agent
 ```
 
-The JSON carries the same suggestion / example / remediation / risk data the validator shows in comments, and `scripts/render_pr_comments.py` reproduces the exact comment layout (stdlib-only, no install). The producer should verify each finding (use `query`) before handing off. Full protocol, JSON schema, verification checklist, and `gh` posting recipe: [references/pr-review-handoff.md](references/pr-review-handoff.md).
+Full protocol: [references/pr-review-handoff.md](references/pr-review-handoff.md). Verification checklist: [references/verification-protocol.md](references/verification-protocol.md).
 
-## Query (no policy file needed)
+## Exit codes
 
-`iam-validator query action|arn|condition` looks up actions, ARN formats, condition keys, and which actions support a given condition key (`--has-condition-key`). Full guide: [references/querying.md](references/querying.md).
+| Code     | Meaning                                                                   |
+| -------- | ------------------------------------------------------------------------- |
+| `0`      | No error-severity findings (warnings may still exist)                     |
+| non-zero | Error-severity findings, or `--fail-on-warnings` + warnings, or CLI error |
+
+Read stderr and findings before drawing conclusions. A non-zero exit does not necessarily mean the policy is dangerous.
+
+## Policy types
+
+`IDENTITY_POLICY` (default), `RESOURCE_POLICY`, `TRUST_POLICY`, `SERVICE_CONTROL_POLICY`, `RESOURCE_CONTROL_POLICY` — auto-detected when `--policy-type` is omitted. Pass it explicitly for trust, resource, SCP, or RCP documents to avoid false positives.
 
 ## References
 
 - [checks.md](references/checks.md) — the 22 checks with IDs and severities
-- [querying.md](references/querying.md) — query actions / ARNs / condition keys and the action↔condition intersection
+- [querying.md](references/querying.md) — query actions / ARNs / condition keys
 - [configuration.md](references/configuration.md) — YAML config, ignore patterns, severity overrides
 - [output-formats.md](references/output-formats.md) — console / json / sarif / markdown / html / csv / enhanced
-- [pr-review-handoff.md](references/pr-review-handoff.md) — export JSON, verify, render + post PR comments from a second agent
-- [troubleshooting.md](references/troubleshooting.md) — cache, offline mode, rate limits, common errors
+- [ci-integration.md](references/ci-integration.md) — `--ci`, `post-to-pr`, `--github-*`, `--comment-tag`, PR workflows
+- [advanced-flags.md](references/advanced-flags.md) — `--stdin`, `--custom-checks-dir`, `--stream`, `completion`, and more
+- [verification-protocol.md](references/verification-protocol.md) — verify findings before posting (query-based checklist)
+- [pr-review-handoff.md](references/pr-review-handoff.md) — export JSON, verify, render + post PR comments
+- [common-mistakes.md](references/common-mistakes.md) — agent accuracy: fabricated flags, wrong inputs, hallucination prevention
+- [troubleshooting.md](references/troubleshooting.md) — cache, offline mode, rate limits, first-run latency
 
 For authoritative per-check detail, see https://boogy.github.io/iam-policy-validator/user-guide/checks/ rather than inventing specifics.
 
 ## Guardrails
 
-- Verify flags with `iam-validator <cmd> --help`; don't fabricate them.
-- Show findings before editing a user's policy; don't silently rewrite.
-- Prefer `uvx iam-policy-validator ...` over global installs; ask before changing the environment.
-- For PRs, default to the JSON handoff; post directly with the validator only when the user explicitly asks.
+- **Verify flags** with `iam-validator <cmd> --help`; don't fabricate them.
+- **Show findings before editing** a user's policy; don't silently rewrite.
+- **Prefer `uvx`** over global installs; ask before changing the environment.
+- **Don't invent findings** — if the validator reports 0 issues, the policy is clean.
+- **Don't invent check IDs** — use only the 22 IDs from [checks.md](references/checks.md).
+- **Verify before posting** — for PRs, follow [verification-protocol.md](references/verification-protocol.md).
+- **Use `--policy-type`** for non-identity policies to avoid false positives.
+- **Read [common-mistakes.md](references/common-mistakes.md)** for the full list of agent pitfalls.

--- a/skills/iam-policy-validator/SKILL.md
+++ b/skills/iam-policy-validator/SKILL.md
@@ -1,218 +1,84 @@
 ---
 name: iam-policy-validator
-description: Validate, analyze, and query AWS IAM policies using the iam-policy-validator CLI. Use this skill when the user asks to check, validate, lint, audit, or find security issues in IAM policies, trust policies, SCPs, RCPs, or resource policies; when they mention wildcard actions, privilege escalation, sensitive actions, confused deputy, or overly permissive policies; when they want to run AWS IAM Access Analyzer, generate a SARIF/Markdown/HTML report from policies, query which AWS actions or condition keys exist for a service, or post IAM findings to a GitHub PR. This is the CLI-based alternative to running the MCP server.
+description: Validate, analyze, and query AWS IAM policies with the iam-policy-validator CLI, and export findings as JSON for a second agent to verify and post to a GitHub PR. Use when checking, validating, linting, or auditing IAM identity, resource, or trust policies, SCPs, or RCPs; when the user mentions wildcard actions, privilege escalation, sensitive actions, confused deputy, or overly permissive policies; when querying which AWS actions, condition keys, or ARNs a service supports (or which actions support a condition key); when running AWS IAM Access Analyzer; or when exporting SARIF/Markdown/HTML/JSON findings for PR review. CLI-based alternative to the MCP server.
 argument-hint: "[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]"
 ---
 
 # IAM Policy Validator (CLI)
 
-Use the `iam-validator` CLI to validate AWS IAM policies against 22 built-in checks (AWS correctness + security best practices) and to query AWS service definitions.
+Validate AWS IAM policies against 22 built-in checks and query AWS service definitions with the `iam-validator` CLI. Self-contained: needs only the CLI (run via `uvx`, no install) plus `python3` for the bundled comment renderer.
 
-Home page: https://github.com/boogy/iam-policy-validator · Docs: https://boogy.github.io/iam-policy-validator/
+Home: https://github.com/boogy/iam-policy-validator · Docs: https://boogy.github.io/iam-policy-validator/
 
 ## Invocation arguments
 
-`argument-hint`: `[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]`
+`[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]`
 
-Interpret the arguments passed to this skill and translate them to real CLI flags. `--export-json` is a skill-level argument (not a CLI flag); map it as shown.
+| Skill argument         | Maps to CLI                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `validate` (default)   | `iam-validator validate --path <path>`                                           |
+| `query`                | `iam-validator query ...` — see [references/querying.md](references/querying.md) |
+| `analyze`              | `iam-validator analyze --path <path>` (AWS IAM Access Analyzer)                  |
+| `--config <file>`      | `--config <file>` (forwarded verbatim; YAML)                                     |
+| `--export-json <file>` | `--format json --output <file>`, then hand off — do NOT post                     |
 
-| Skill argument         | Meaning                                                        | Maps to CLI                                                                      |
-| ---------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `validate` (default)   | Validate policies — the default verb when none is given        | `iam-validator validate ...`                                                     |
-| `query`                | Look up actions / ARNs / condition keys (no policy needed)     | `iam-validator query ...` — see [references/querying.md](references/querying.md) |
-| `analyze`              | Run AWS IAM Access Analyzer                                    | `iam-validator analyze ...`                                                      |
-| `<policy-path\|dir>`   | File or directory to validate                                  | `--path <policy-path\|dir>`                                                      |
-| `--config <file>`      | Path to a YAML config file                                     | `--config <file>` (forwarded verbatim)                                           |
-| `--export-json <file>` | Export findings as JSON for the PR-review handoff; do NOT post | `--format json --output <file>` (and skip `--github-*`/`post-to-pr`)             |
+Defaults: no verb → `validate`. With `--export-json`, follow the PR handoff below and never post comments with the validator.
 
-Rules:
-
-- No verb → default to `validate`.
-- `--config <file>` present → always forward it to the CLI.
-- `--export-json <file>` present → follow the handoff workflow in [references/pr-review-handoff.md](references/pr-review-handoff.md); never post PR comments yourself with the validator.
-
-## Installation
-
-Preferred — run without installing:
+## Install / run
 
 ```bash
-uvx iam-policy-validator validate --path policy.json
-```
-
-Or install in the current project:
-
-```bash
-uv add iam-policy-validator       # uv
-pip install iam-policy-validator  # pip
-```
-
-Verify:
-
-```bash
+uvx iam-policy-validator validate --path policy.json   # preferred, no install
+uv add iam-policy-validator        # or: pip install iam-policy-validator
 iam-validator --version
 ```
 
-Never install `iam-policy-validator[mcp]` for this skill — the MCP server is a separate usage path; this skill is CLI-only.
+Do not install the `[mcp]` extra — this skill is CLI-only.
 
-## Decision guide
-
-Pick the right command from the user's intent:
-
-| User asks                                                   | Command                             |
-| ----------------------------------------------------------- | ----------------------------------- |
-| "validate / check / lint / audit this policy"               | `iam-validator validate`            |
-| "scan the whole policies directory"                         | `iam-validator validate --path DIR` |
-| "what would AWS Access Analyzer say?"                       | `iam-validator analyze`             |
-| "post these findings to the PR"                             | `iam-validator post-to-pr`          |
-| "which S3 actions exist / what condition keys does X have?" | `iam-validator query`               |
-| "pre-download AWS service definitions for offline / CI"     | `iam-validator sync-services`       |
-| "clear / inspect the cache"                                 | `iam-validator cache`               |
-
-Always run with `--help` when unsure of a flag: `iam-validator <subcommand> --help`.
-
-## Core workflow — validate
+## Validate
 
 ```bash
-# Single file, console output
-iam-validator validate --path policy.json
-
-# Directory, recursive (default). Non-zero exit on errors; add --fail-on-warnings for strict mode.
-iam-validator validate --path ./policies/ --fail-on-warnings
-
-# Different policy types
+iam-validator validate --path ./policies/                          # recursive
 iam-validator validate --path trust.json --policy-type TRUST_POLICY
-iam-validator validate --path scp.json   --policy-type SERVICE_CONTROL_POLICY
-iam-validator validate --path rcp.json   --policy-type RESOURCE_CONTROL_POLICY
-
-# Alternate output formats (see references/output-formats.md)
-iam-validator validate --path policy.json --format sarif    --output results.sarif
-iam-validator validate --path policy.json --format markdown --output report.md
-iam-validator validate --path policy.json --format html     --output report.html
-
-# With a config file (see references/configuration.md)
 iam-validator validate --path ./policies/ --config iam-validator.yaml
+iam-validator validate --path policy.json --format sarif --output results.sarif
 ```
 
-Exit codes: `0` on success, non-zero when the validator hits errors. By default warnings do not fail the run — pass `--fail-on-warnings` to treat them as failures in CI.
+Policy types: `IDENTITY_POLICY` (default), `RESOURCE_POLICY`, `TRUST_POLICY`, `SERVICE_CONTROL_POLICY`, `RESOURCE_CONTROL_POLICY` — auto-detected when `--policy-type` is omitted. Exit `0` on success, non-zero on errors; add `--fail-on-warnings` for strict CI.
 
-## Policy types
+Common targets: wildcards (`full_wildcard`, `wildcard_action`, `wildcard_resource`, `service_wildcard`); privilege escalation (`sensitive_action`, 490+ actions); confused deputy on trust policies (`trust_policy_validation`). See [references/checks.md](references/checks.md).
 
-Pass `--policy-type` when validating anything other than a standard identity policy:
+## Agent-to-agent PR workflow (don't post directly)
 
-- `IDENTITY_POLICY` (default) — user / role / group policies
-- `RESOURCE_POLICY` — S3 bucket, SQS, SNS, KMS key policies
-- `TRUST_POLICY` — IAM role trust (assume-role) policies
-- `SERVICE_CONTROL_POLICY` — AWS Organizations SCP
-- `RESOURCE_CONTROL_POLICY` — AWS Organizations RCP
-
-If unsure, try running without the flag first — the validator auto-detects many cases and suggests the right one.
-
-## Common recipes
-
-**Find wildcards / full-admin policies**
-
-Run `validate`; the `full_wildcard`, `wildcard_action`, `wildcard_resource`, and `service_wildcard` checks flag these by default.
-
-**Check for privilege-escalation risks**
-
-Run `validate`; the `sensitive_action` check flags 490+ privilege-escalation actions across 20+ risk categories.
-
-**Trust policy + confused deputy audit**
+Two roles. The **producer** validates, verifies, and exports JSON. The **poster** renders and posts. The validator never comments itself.
 
 ```bash
-iam-validator validate --path role-trust.json --policy-type TRUST_POLICY
-```
-
-The `trust_policy_validation` check flags missing `aws:SourceArn` / `aws:SourceAccount` on service principals.
-
-**GitHub PR posting**
-
-Default to the **two-layer** flow: export findings as JSON, then let a _separate_ reviewing agent verify and post. Do not post directly from this skill.
-
-```bash
-# Export only — no posting. Hand findings.json to a reviewing agent.
+# Producer: export findings only — no --github-* flags, no post-to-pr
 iam-validator validate --path ./policies/ --format json --output findings.json
+
+# Poster: deterministic render → ready-to-post comment objects
+python3 scripts/render_pr_comments.py findings.json --format json > comments.json
 ```
 
-The JSON carries the same suggestion/example/remediation content the validator shows in comments. See [references/pr-review-handoff.md](references/pr-review-handoff.md) for the schema, verification checklist, comment-render recipe, and `gh` posting commands.
+The JSON carries the same suggestion / example / remediation / risk data the validator shows in comments, and `scripts/render_pr_comments.py` reproduces the exact comment layout (stdlib-only, no install). The producer should verify each finding (use `query`) before handing off. Full protocol, JSON schema, verification checklist, and `gh` posting recipe: [references/pr-review-handoff.md](references/pr-review-handoff.md).
 
-The validator _can_ also post directly (`--github-comment --github-review --github-summary`, or `post-to-pr --report findings.json`) — use that only when the user explicitly wants the validator to be the poster and no second-layer review is required. Both direct paths need `GITHUB_TOKEN` and a PR context.
+## Query (no policy file needed)
 
-**AWS Access Analyzer**
-
-```bash
-iam-validator analyze --path policy.json
-```
-
-Requires AWS credentials with `access-analyzer:ValidatePolicy` permission.
-
-**Query the AWS service catalog (no policy file needed)**
-
-For the full query reference — access-level / resource-type filtering, the action↔condition intersection, and using queries to verify a finding — see [references/querying.md](references/querying.md).
-
-`query` has three subcommands: `action`, `arn`, `condition`.
-
-```bash
-# List every action for a service
-iam-validator query action --service s3
-
-# Look up a single action (service prefix optional via --name)
-iam-validator query action --name s3:GetObject
-iam-validator query action --service s3 --name GetObject
-
-# Expand a wildcard pattern
-iam-validator query action --name "s3:Get*"
-
-# ARN formats for a service's resource types
-iam-validator query arn --service s3
-
-# Condition keys for a service
-iam-validator query condition --service s3
-```
-
-**Find actions that support a specific condition key**
-
-Use this when the user asks "which S3 actions support `s3:ResourceAccount`?" or needs to scope a policy to actions that accept a given condition.
-
-```bash
-# All actions in a service that support the given condition key
-iam-validator query action --service s3 --has-condition-key "s3:ResourceAccount"
-
-# Narrow to a pattern within a service
-iam-validator query action --name "s3:Get*" --has-condition-key "s3:ResourceAccount"
-
-# Across services — use a global key like aws:SourceVpc
-iam-validator query action --service ec2 --has-condition-key "aws:SourceVpc"
-
-# Show the condition keys that each matching action supports
-iam-validator query action --service s3 --name "Get*" --show-condition-keys
-
-# Filter ARN resource types by supported condition key
-iam-validator query arn --service s3 --has-condition-key "s3:ResourceAccount"
-
-# Machine-readable output for scripting
-iam-validator query action --service s3 --has-condition-key "s3:ResourceAccount" --output json
-```
-
-Condition keys can be service-scoped (`s3:ResourceAccount`, `kms:ViaService`) or global AWS keys (`aws:SourceVpc`, `aws:PrincipalOrgID`). Both work with `--has-condition-key`.
+`iam-validator query action|arn|condition` looks up actions, ARN formats, condition keys, and which actions support a given condition key (`--has-condition-key`). Full guide: [references/querying.md](references/querying.md).
 
 ## References
 
-For details, read only what's needed:
+- [checks.md](references/checks.md) — the 22 checks with IDs and severities
+- [querying.md](references/querying.md) — query actions / ARNs / condition keys and the action↔condition intersection
+- [configuration.md](references/configuration.md) — YAML config, ignore patterns, severity overrides
+- [output-formats.md](references/output-formats.md) — console / json / sarif / markdown / html / csv / enhanced
+- [pr-review-handoff.md](references/pr-review-handoff.md) — export JSON, verify, render + post PR comments from a second agent
+- [troubleshooting.md](references/troubleshooting.md) — cache, offline mode, rate limits, common errors
 
-- [references/checks.md](references/checks.md) — the 22 built-in checks with IDs, categories, and severities
-- [references/querying.md](references/querying.md) — query actions / ARNs / condition keys and the action↔condition intersection
-- [references/configuration.md](references/configuration.md) — YAML config (disabling checks, ignore patterns, severity overrides)
-- [references/output-formats.md](references/output-formats.md) — console / json / markdown / sarif / csv / html / enhanced
-- [references/pr-review-handoff.md](references/pr-review-handoff.md) — export JSON, verify findings, render + post PR comments from a second agent
-- [references/troubleshooting.md](references/troubleshooting.md) — cache, offline mode, rate limits, common errors
-
-When the user wants authoritative per-check detail beyond check IDs, point them at https://boogy.github.io/iam-policy-validator/user-guide/checks/ rather than inventing specifics.
+For authoritative per-check detail, see https://boogy.github.io/iam-policy-validator/user-guide/checks/ rather than inventing specifics.
 
 ## Guardrails
 
-- Don't fabricate flag names — always verify with `iam-validator <cmd> --help` if uncertain.
-- Don't claim a check catches something without looking at [references/checks.md](references/checks.md) or the live docs.
-- When editing a user's policy based on findings, show them the finding first; don't silently rewrite.
-- If the CLI isn't installed and installing would change the user's environment, ask first; prefer `uvx iam-policy-validator ...` to avoid installing globally.
-- When findings are headed to a PR, prefer exporting JSON and handing off to a reviewing agent ([references/pr-review-handoff.md](references/pr-review-handoff.md)). Post directly with the validator only when the user explicitly asks for it.
+- Verify flags with `iam-validator <cmd> --help`; don't fabricate them.
+- Show findings before editing a user's policy; don't silently rewrite.
+- Prefer `uvx iam-policy-validator ...` over global installs; ask before changing the environment.
+- For PRs, default to the JSON handoff; post directly with the validator only when the user explicitly asks.

--- a/skills/iam-policy-validator/SKILL.md
+++ b/skills/iam-policy-validator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: iam-policy-validator
 description: Validate, analyze, and query AWS IAM policies using the iam-policy-validator CLI. Use this skill when the user asks to check, validate, lint, audit, or find security issues in IAM policies, trust policies, SCPs, RCPs, or resource policies; when they mention wildcard actions, privilege escalation, sensitive actions, confused deputy, or overly permissive policies; when they want to run AWS IAM Access Analyzer, generate a SARIF/Markdown/HTML report from policies, query which AWS actions or condition keys exist for a service, or post IAM findings to a GitHub PR. This is the CLI-based alternative to running the MCP server.
+argument-hint: "[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]"
 ---
 
 # IAM Policy Validator (CLI)
@@ -8,6 +9,27 @@ description: Validate, analyze, and query AWS IAM policies using the iam-policy-
 Use the `iam-validator` CLI to validate AWS IAM policies against 22 built-in checks (AWS correctness + security best practices) and to query AWS service definitions.
 
 Home page: https://github.com/boogy/iam-policy-validator · Docs: https://boogy.github.io/iam-policy-validator/
+
+## Invocation arguments
+
+`argument-hint`: `[validate|query|analyze] <policy-path|dir> [--config <file>] [--export-json <file>]`
+
+Interpret the arguments passed to this skill and translate them to real CLI flags. `--export-json` is a skill-level argument (not a CLI flag); map it as shown.
+
+| Skill argument         | Meaning                                                        | Maps to CLI                                                                      |
+| ---------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `validate` (default)   | Validate policies — the default verb when none is given        | `iam-validator validate ...`                                                     |
+| `query`                | Look up actions / ARNs / condition keys (no policy needed)     | `iam-validator query ...` — see [references/querying.md](references/querying.md) |
+| `analyze`              | Run AWS IAM Access Analyzer                                    | `iam-validator analyze ...`                                                      |
+| `<policy-path\|dir>`   | File or directory to validate                                  | `--path <policy-path\|dir>`                                                      |
+| `--config <file>`      | Path to a YAML config file                                     | `--config <file>` (forwarded verbatim)                                           |
+| `--export-json <file>` | Export findings as JSON for the PR-review handoff; do NOT post | `--format json --output <file>` (and skip `--github-*`/`post-to-pr`)             |
+
+Rules:
+
+- No verb → default to `validate`.
+- `--config <file>` present → always forward it to the CLI.
+- `--export-json <file>` present → follow the handoff workflow in [references/pr-review-handoff.md](references/pr-review-handoff.md); never post PR comments yourself with the validator.
 
 ## Installation
 
@@ -103,21 +125,18 @@ iam-validator validate --path role-trust.json --policy-type TRUST_POLICY
 
 The `trust_policy_validation` check flags missing `aws:SourceArn` / `aws:SourceAccount` on service principals.
 
-**GitHub PR posting (from CI)**
+**GitHub PR posting**
 
-Two paths:
+Default to the **two-layer** flow: export findings as JSON, then let a _separate_ reviewing agent verify and post. Do not post directly from this skill.
 
 ```bash
-# 1. One-shot: validate and post in a single invocation
-iam-validator validate --path ./policies/ \
-  --github-comment --github-review --github-summary
-
-# 2. Two-phase: generate a JSON report, then post it
-iam-validator validate --path ./policies/ --format json --output report.json
-iam-validator post-to-pr --report report.json
+# Export only — no posting. Hand findings.json to a reviewing agent.
+iam-validator validate --path ./policies/ --format json --output findings.json
 ```
 
-Both require `GITHUB_TOKEN` and a PR context (standard in GitHub Actions).
+The JSON carries the same suggestion/example/remediation content the validator shows in comments. See [references/pr-review-handoff.md](references/pr-review-handoff.md) for the schema, verification checklist, comment-render recipe, and `gh` posting commands.
+
+The validator _can_ also post directly (`--github-comment --github-review --github-summary`, or `post-to-pr --report findings.json`) — use that only when the user explicitly wants the validator to be the poster and no second-layer review is required. Both direct paths need `GITHUB_TOKEN` and a PR context.
 
 **AWS Access Analyzer**
 
@@ -128,6 +147,8 @@ iam-validator analyze --path policy.json
 Requires AWS credentials with `access-analyzer:ValidatePolicy` permission.
 
 **Query the AWS service catalog (no policy file needed)**
+
+For the full query reference — access-level / resource-type filtering, the action↔condition intersection, and using queries to verify a finding — see [references/querying.md](references/querying.md).
 
 `query` has three subcommands: `action`, `arn`, `condition`.
 
@@ -180,8 +201,10 @@ Condition keys can be service-scoped (`s3:ResourceAccount`, `kms:ViaService`) or
 For details, read only what's needed:
 
 - [references/checks.md](references/checks.md) — the 22 built-in checks with IDs, categories, and severities
+- [references/querying.md](references/querying.md) — query actions / ARNs / condition keys and the action↔condition intersection
 - [references/configuration.md](references/configuration.md) — YAML config (disabling checks, ignore patterns, severity overrides)
 - [references/output-formats.md](references/output-formats.md) — console / json / markdown / sarif / csv / html / enhanced
+- [references/pr-review-handoff.md](references/pr-review-handoff.md) — export JSON, verify findings, render + post PR comments from a second agent
 - [references/troubleshooting.md](references/troubleshooting.md) — cache, offline mode, rate limits, common errors
 
 When the user wants authoritative per-check detail beyond check IDs, point them at https://boogy.github.io/iam-policy-validator/user-guide/checks/ rather than inventing specifics.
@@ -192,3 +215,4 @@ When the user wants authoritative per-check detail beyond check IDs, point them 
 - Don't claim a check catches something without looking at [references/checks.md](references/checks.md) or the live docs.
 - When editing a user's policy based on findings, show them the finding first; don't silently rewrite.
 - If the CLI isn't installed and installing would change the user's environment, ask first; prefer `uvx iam-policy-validator ...` to avoid installing globally.
+- When findings are headed to a PR, prefer exporting JSON and handing off to a reviewing agent ([references/pr-review-handoff.md](references/pr-review-handoff.md)). Post directly with the validator only when the user explicitly asks for it.

--- a/skills/iam-policy-validator/references/advanced-flags.md
+++ b/skills/iam-policy-validator/references/advanced-flags.md
@@ -1,0 +1,84 @@
+# Advanced flags
+
+> Always confirm a flag with `iam-validator <command> --help` before relying on it.
+
+## `--stdin`
+
+Read policy JSON from stdin instead of a file. Mutually exclusive with `--path`.
+
+```bash
+cat policy.json | iam-validator validate --stdin
+echo '{"Version":"2012-10-17","Statement":[...]}' | iam-validator validate --stdin
+
+# Combine with --format json for machine-readable output
+cat policy.json | iam-validator validate --stdin --format json
+```
+
+## `--custom-checks-dir`
+
+Load additional checks from a directory. Custom checks must implement the `PolicyCheck` ABC.
+
+```bash
+iam-validator validate --path ./policies/ --custom-checks-dir ./my-checks/
+```
+
+See `examples/custom_checks/` in the repo for a working implementation template.
+
+## `--stream` and `--batch-size`
+
+`--stream` processes files one-by-one instead of loading all into memory. Use for large policy directories or when you need progressive feedback.
+
+`--batch-size N` sets policies per batch (default: `10`). Only meaningful with `--stream`.
+
+```bash
+iam-validator validate --path ./large-dir/ --stream
+iam-validator validate --path ./large-dir/ --stream --batch-size 5
+```
+
+## `--no-recursive`
+
+Skip subdirectories when `--path` is a directory. Default behavior is recursive.
+
+```bash
+# Validate only top-level files in ./policies/
+iam-validator validate --path ./policies/ --no-recursive
+```
+
+## `--summary` and `--severity-breakdown`
+
+Both flags only affect `--format enhanced` output.
+
+- `--summary` adds an Executive Summary section.
+- `--severity-breakdown` adds an Issue Severity Breakdown section.
+
+```bash
+iam-validator validate --path ./policies/ --format enhanced --summary --severity-breakdown
+```
+
+## `--log-level`
+
+Global flag (place before the subcommand). Controls log verbosity.
+
+```
+--log-level {debug,info,warning,error,critical}   default: warning
+```
+
+`debug` emits one `policy_type=... source=... file=...` line per policy — useful for diagnosing auto-detection or config-glob resolution.
+
+```bash
+iam-validator --log-level debug validate --path ./policies/
+```
+
+## `completion`
+
+Generates shell completion scripts. Helps with flag discovery during interactive use.
+
+```bash
+# bash
+iam-validator completion bash > ~/.bash_completion.d/iam-validator
+source ~/.bash_completion.d/iam-validator
+
+# zsh
+iam-validator completion zsh > ~/.zfunc/_iam-validator
+# then add fpath=(~/.zfunc $fpath) + autoload -Uz compinit && compinit to ~/.zshrc
+```

--- a/skills/iam-policy-validator/references/ci-integration.md
+++ b/skills/iam-policy-validator/references/ci-integration.md
@@ -1,0 +1,111 @@
+# CI/CD and PR integration
+
+`iam-validator` integrates with GitHub Actions and pull requests via `--ci` mode, the `post-to-pr` command, and several `--github-*` flags on `validate`. The recommended pattern for agent-assisted review is: validate -> inspect JSON -> post-to-pr.
+
+> Always confirm a flag with `iam-validator <command> --help` before relying on it.
+
+## `--ci` mode
+
+`--ci` prints enhanced console output suitable for job logs and writes a JSON report to disk.
+
+Flag: `--ci-output <file>` sets the output filename (default: `validation-report.json`).
+
+```bash
+iam-validator validate --path ./policies/ --ci
+iam-validator validate --path ./policies/ --ci --ci-output results.json
+```
+
+Use the JSON file as input to `post-to-pr` or for agent-side verification before posting.
+
+## `post-to-pr` command
+
+Posts a pre-generated JSON report to a GitHub PR. Separating validation from posting lets you inspect or filter findings before they appear on the PR.
+
+**Required env vars:** `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and PR number context (normally from `GITHUB_EVENT_PATH` in Actions).
+
+Flags: `--report <file>`, `--create-review`/`--no-review`, `--add-summary`/`--no-summary`, `--config`, `--off-diff-comment-mode`, `--comment-tag`.
+
+```bash
+# Full: line-level review comments + summary table
+iam-validator post-to-pr --report report.json
+
+# Summary table only (no inline review comments)
+iam-validator post-to-pr --report report.json --no-review
+
+# Inline review comments only (no summary table)
+iam-validator post-to-pr --report report.json --no-summary
+```
+
+## `--github-*` flags on `validate`
+
+Run validation and post to GitHub in a single step.
+
+| Flag               | Effect                                   |
+| ------------------ | ---------------------------------------- |
+| `--github-comment` | Summary comment on the PR conversation   |
+| `--github-review`  | Line-specific review comments            |
+| `--github-summary` | GitHub Actions job summary (Actions tab) |
+
+```bash
+iam-validator validate --path ./policies/ --github-review --github-comment
+```
+
+For agent-assisted review, prefer the two-step flow (`validate --format json` -> verify -> `post-to-pr`) so findings can be checked before posting.
+
+## `--comment-tag`
+
+Scopes PR comment markers so multiple validator runs on the same PR don't overwrite each other. Valid: 1-32 chars, `[A-Za-z0-9._-]`. Available on both `validate` and `post-to-pr`.
+
+```bash
+# Run two separate scoped validators on the same PR
+iam-validator post-to-pr --report trust.json    --comment-tag trust-policies
+iam-validator post-to-pr --report identity.json --comment-tag identity-policies
+```
+
+Without `--comment-tag`, a second run overwrites the first run's PR comment.
+
+## `--off-diff-comment-mode`
+
+Controls how findings on unchanged lines are posted to PR reviews.
+
+| Value                      | Behavior                                     |
+| -------------------------- | -------------------------------------------- |
+| `summary_only` (default)   | Findings appear only in the summary table    |
+| `individual`               | Each finding posted as a review comment      |
+| `modified_statements_only` | Review comments only for modified statements |
+
+```bash
+iam-validator post-to-pr --report report.json --off-diff-comment-mode individual
+```
+
+## `--allow-owner-ignore` / `--no-owner-ignore`
+
+Allows CODEOWNERS to reply "ignore" to a review comment to suppress that finding. Enabled by default.
+
+```bash
+iam-validator post-to-pr --report report.json --no-owner-ignore
+```
+
+## GitHub Actions workflow
+
+```yaml
+- uses: actions/checkout@v4
+- run: |
+    uvx iam-policy-validator validate \
+      --path ./policies/ \
+      --ci \
+      --github-review \
+      --github-comment
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+For the two-step pattern:
+
+```yaml
+- uses: actions/checkout@v4
+- run: uvx iam-policy-validator validate --path ./policies/ --ci --ci-output report.json
+- run: uvx iam-policy-validator post-to-pr --report report.json
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/skills/iam-policy-validator/references/common-mistakes.md
+++ b/skills/iam-policy-validator/references/common-mistakes.md
@@ -1,0 +1,48 @@
+# Common agent mistakes
+
+Mistakes that cause hallucinations, misuse, or silent failures when using `iam-validator`.
+
+### Fabricating CLI flags
+
+**Wrong:** passing invented flags like `--check`, `--disable-check`, `--severity`, or `--exclude`.
+**Right:** confirm every flag with `iam-validator <cmd> --help` before use. The CLI will error on unknown flags.
+
+### Scanning non-IAM files as policies
+
+**Wrong:** feeding CloudFormation templates, Terraform `.tf` files, CDK code, or SAM templates directly to `validate`.
+**Right:** the validator expects a raw IAM policy document — `{"Version":"2012-10-17","Statement":[...]}`. Extract the policy block from the IaC file first, then validate it.
+
+### Hallucinating findings when the validator returns 0 issues
+
+**Wrong:** inventing findings when the validator reports none.
+**Right:** 0 issues means the policy is clean per the checks that ran. Report it as clean. If you suspect a check did not run, verify with `--format json` and inspect the output.
+
+### Inventing check IDs
+
+**Wrong:** referencing IDs like `overly_permissive`, `missing_condition`, or `no_mfa` that do not exist.
+**Right:** the 22 valid check IDs are listed in [checks.md](checks.md). Real check IDs appear in `validate --format json` output under each finding's `check_id` field. Never fabricate one.
+
+### Using GitHub flags outside PR context
+
+**Wrong:** running `--github-comment`, `--github-review`, or `post-to-pr` in local or ad-hoc contexts.
+**Right:** these flags require `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and a PR event context. Without them they fail silently or error. Use `--format json` and handle posting separately.
+
+### Forgetting `--policy-type` for non-identity policies
+
+**Wrong:** validating trust policies, resource policies, SCPs, or RCPs without specifying type; the validator defaults to identity policy and raises false positives.
+**Right:** pass `--policy-type TRUST_POLICY` (or `RESOURCE_POLICY`, `SERVICE_CONTROL_POLICY`, `RESOURCE_CONTROL_POLICY`) explicitly, or configure `policy_types:` glob mapping in the YAML config. See [configuration.md](configuration.md).
+
+### Posting unverified findings to PRs
+
+**Wrong:** running `validate --github-review` directly and posting whatever comes back.
+**Right:** use the two-step approach — `validate --format json` to collect findings, then `query` to verify each one (see [verification-protocol.md](verification-protocol.md)), then `post-to-pr` or JSON handoff.
+
+### Misinterpreting exit codes
+
+**Wrong:** treating any non-zero exit as "policy is dangerous".
+**Right:** exit `0` means no error-severity findings (warnings may still exist). Non-zero means error-severity findings exist, OR `--fail-on-warnings` was set and warnings are present, OR the validator itself errored (bad path, parse failure). Always read stderr and the findings before drawing conclusions.
+
+### Assuming the first run is instant
+
+**Wrong:** timing out or failing CI on first run because the validator appears slow.
+**Right:** the first run fetches AWS service definitions (~10-30s). Subsequent runs use disk cache. For CI, pre-warm with `iam-validator sync-services` or point `--aws-services-dir` at a pre-populated directory.

--- a/skills/iam-policy-validator/references/configuration.md
+++ b/skills/iam-policy-validator/references/configuration.md
@@ -15,25 +15,25 @@ The top level has two kinds of keys:
 ```yaml
 # Global behavior
 settings:
-  fail_on_severity: [error, critical, high]   # which severities fail the run
-  hide_severities: [low, info]                # hide from all output
+  fail_on_severity: [error, critical, high] # which severities fail the run
+  hide_severities: [low, info] # hide from all output
   parallel_execution: true
   cache_enabled: true
-  cache_ttl_hours: 168                        # 7 days
+  cache_ttl_hours: 168 # 7 days
 
 # Each check is a top-level key
 wildcard_action:
   enabled: true
-  severity: high                              # override default (medium)
-  message: "Wildcards violate SEC-001"        # custom message
-  suggestion: "Use specific actions."         # custom remediation hint
-  ignore_patterns:                            # per-check suppressions
+  severity: high # override default (medium)
+  message: "Wildcards violate SEC-001" # custom message
+  suggestion: "Use specific actions." # custom remediation hint
+  ignore_patterns: # per-check suppressions
     - filepath: "^tests/"
     - sid: "^AllowReadOnly"
     - action: "^s3:(Get|List|Describe).*"
 
 sid_uniqueness:
-  enabled: false                              # disable a check entirely
+  enabled: false # disable a check entirely
 
 action_condition_enforcement:
   enabled: true
@@ -47,13 +47,13 @@ action_condition_enforcement:
 
 Each pattern object may combine any of (AND across fields, OR across list entries):
 
-| Field           | Matches                                                  |
-| --------------- | -------------------------------------------------------- |
-| `filepath`      | Policy file path (regex, case-insensitive)               |
-| `action`        | Action string in the finding                             |
-| `resource`      | Resource ARN in the finding                              |
-| `sid`           | Statement `Sid`                                          |
-| `condition_key` | Condition key referenced by the finding                  |
+| Field           | Matches                                    |
+| --------------- | ------------------------------------------ |
+| `filepath`      | Policy file path (regex, case-insensitive) |
+| `action`        | Action string in the finding               |
+| `resource`      | Resource ARN in the finding                |
+| `sid`           | Statement `Sid`                            |
+| `condition_key` | Condition key referenced by the finding    |
 
 ## Precedence
 

--- a/skills/iam-policy-validator/references/output-formats.md
+++ b/skills/iam-policy-validator/references/output-formats.md
@@ -33,3 +33,5 @@ iam-validator validate --path ./policies/ \
 - SARIF is the right pick for CI → GitHub Security tab.
 - Markdown is what the `post-to-pr` subcommand emits; if you already use `post-to-pr` you don't need to generate it separately.
 - `json` output is stable enough to parse with `jq`; schema docs: https://boogy.github.io/iam-policy-validator/user-guide/output-formats/
+
+For the JSON-export → verify → PR-comment workflow (and the per-finding JSON schema), see [pr-review-handoff.md](pr-review-handoff.md).

--- a/skills/iam-policy-validator/references/pr-review-handoff.md
+++ b/skills/iam-policy-validator/references/pr-review-handoff.md
@@ -1,6 +1,9 @@
 # Exporting findings for PR review (second verification layer)
 
-When findings will land on a pull request, **do not** let the validator post them. Skip `--github-comment`, `--github-review`, `--github-summary`, and `post-to-pr`. Instead export JSON and hand it to a separate reviewing agent that verifies each finding and posts the surviving ones. This inserts a human-style second check between detection and publication.
+When findings will land on a pull request, prefer a two-step flow over single-command posting. Two options:
+
+1. **Native `post-to-pr`** — validate to JSON, then `iam-validator post-to-pr --report report.json`. Simpler, but posts all findings without agent verification.
+2. **JSON handoff** (recommended for agent workflows) — validate to JSON, verify each finding with `query` (see [verification-protocol.md](verification-protocol.md)), then render and post from a separate agent. This inserts a second check between detection and publication.
 
 ## Agent roles
 
@@ -73,19 +76,20 @@ A finding's example may live in the `example` field **or** be embedded inside `s
 
 ## Step 3 — verification checklist (the second layer)
 
-For each finding, before posting:
-
-1. **Confirm the premise** with `query` (see [querying.md](querying.md)): does the action exist? does it support the suggested condition key? is the ARN format real?
-2. **Drop false positives** — if the query contradicts the finding (e.g. the action _does_ support the condition the check says to add), discard or downgrade it and note why.
-3. **Dedupe** identical findings across statements/files.
-4. **Sanity-check severity** against the actual blast radius; keep the validator's severity unless the query evidence justifies a change.
-5. **Keep the evidence** — record the query and result so the PR comment can cite it.
-
-Only findings that survive this pass get posted.
+Follow the full checklist in [verification-protocol.md](verification-protocol.md). In short: confirm each finding's premise with `query`, drop false positives, dedupe, sanity-check severity, and record evidence. Only findings that survive this pass get posted.
 
 ## Step 4 — render a comment from a finding
 
-**Recommended (deterministic):** use the bundled renderer — stdlib-only Python, no install, no dependency on the validator's source tree:
+**Recommended (deterministic):** use the bundled renderer — stdlib-only Python (3.10+), no install, no dependency on the validator's source tree.
+
+If you installed via `uvx` or `pip` and don't have the skill repo on disk, fetch the script:
+
+```bash
+curl -sL https://raw.githubusercontent.com/boogy/iam-policy-validator/main/skills/iam-policy-validator/scripts/render_pr_comments.py \
+  -o render_pr_comments.py
+```
+
+Usage:
 
 ```bash
 # Ready-to-post objects: [{policy_file, line_number, check_id, severity, ..., body}]

--- a/skills/iam-policy-validator/references/pr-review-handoff.md
+++ b/skills/iam-policy-validator/references/pr-review-handoff.md
@@ -2,6 +2,13 @@
 
 When findings will land on a pull request, **do not** let the validator post them. Skip `--github-comment`, `--github-review`, `--github-summary`, and `post-to-pr`. Instead export JSON and hand it to a separate reviewing agent that verifies each finding and posts the surviving ones. This inserts a human-style second check between detection and publication.
 
+## Agent roles
+
+- **Producer agent** — runs the validator, verifies each finding (Step 3), and exports the JSON. Owns Steps 1–3. Never posts.
+- **Poster agent** — consumes the JSON, renders comment bodies (Step 4, ideally via the bundled script), and posts them (Step 5). Owns Steps 4–5. Never re-runs detection.
+
+The contract between them is the JSON in Step 2 — nothing else is shared. Either role can be a different agent, model, or process.
+
 ## Step 1 — export JSON
 
 ```bash
@@ -78,7 +85,20 @@ Only findings that survive this pass get posted.
 
 ## Step 4 — render a comment from a finding
 
-Reproduce the validator's native comment layout (source of truth: `ValidationIssue.to_pr_comment()` in `iam_validator/core/models.py`). Omit the validator's hidden HTML bot/identifier markers — those are only for the validator's own comment cleanup. Build the body in this order:
+**Recommended (deterministic):** use the bundled renderer — stdlib-only Python, no install, no dependency on the validator's source tree:
+
+```bash
+# Ready-to-post objects: [{policy_file, line_number, check_id, severity, ..., body}]
+python3 scripts/render_pr_comments.py findings.json --format json > comments.json
+
+# Or a human-readable preview of every comment body
+python3 scripts/render_pr_comments.py findings.json
+# Filter low-noise findings: --min-severity high
+```
+
+`render_pr_comments.py` reproduces the layout below and omits the validator's hidden HTML bot/identifier markers (those exist only for the validator's own comment-cleanup lifecycle and are unwanted when another agent posts). The `body` field is ready to post verbatim.
+
+**Manual layout (the spec the script implements** — for porting to another language, or rendering by hand). Build the body in this order:
 
 ````markdown
 {severity-emoji} **{SEVERITY}** - {action-guidance}{ | risk-category}
@@ -122,26 +142,29 @@ _Check: `{check_id}`_ | [📖 Documentation]({documentation_url})
 
 Include only the sub-blocks whose fields are non-null. The `<details>` block appears only if at least one of action/resource/condition_key/suggestion/example/remediation_steps is present.
 
+> Maintainers: the canonical layout lives in `ValidationIssue.to_pr_comment()` and the severity/risk maps in `core/constants.py` (`SEVERITY_CONFIG`) and `core/config/check_documentation.py` (`RISK_CATEGORY_ICONS`). Keep `scripts/render_pr_comments.py` in sync if those change.
+
 ## Step 5 — post with `gh` (concrete recipe)
 
-After verification, post from the reviewing agent (requires `gh auth` and a PR context):
+After verification, post from the poster agent (requires `gh auth` and a PR context). Drive it straight from the renderer's `comments.json`:
 
 ```bash
-# One summary comment
-gh pr comment "$PR_NUMBER" --body-file verified-summary.md
+# One inline review comment per finding that has a line number
+jq -c '.[] | select(.line_number != null)' comments.json | while read -r c; do
+  gh api --method POST "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" \
+    -f body="$(jq -r '.body' <<<"$c")" \
+    -f commit_id="$HEAD_SHA" \
+    -f path="$(jq -r '.policy_file' <<<"$c")" \
+    -F line="$(jq -r '.line_number' <<<"$c")" \
+    -f side="RIGHT"
+done
 
-# Per-finding inline review comments (when you have file + line)
-gh api \
-  --method POST \
-  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" \
-  -f body="$(cat finding-1.md)" \
-  -f commit_id="$HEAD_SHA" \
-  -f path="$POLICY_PATH" \
-  -F line="$LINE_NUMBER" \
-  -f side="RIGHT"
+# Or a single summary comment built from all bodies
+jq -r '.[].body' comments.json > verified-summary.md
+gh pr comment "$PR_NUMBER" --body-file verified-summary.md
 ```
 
-Build each `*.md` body with the Step 4 recipe from the verified finding.
+Each `body` already follows the Step 4 layout, so no further formatting is needed.
 
 ## Tool-agnostic contract
 

--- a/skills/iam-policy-validator/references/pr-review-handoff.md
+++ b/skills/iam-policy-validator/references/pr-review-handoff.md
@@ -1,0 +1,148 @@
+# Exporting findings for PR review (second verification layer)
+
+When findings will land on a pull request, **do not** let the validator post them. Skip `--github-comment`, `--github-review`, `--github-summary`, and `post-to-pr`. Instead export JSON and hand it to a separate reviewing agent that verifies each finding and posts the surviving ones. This inserts a human-style second check between detection and publication.
+
+## Step 1 — export JSON
+
+```bash
+iam-validator validate --path ./policies/ --format json --output findings.json
+```
+
+(Skill invocation equivalent: `... --export-json findings.json`.) The JSON is produced by `report.model_dump()` and contains the **same** `suggestion`, `example`, `remediation_steps`, `risk_explanation`, and `documentation_url` data the validator would otherwise render into comments — nothing is lost by going through JSON.
+
+## Step 2 — the JSON schema (handoff contract)
+
+Top level:
+
+| Field                           | Type  | Meaning                                               |
+| ------------------------------- | ----- | ----------------------------------------------------- |
+| `total_policies`                | int   | Policies scanned                                      |
+| `valid_policies`                | int   | Policies passing per `fail_on_severity`               |
+| `invalid_policies`              | int   | Policies failing                                      |
+| `total_issues`                  | int   | All findings across policies                          |
+| `validity_issues`               | int   | Count of IAM-validity findings (error/warning/info)   |
+| `security_issues`               | int   | Count of security findings (critical/high/medium/low) |
+| `policies_with_security_issues` | int   | Policies with a security-categorized finding          |
+| `results`                       | array | One entry per policy (see below)                      |
+| `parsing_errors`                | array | `[file_path, error_message]` pairs                    |
+| `policies_with_errors`          | int   | Structurally AWS-invalid policies (computed)          |
+| `policies_with_findings`        | int   | Policies with any non-error finding (computed)        |
+
+Each `results[]` entry:
+
+| Field                    | Type   | Meaning                                 |
+| ------------------------ | ------ | --------------------------------------- |
+| `policy_file`            | string | Path to the policy                      |
+| `is_valid`               | bool   | Whether the policy passed               |
+| `policy_type`            | string | `IDENTITY_POLICY`, `TRUST_POLICY`, etc. |
+| `issues`                 | array  | Findings (see below)                    |
+| `actions_checked`        | int    | Coverage counter                        |
+| `condition_keys_checked` | int    | Coverage counter                        |
+| `resources_checked`      | int    | Coverage counter                        |
+
+Each `issues[]` finding — **these are the comment fields**:
+
+| Field               | Type           | Role in a PR comment                                       |
+| ------------------- | -------------- | ---------------------------------------------------------- |
+| `severity`          | string         | `error/warning/info` or `critical/high/medium/low`         |
+| `statement_sid`     | string \| null | Statement Sid (for navigation)                             |
+| `statement_index`   | int            | Statement position                                         |
+| `issue_type`        | string         | e.g. `security_risk`, `invalid_action`                     |
+| `message`           | string         | Headline shown immediately                                 |
+| `action`            | string \| null | Affected action                                            |
+| `resource`          | string \| null | Affected resource                                          |
+| `condition_key`     | string \| null | Affected condition key                                     |
+| `suggestion`        | string \| null | "💡 Suggested Fix" text                                    |
+| `example`           | string \| null | "Example:" JSON snippet shown in a code block              |
+| `remediation_steps` | array \| null  | "🔧 How to Fix" numbered list                              |
+| `risk_explanation`  | string \| null | "Why this matters" blockquote                              |
+| `risk_category`     | string \| null | Category (drives an icon)                                  |
+| `documentation_url` | string \| null | Footer "📖 Documentation" link                             |
+| `check_id`          | string \| null | Footer "Check: …"                                          |
+| `line_number`       | int \| null    | Line for inline placement                                  |
+| `field_name`        | string \| null | `action`/`resource`/`condition`/… (precise line targeting) |
+
+A finding's example may live in the `example` field **or** be embedded inside `suggestion` as a trailing `\nExample:\n<code>` block — handle both. Many checks populate `remediation_steps`, `risk_explanation`, and `documentation_url` by default even when `example` is `null`.
+
+## Step 3 — verification checklist (the second layer)
+
+For each finding, before posting:
+
+1. **Confirm the premise** with `query` (see [querying.md](querying.md)): does the action exist? does it support the suggested condition key? is the ARN format real?
+2. **Drop false positives** — if the query contradicts the finding (e.g. the action _does_ support the condition the check says to add), discard or downgrade it and note why.
+3. **Dedupe** identical findings across statements/files.
+4. **Sanity-check severity** against the actual blast radius; keep the validator's severity unless the query evidence justifies a change.
+5. **Keep the evidence** — record the query and result so the PR comment can cite it.
+
+Only findings that survive this pass get posted.
+
+## Step 4 — render a comment from a finding
+
+Reproduce the validator's native comment layout (source of truth: `ValidationIssue.to_pr_comment()` in `iam_validator/core/models.py`). Omit the validator's hidden HTML bot/identifier markers — those are only for the validator's own comment cleanup. Build the body in this order:
+
+````markdown
+{severity-emoji} **{SEVERITY}** - {action-guidance}{ | risk-category}
+
+**Statement:** `{statement_sid}` (Statement[{statement_index}]) (line {line_number})
+
+{message}
+
+> **Why this matters:** {risk_explanation} ← only if present
+
+<details>
+<summary>📋 <b>View Details</b></summary>
+
+**Affected Fields:**
+
+- Action: `{action}`
+- Resource: `{resource}`
+- Condition Key: `{condition_key}`
+
+**🔧 How to Fix:**
+
+1. {remediation_steps[0]}
+2. {remediation_steps[1]}
+
+**💡 Suggested Fix:**
+
+{suggestion}
+
+**Example:**
+
+```json
+{example}
+```
+
+</details>
+
+---
+
+_Check: `{check_id}`_ | [📖 Documentation]({documentation_url})
+````
+
+Include only the sub-blocks whose fields are non-null. The `<details>` block appears only if at least one of action/resource/condition_key/suggestion/example/remediation_steps is present.
+
+## Step 5 — post with `gh` (concrete recipe)
+
+After verification, post from the reviewing agent (requires `gh auth` and a PR context):
+
+```bash
+# One summary comment
+gh pr comment "$PR_NUMBER" --body-file verified-summary.md
+
+# Per-finding inline review comments (when you have file + line)
+gh api \
+  --method POST \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" \
+  -f body="$(cat finding-1.md)" \
+  -f commit_id="$HEAD_SHA" \
+  -f path="$POLICY_PATH" \
+  -F line="$LINE_NUMBER" \
+  -f side="RIGHT"
+```
+
+Build each `*.md` body with the Step 4 recipe from the verified finding.
+
+## Tool-agnostic contract
+
+The JSON in Step 2 _is_ the interface. Any consumer — a `gh`-based agent, a Slack bot, a dashboard — can read `results[].issues[]`, apply the Step 3 checklist, and render with Step 4. Nothing in the handoff depends on the validator posting. The only rule: the validator detects and exports; a separate verifier decides and posts.

--- a/skills/iam-policy-validator/references/querying.md
+++ b/skills/iam-policy-validator/references/querying.md
@@ -83,11 +83,9 @@ Condition keys are either **service-scoped** (`s3:ResourceAccount`, `kms:ViaServ
 
 ## Using queries to verify a finding
 
-Before acting on a validation issue, confirm its premises with `query`:
+Before acting on a validation issue, confirm its premises with `query`. The full verification checklist (8 steps) is in [verification-protocol.md](verification-protocol.md). Quick examples:
 
-- **"Action does not exist"** → `iam-validator query action --name <svc:Action>`. Empty/none result corroborates the finding.
-- **"Add condition X"** → `iam-validator query action --name <svc:Action> --has-condition-key <X>`. If the action is absent from the result, X cannot apply — the suggestion is wrong for that action.
-- **"Resource ARN is malformed"** → `iam-validator query arn --service <svc> --name <resource-type>` to get the canonical format template.
-- **Wildcard scope** → `iam-validator query action --name "<svc:Prefix*>"` to see exactly which actions a wildcard expands to.
-
-Record the query you ran and its result alongside the finding when handing off for PR review (see [pr-review-handoff.md](pr-review-handoff.md)).
+- **"Action does not exist"** → `iam-validator query action --name <svc:Action>`
+- **"Add condition X"** → `iam-validator query action --name <svc:Action> --has-condition-key <X>`
+- **"Resource ARN is malformed"** → `iam-validator query arn --service <svc> --name <resource-type>`
+- **Wildcard scope** → `iam-validator query action --name "<svc:Prefix*>"`

--- a/skills/iam-policy-validator/references/querying.md
+++ b/skills/iam-policy-validator/references/querying.md
@@ -1,0 +1,93 @@
+# Querying the AWS service catalog
+
+`iam-validator query` answers AWS IAM metadata questions without a policy file: which actions exist, which ARN formats a resource type uses, which condition keys a service exposes, and **which actions support a given condition key**. Use it to author least-privilege policies and to _verify_ validation findings before acting on them.
+
+Three subcommands: `action`, `arn`, `condition`. All accept `--output json|yaml|text` (default `text`); use `--output json` when you need to parse the result.
+
+> Always confirm a flag with `iam-validator query <sub> --help` before relying on it.
+
+## query action
+
+Flags: `--service <prefix>`, `--name <name|pattern>` (service prefix optional; supports wildcards), `--access-level read|write|list|tagging|permissions-management`, `--resource-type <type>` (`*` = wildcard-only actions), `--has-condition-key <key>` (alias `--condition`), `--show-condition-keys`, `--show-resource-types`, `--show-access-level`, `--output`.
+
+```bash
+# Every action in a service
+iam-validator query action --service s3
+
+# A single action (prefix optional)
+iam-validator query action --name s3:GetObject
+iam-validator query action --service s3 --name GetObject
+
+# Expand a wildcard pattern to concrete actions
+iam-validator query action --name "s3:Get*"
+
+# Filter by access level (e.g. all write actions)
+iam-validator query action --service s3 --access-level write
+
+# Filter by resource type; "*" finds actions that only allow Resource "*"
+iam-validator query action --service s3 --resource-type "*"
+
+# Show each action's access level / supported condition keys
+iam-validator query action --service s3 --name "Get*" --show-access-level --show-condition-keys
+```
+
+## query arn
+
+Flags: `--service <prefix>`, `--name <resource-type>` (e.g. `bucket` or `s3:bucket`), `--list-arn-types`, `--has-condition-key <key>`, `--show-condition-keys`, `--show-arn-format`, `--show-resource-type`, `--output`.
+
+```bash
+# All ARN formats for a service's resource types
+iam-validator query arn --service s3
+
+# One resource type's ARN format
+iam-validator query arn --service s3 --name bucket
+
+# List all ARN types with their format templates
+iam-validator query arn --service s3 --list-arn-types
+
+# ARN resource types that support a given condition key
+iam-validator query arn --service s3 --has-condition-key "s3:ResourceAccount"
+```
+
+## query condition
+
+Flags: `--service <prefix>`, `--name <key>` (e.g. `prefix` or `s3:prefix`), `--output`.
+
+```bash
+# All condition keys a service exposes
+iam-validator query condition --service s3
+
+# Detail for one condition key
+iam-validator query condition --service s3 --name "s3:prefix"
+```
+
+## Which action supports which condition (the intersection)
+
+This is the highest-value query for scoping policies. `--has-condition-key` filters actions/ARNs down to those that accept a given key; `--show-condition-keys` lists every key an action supports.
+
+```bash
+# All actions in a service that support a condition key
+iam-validator query action --service s3 --has-condition-key "s3:ResourceAccount"
+
+# Narrow to a pattern
+iam-validator query action --name "s3:Get*" --has-condition-key "s3:ResourceAccount"
+
+# Use a global key across a service
+iam-validator query action --service ec2 --has-condition-key "aws:SourceVpc"
+
+# Machine-readable, for scripting another agent
+iam-validator query action --service s3 --has-condition-key "s3:ResourceAccount" --output json
+```
+
+Condition keys are either **service-scoped** (`s3:ResourceAccount`, `kms:ViaService`) or **global** (`aws:SourceVpc`, `aws:PrincipalOrgID`, `aws:SourceArn`). Both work with `--has-condition-key`. A key that a target action does not support cannot constrain it — verify support before recommending a condition.
+
+## Using queries to verify a finding
+
+Before acting on a validation issue, confirm its premises with `query`:
+
+- **"Action does not exist"** → `iam-validator query action --name <svc:Action>`. Empty/none result corroborates the finding.
+- **"Add condition X"** → `iam-validator query action --name <svc:Action> --has-condition-key <X>`. If the action is absent from the result, X cannot apply — the suggestion is wrong for that action.
+- **"Resource ARN is malformed"** → `iam-validator query arn --service <svc> --name <resource-type>` to get the canonical format template.
+- **Wildcard scope** → `iam-validator query action --name "<svc:Prefix*>"` to see exactly which actions a wildcard expands to.
+
+Record the query you ran and its result alongside the finding when handing off for PR review (see [pr-review-handoff.md](pr-review-handoff.md)).

--- a/skills/iam-policy-validator/references/troubleshooting.md
+++ b/skills/iam-policy-validator/references/troubleshooting.md
@@ -1,5 +1,27 @@
 # Troubleshooting
 
+## Requirements
+
+Python 3.10+ is required. Check with `python3 --version`.
+
+## First run is slow / AWS fetch is slow
+
+The validator fetches AWS service definitions on first use (~10-30s depending on network). Subsequent runs use a local cache. For CI or air-gapped environments:
+
+```bash
+# Pre-download once (committed to a folder you ship with CI)
+iam-validator sync-services --output-dir ./aws_services/
+
+# Use it
+iam-validator validate --path ./policies/ --aws-services-dir ./aws_services/
+```
+
+See "Cache management" below for controlling the local cache.
+
+## Validator reports 0 findings
+
+This means the policy passed all enabled checks. The policy is clean — do not invent or hallucinate findings. Report it as valid and move on.
+
 ## "Command not found: iam-validator"
 
 The package isn't installed in the current environment. Options:
@@ -8,18 +30,6 @@ The package isn't installed in the current environment. Options:
 uvx iam-policy-validator validate --path policy.json   # no install
 uv add iam-policy-validator                            # per project
 pipx install iam-policy-validator                      # user-wide
-```
-
-## AWS fetch is slow / rate-limited / offline environment
-
-The validator fetches AWS service definitions on first use and caches them. For CI or air-gapped environments:
-
-```bash
-# Pre-download once (committed to a folder you ship with CI)
-iam-validator sync-services --output-dir ./aws_services/
-
-# Use it
-iam-validator validate --path ./policies/ --aws-services-dir ./aws_services/
 ```
 
 ## Cache management
@@ -56,7 +66,7 @@ Trust-policy files routinely trigger identity-policy checks when scanned without
 
 ## Exit code behavior
 
-By default the validator exits non-zero on **errors** (broken JSON, AWS API failure, error-severity findings). Warnings do not fail the run. Use `--fail-on-warnings` to make warnings fail too. Check stderr when the exit code surprises you.
+Exit `0` = no error-severity findings (warnings may still exist). Non-zero = error-severity findings, or `--fail-on-warnings` was set and warnings exist, or the CLI itself errored (bad path, parse failure). Check stderr and the findings when the exit code surprises you.
 
 ## Got an unexpected error or bug
 

--- a/skills/iam-policy-validator/references/verification-protocol.md
+++ b/skills/iam-policy-validator/references/verification-protocol.md
@@ -1,0 +1,80 @@
+# Verification Protocol
+
+Every finding must be verified before posting to a PR or presenting to a user as confirmed. This is the single source of truth for verification — [pr-review-handoff.md](pr-review-handoff.md) and [querying.md](querying.md) both link here.
+
+## The checklist
+
+### 1. Confirm the action exists
+
+```bash
+iam-validator query action --name <svc:Action>
+```
+
+Empty result = action doesn't exist = finding is valid. A non-empty result means the action is real; don't flag it as invalid.
+
+### 2. Confirm condition key support
+
+If the finding suggests adding a condition key:
+
+```bash
+iam-validator query action --name <svc:Action> --has-condition-key <key>
+```
+
+If the action is absent from results, the key cannot constrain it — the suggestion is wrong for that action. Drop or flag the finding.
+
+### 3. Confirm ARN format
+
+If the finding flags a malformed ARN:
+
+```bash
+iam-validator query arn --service <svc> --name <resource-type>
+```
+
+Compare the canonical format template against the policy's ARN.
+
+### 4. Confirm wildcard expansion
+
+If the finding is about a wildcard pattern:
+
+```bash
+iam-validator query action --name "<svc:Prefix*>"
+```
+
+See exactly which actions the wildcard matches. Assess blast radius before reporting severity.
+
+### 5. Drop false positives
+
+If query evidence contradicts the finding, discard or downgrade it. Do not silently drop — tell the user: "The validator flagged X, but `query` shows Y — this appears to be a false positive."
+
+### 6. Deduplicate
+
+Same issue across multiple statements or files = one finding, referencing all locations.
+
+### 7. Sanity-check severity
+
+Keep the validator's severity unless query evidence justifies a change. Don't inflate.
+
+### 8. Record evidence
+
+For each surviving finding, record:
+
+- The query command you ran
+- The result (or key excerpt)
+- Your verdict: confirmed / downgraded / dropped
+
+This evidence should accompany the finding when handing off for PR review.
+
+## When to skip verification
+
+- **Structural checks** (`policy_structure`, `policy_size`, `sid_uniqueness`) — deterministic; no query needed.
+- **Interactive terminal use** — if the user is reviewing findings themselves (not posting to a PR), show findings and let them decide. Offer to verify if asked.
+
+## Quick reference
+
+| Finding type             | Verification command                                                   |
+| ------------------------ | ---------------------------------------------------------------------- |
+| Action doesn't exist     | `query action --name <svc:Action>`                                     |
+| Condition key suggestion | `query action --name <svc:Action> --has-condition-key <key>`           |
+| Malformed ARN            | `query arn --service <svc> --name <resource-type>`                     |
+| Wildcard blast radius    | `query action --name "<svc:Prefix*>"`                                  |
+| Condition key scope      | `query action --service <svc> --has-condition-key <key> --output json` |

--- a/skills/iam-policy-validator/scripts/render_pr_comments.py
+++ b/skills/iam-policy-validator/scripts/render_pr_comments.py
@@ -162,7 +162,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    raw = sys.stdin.read() if args.input == "-" else open(args.input, encoding="utf-8").read()
+    if args.input == "-":
+        raw = sys.stdin.read()
+    else:
+        with open(args.input, encoding="utf-8") as infile:
+            raw = infile.read()
     try:
         report = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/skills/iam-policy-validator/scripts/render_pr_comments.py
+++ b/skills/iam-policy-validator/scripts/render_pr_comments.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Render iam-policy-validator JSON findings into PR-comment markdown.
+
+Portable, stdlib-only (Python 3.10+). Turns the JSON produced by
+`iam-validator validate --format json` into the same comment layout the
+validator posts itself — so a *separate* agent can verify findings and post
+them, without re-implementing the rendering or depending on the validator's
+source tree.
+
+The layout mirrors `ValidationIssue.to_pr_comment()` but omits the validator's
+hidden HTML bot/identifier markers (those exist only for the validator's own
+comment-cleanup lifecycle and are not wanted when another agent posts).
+
+Usage:
+    # Human-readable: every finding's comment body, divider-separated
+    python3 render_pr_comments.py findings.json
+
+    # Machine-readable: JSON array of {policy_file, line_number, ..., body}
+    python3 render_pr_comments.py findings.json --format json
+
+    # Read from stdin and filter by minimum severity
+    iam-validator validate --path ./policies/ --format json \\
+        | python3 render_pr_comments.py - --min-severity high --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# Severity → (emoji, action guidance). Mirrors core/constants.py SEVERITY_CONFIG.
+SEVERITY_CONFIG: dict[str, tuple[str, str]] = {
+    "critical": ("🔴", "Block deployment"),
+    "high": ("🟠", "Fix before merge"),
+    "medium": ("🟡", "Address soon"),
+    "low": ("🔵", "Consider fixing"),
+    "error": ("❌", "Must fix - AWS will reject"),
+    "warning": ("⚠️", "Review"),
+    "info": ("ℹ️", "Optional"),
+}
+
+# Higher = more severe. Used by --min-severity. Mirrors SEVERITY_RANK.
+SEVERITY_RANK: dict[str, int] = {
+    "error": 100,
+    "critical": 90,
+    "high": 70,
+    "warning": 50,
+    "medium": 40,
+    "low": 20,
+    "info": 10,
+}
+
+# Risk category → icon. Mirrors config/check_documentation.py RISK_CATEGORY_ICONS.
+RISK_CATEGORY_ICONS: dict[str, str] = {
+    "privilege_escalation": "🔐",
+    "data_exfiltration": "📤",
+    "denial_of_service": "🚫",
+    "resource_exposure": "🌐",
+    "credential_exposure": "🔑",
+    "compliance": "📋",
+    "configuration": "⚙️",
+    "validation": "✅",
+}
+
+
+def render_body(issue: dict) -> str:
+    """Build the PR-comment markdown body for one finding."""
+    severity = issue.get("severity", "info")
+    emoji, action_guidance = SEVERITY_CONFIG.get(severity, ("•", "Review"))
+
+    risk_icon = ""
+    risk_category = issue.get("risk_category")
+    if risk_category:
+        icon = RISK_CATEGORY_ICONS.get(risk_category, "")
+        if icon:
+            label = risk_category.replace("_", " ").title()
+            risk_icon = f" | {icon} {label}"
+
+    parts: list[str] = [f"{emoji} **{severity.upper()}** - {action_guidance}{risk_icon}", ""]
+
+    context = f"Statement[{issue.get('statement_index')}]"
+    if issue.get("statement_sid"):
+        context = f"`{issue['statement_sid']}` ({context})"
+    if issue.get("line_number"):
+        context = f"{context} (line {issue['line_number']})"
+    parts.append(f"**Statement:** {context}")
+    parts.append("")
+    parts.append(issue.get("message", ""))
+
+    if issue.get("risk_explanation"):
+        parts.append("")
+        parts.append(f"> **Why this matters:** {issue['risk_explanation']}")
+
+    field_action = issue.get("action")
+    resource = issue.get("resource")
+    condition_key = issue.get("condition_key")
+    suggestion = issue.get("suggestion")
+    example = issue.get("example")
+    remediation_steps = issue.get("remediation_steps")
+
+    if field_action or resource or condition_key or suggestion or example or remediation_steps:
+        parts.extend(["", "<details>", "<summary>📋 <b>View Details</b></summary>", "", ""])
+
+        if field_action or resource or condition_key:
+            parts.append("**Affected Fields:**")
+            if field_action:
+                parts.append(f"  - Action: `{field_action}`")
+            if resource:
+                parts.append(f"  - Resource: `{resource}`")
+            if condition_key:
+                parts.append(f"  - Condition Key: `{condition_key}`")
+            parts.append("")
+
+        if remediation_steps:
+            parts.append("**🔧 How to Fix:**")
+            for i, step in enumerate(remediation_steps, 1):
+                parts.append(f"  {i}. {step}")
+            parts.append("")
+
+        if suggestion:
+            parts.extend(["**💡 Suggested Fix:**", "", suggestion, ""])
+
+        if example:
+            parts.extend(["**Example:**", "```json", example, "```"])
+
+        parts.extend(["", "</details>"])
+
+    footer: list[str] = []
+    if issue.get("check_id"):
+        footer.append(f"*Check: `{issue['check_id']}`*")
+    if issue.get("documentation_url"):
+        footer.append(f"[📖 Documentation]({issue['documentation_url']})")
+    if footer:
+        parts.extend(["", "---", " | ".join(footer)])
+
+    return "\n".join(parts)
+
+
+def iter_findings(report: dict, min_rank: int):
+    """Yield (policy_file, issue) pairs above the severity threshold."""
+    for result in report.get("results", []):
+        policy_file = result.get("policy_file", "")
+        for issue in result.get("issues", []):
+            severity = issue.get("severity", "info")
+            if severity == "none":
+                continue
+            if SEVERITY_RANK.get(severity, 0) < min_rank:
+                continue
+            yield policy_file, issue
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input", nargs="?", default="-", help="Validator JSON file, or '-' for stdin (default)")
+    parser.add_argument("--format", choices=["markdown", "json"], default="markdown", help="Output format")
+    parser.add_argument(
+        "--min-severity",
+        choices=list(SEVERITY_RANK),
+        default="info",
+        help="Drop findings below this severity (default: info = keep all)",
+    )
+    args = parser.parse_args(argv)
+
+    raw = sys.stdin.read() if args.input == "-" else open(args.input, encoding="utf-8").read()
+    try:
+        report = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: input is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    min_rank = SEVERITY_RANK[args.min_severity]
+    comments = []
+    for policy_file, issue in iter_findings(report, min_rank):
+        comments.append(
+            {
+                "policy_file": policy_file,
+                "statement_index": issue.get("statement_index"),
+                "statement_sid": issue.get("statement_sid"),
+                "line_number": issue.get("line_number"),
+                "field_name": issue.get("field_name"),
+                "check_id": issue.get("check_id"),
+                "issue_type": issue.get("issue_type"),
+                "severity": issue.get("severity"),
+                "action": issue.get("action"),
+                "resource": issue.get("resource"),
+                "condition_key": issue.get("condition_key"),
+                "body": render_body(issue),
+            }
+        )
+
+    if args.format == "json":
+        print(json.dumps(comments, indent=2, ensure_ascii=False))
+    else:
+        for i, c in enumerate(comments):
+            if i:
+                print("\n\n")
+            print(f"<!-- {c['policy_file']} | {c['check_id']} | statement {c['statement_index']} -->")
+            print(c["body"])
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

  - Restructure SKILL.md with decision tree, quickstart, exit code contract, and `post-to-pr` as first-class workflow
  - Add 4 new reference docs: ci-integration, advanced-flags, common-mistakes, verification-protocol
  - Consolidate verification guidance into single source of truth
  - Fix renderer portability for `uvx` users, merge duplicate troubleshooting sections

  ## Changes

  - `SKILL.md`: Decision tree table, quickstart block, PR workflow (2 options), exit codes, expanded guardrails (8 items)
  - `references/ci-integration.md`: `--ci`, `post-to-pr`, `--github-*`, `--comment-tag`, `--off-diff-comment-mode`, GH Actions workflows
  - `references/advanced-flags.md`: `--stdin`, `--custom-checks-dir`, `--stream`, `--batch-size`, `completion`, `--log-level`
  - `references/common-mistakes.md`: 9 agent pitfalls in Wrong/Right format
  - `references/verification-protocol.md`: 8-step finding verification checklist
  - `references/pr-review-handoff.md`: Added `post-to-pr` alternative, `curl` fetch for renderer, deferred verification to protocol
  - `references/querying.md`: Verification section now links to protocol instead of duplicating
  - `references/troubleshooting.md`: Python 3.10+ requirement, merged duplicate sections, fixed exit code docs, added 0-findings guidance

  ## Testing

  - [x] All existing tests pass (1276 passed, MCP failure is pre-existing)
  - [x] Prettier formatting applied
  - [x] Cross-references verified across all 10 reference files
  - [x] No contradictions between files