### PR TITLE
docs(ci): correct rolling-tag commands in release summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,12 +234,17 @@ jobs:
           $(if [ "$IS_PRERELEASE" = "false" ]; then echo "- ✅ Published to [PyPI](https://pypi.org/project/${PYPI_PROJECT}/)"; else echo "- ⏭️ Skipped (pre-release version)"; fi)
 
           ### Rolling Tags
-          - ⚠️ Run manually after this release:
+          - ⚠️ Run manually after this release — intentionally not automated so the
+            rolling tags stay signed with the maintainer's key rather than a CI key:
           \`\`\`bash
           git fetch --tags
-          git tag -f v$MAJOR v$VERSION && git tag -f v$MINOR v$VERSION
+          git tag -f -s v$MAJOR -m "Rolling tag: v$MAJOR → v$VERSION" $TAG^{}
+          git tag -f -s v$MINOR -m "Rolling tag: v$MINOR → v$VERSION" $TAG^{}
           git push --force origin v$MAJOR v$MINOR
           \`\`\`
+          - ℹ️ \`-s -m\` are required (\`tag.gpgsign=true\` makes a message mandatory), and
+            the target is \`$TAG^{}\` — the commit, not the tag — so these stay annotated
+            rolling tags instead of becoming nested lightweight ones.
           - 🏷️ Immutable tag: \`v$VERSION\`
 
           ## 🔗 Quick Links


### PR DESCRIPTION
The commands printed in the release step summary did not work in this repo:

- tag.gpgsign=true makes a tag message mandatory, so the bare 'git tag -f v$MAJOR v$VERSION' form fails with 'fatal: no tag message?' when the minor rolling tag does not exist yet
- passing the tag name as the target creates a nested lightweight tag instead of the annotated 'Rolling tag: X -> Y' shape every previous rolling tag uses

Print the '-f -s -m' form targeting $TAG^{} (the commit) instead, and note why the step is manual: keeping the rolling tags signed with the maintainer's key rather than a CI key.

Summary text only - no change to what the workflow executes.