### PR TITLE
fix: skip Deny statements in principal_validation

### DIFF
--- a/docs/user-guide/checks/security-checks.md
+++ b/docs/user-guide/checks/security-checks.md
@@ -338,6 +338,23 @@ Validates Principal elements in resource policies and trust policies.
 
 **Severity:** `high` (varies by issue type)
 
+**Scope:** `Effect: Deny` statements are skipped unless they use `NotPrincipal`.
+
+Every rule below describes an over-broad *grant*, and a `Deny` over `Principal` cannot
+over-grant — `Deny` with `Principal: "*"` is the standard guardrail idiom (resource
+control policies, org perimeters, `sts:TagSession` restrictions), and scoping it with
+`aws:SourceArn`/`aws:PrincipalOrgID` would narrow the deny and weaken the policy.
+
+Inverted denies are the exception, because the carve-out is the exposure. `NotPrincipal`
+spells the inversion with a principal, so those statements are still checked in full.
+[AWS recommends](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html)
+spelling it with a condition instead — `Principal: "*"` plus `ArnNotEquals` on
+`aws:PrincipalArn` — and that form is reported as `ineffective_deny_carve_out` when the
+carve-out is `*`, since exempting every principal denies nobody.
+
+See also [`rcp_best_practices`](advanced-checks.md#rcp_best_practices) and
+[`not_principal_validation`](aws-validation.md#not_principal_validation).
+
 ### What It Checks
 
 - **Service Principal Wildcards** (`critical`): Detects dangerous `{"Service": "*"}` patterns

--- a/iam_validator/checks/principal_validation.py
+++ b/iam_validator/checks/principal_validation.py
@@ -8,7 +8,9 @@ This check enforces:
 - Rich condition requirements for principals (supports any_of/all_of/none_of)
 - Service principal validation
 
-Only runs for RESOURCE_POLICY and TRUST_POLICY types.
+Only runs for RESOURCE_POLICY and TRUST_POLICY types. ``Effect: Deny`` statements are
+skipped unless they use ``NotPrincipal``: a Deny over ``Principal`` cannot over-grant,
+but ``NotPrincipal`` inverts the set, so a broad exception list is a real exposure.
 
 Configuration format:
 
@@ -75,6 +77,14 @@ class PrincipalValidationCheck(PolicyCheck):
         # Skip if no principal
         if statement.principal is None and statement.not_principal is None:
             return issues
+
+        # A Deny over Principal grants nothing, so the rules below do not apply -- except
+        # that an inverted Deny carves principals *out* of the deny, and a carve-out of
+        # "*" denies nobody. NotPrincipal spells that inversion with a principal (so it
+        # falls through to the normal rules); ArnNotEquals & friends spell it with a
+        # condition, which only this check catches.
+        if self._is_deny(statement) and statement.not_principal is None:
+            return self._check_deny_carve_out(statement, statement_idx, config)
 
         # Get configuration (defaults match defaults.py)
         blocked_principals = list(config.config.get("blocked_principals", []))
@@ -172,6 +182,97 @@ class PrincipalValidationCheck(PolicyCheck):
                 issues.extend(condition_issues)
 
         return issues
+
+    #: Condition operators that carve principals *out* of a Deny (negated matching).
+    _NEGATED_OPERATORS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "arnnotequals",
+            "arnnotlike",
+            "stringnotequals",
+            "stringnotequalsignorecase",
+            "stringnotlike",
+        }
+    )
+
+    #: Condition keys that identify *who* the caller is, as opposed to what they request.
+    _PRINCIPAL_CONDITION_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "aws:principalarn",
+            "aws:principalaccount",
+            "aws:principalorgid",
+            "aws:principalorgpaths",
+            "aws:principalservicename",
+            "aws:principaltype",
+            "aws:principalisawsservice",
+            "aws:userid",
+            "aws:username",
+        }
+    )
+
+    @staticmethod
+    def _is_deny(statement: Statement) -> bool:
+        """Return True only for an unambiguous Deny, so a malformed Effect is still checked.
+
+        Matched case-insensitively: policies reach the check straight from user files.
+        """
+        return isinstance(statement.effect, str) and statement.effect.strip().lower() == "deny"
+
+    @classmethod
+    def _is_principal_condition_key(cls, key: str) -> bool:
+        normalized = key.strip().lower()
+        return normalized in cls._PRINCIPAL_CONDITION_KEYS or normalized.startswith("aws:principaltag/")
+
+    @classmethod
+    def _is_negated_operator(cls, operator: str) -> bool:
+        # Strip set prefixes (ForAnyValue:/ForAllValues:) and the IfExists suffix
+        base = operator.strip().lower().rsplit(":", 1)[-1].removesuffix("ifexists")
+        return base in cls._NEGATED_OPERATORS
+
+    def _check_deny_carve_out(
+        self,
+        statement: Statement,
+        statement_idx: int,
+        config: CheckConfig,
+    ) -> list[ValidationIssue]:
+        """Flag an inverted Deny whose carve-out matches every principal.
+
+        AWS recommends replacing ``NotPrincipal`` with ``Deny`` + ``Principal: "*"`` and a
+        negated principal condition such as ``ArnNotEquals`` on ``aws:PrincipalArn``. That
+        rewrite exempts the listed principals from the deny, so a carve-out of ``"*"``
+        exempts everyone and the statement denies nothing -- the condition equivalent of
+        ``NotPrincipal: "*"``.
+        """
+        if not statement.condition:
+            return []
+
+        for operator, entries in statement.condition.items():
+            if not self._is_negated_operator(operator) or not isinstance(entries, dict):
+                continue
+            for key, value in entries.items():
+                if not self._is_principal_condition_key(key):
+                    continue
+                values = value if isinstance(value, list) else [value]
+                if not any(str(v).strip() == "*" for v in values):
+                    continue
+                return [
+                    ValidationIssue(
+                        severity=self.get_severity(config),
+                        statement_sid=statement.sid,
+                        statement_index=statement_idx,
+                        issue_type="ineffective_deny_carve_out",
+                        message=(
+                            f"`Deny` carve-out `{operator}` on `{key}` is `*`, which exempts every "
+                            "principal from the deny. The statement denies nothing."
+                        ),
+                        suggestion=(
+                            "Replace `*` with the specific principals that must be exempt, or remove "
+                            f"the `{key}` condition if nothing should be exempt."
+                        ),
+                        line_number=statement.line_number,
+                        field_name="condition",
+                    )
+                ]
+        return []
 
     def _extract_principals(self, statement: Statement) -> list[str]:
         """Extract all principals from a statement.

--- a/tests/checks/test_principal_validation_check.py
+++ b/tests/checks/test_principal_validation_check.py
@@ -452,3 +452,440 @@ class TestServicePrincipalWildcardDetection:
         # Should have no service_principal_wildcard issues
         service_wildcard_issues = [i for i in issues if i.issue_type == "service_principal_wildcard"]
         assert len(service_wildcard_issues) == 0
+
+
+class TestDenyStatementsAreSkipped:
+    """A Deny cannot over-grant, so none of this check's rules apply to it.
+
+    `Deny` + `Principal: "*"` is the canonical guardrail idiom (resource control
+    policies, org-wide perimeters, `sts:TagSession` restrictions). Flagging it as
+    public access is a false positive, and the suggested remediation -- scoping the
+    statement with `aws:SourceArn`/`aws:PrincipalOrgID` -- would narrow the Deny and
+    weaken the policy.
+    """
+
+    @pytest.fixture
+    def check(self):
+        return PrincipalValidationCheck()
+
+    @pytest.mark.asyncio
+    async def test_deny_wildcard_principal_without_conditions_is_clean(self, check, fetcher):
+        """The regression: a bare `Deny` + `Principal: "*"` must not be flagged."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={
+                "principal_condition_requirements": [
+                    {
+                        "principals": ["*"],
+                        "severity": "critical",
+                        "required_conditions": {
+                            "any_of": [
+                                {"condition_key": "aws:SourceArn"},
+                                {"condition_key": "aws:PrincipalOrgID"},
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+        statement = Statement(
+            Sid="DenyInsecureTransport",
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::my-bucket/*"],
+            Principal="*",
+            Condition={"BoolIfExists": {"aws:SecureTransport": "false"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_allow_wildcard_principal_is_still_flagged(self, check, fetcher):
+        """The guard must not weaken the Allow path -- same shape, Effect: Allow."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={
+                "principal_condition_requirements": [
+                    {
+                        "principals": ["*"],
+                        "severity": "critical",
+                        "required_conditions": {
+                            "any_of": [
+                                {"condition_key": "aws:SourceArn"},
+                                {"condition_key": "aws:PrincipalOrgID"},
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+        statement = Statement(
+            Sid="AllowAnyone",
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::my-bucket/*"],
+            Principal="*",
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "missing_principal_condition_any_of"
+        assert issues[0].severity == "critical"
+
+    @pytest.mark.asyncio
+    async def test_deny_blocked_principal_is_clean(self, check, fetcher):
+        """`blocked_principals` describes who may be granted access, not denied."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"blocked_principals": ["*"], "block_wildcard_principal": True},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_deny_service_principal_wildcard_is_clean(self, check, fetcher):
+        """`{"Service": "*"}` under Deny denies every service -- that is hardening."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"block_service_principal_wildcard": True},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["sts:AssumeRole"],
+            Resource=["*"],
+            Principal={"Service": "*"},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_deny_non_allowlisted_principal_is_clean(self, check, fetcher):
+        """An `allowed_principals` allow-list constrains grants, not denies."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"allowed_principals": ["arn:aws:iam::111122223333:root"]},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal={"AWS": "arn:aws:iam::999988887777:root"},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    async def test_deny_forbidden_condition_is_clean(self, check, fetcher):
+        """`none_of` forbids allowing insecure transport; denying it is the fix."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={
+                "principal_condition_requirements": [
+                    {
+                        "principals": ["*"],
+                        "required_conditions": {
+                            "none_of": [
+                                {
+                                    "condition_key": "aws:SecureTransport",
+                                    "expected_value": False,
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"Bool": {"aws:SecureTransport": "false"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("effect", ["Deny", "deny", "DENY", " Deny "])
+    async def test_deny_casing_variants_are_skipped(self, check, fetcher, effect):
+        """AWS mandates exact casing, but user files reach the check unnormalised."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"blocked_principals": ["*"], "block_wildcard_principal": True},
+        )
+        statement = Statement(Effect=effect, Action=["s3:*"], Resource=["*"], Principal="*")
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "not_principal",
+        ["*", {"AWS": "*"}, {"Service": "*"}],
+    )
+    async def test_deny_with_notprincipal_wildcard_is_still_flagged(self, check, fetcher, not_principal):
+        """NotPrincipal inverts the set, so a wildcard exception is real exposure.
+
+        `Deny` + `NotPrincipal: "*"` denies nobody -- everyone is in "*", so nobody is
+        "not *". The guard must not silence that.
+        """
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"blocked_principals": ["*"], "block_wildcard_principal": True},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            NotPrincipal=not_principal,
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "blocked_principal"
+
+    @pytest.mark.asyncio
+    async def test_deny_with_scoped_notprincipal_is_clean(self, check, fetcher):
+        """A narrow NotPrincipal exception is a real lockdown, not an exposure."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"blocked_principals": ["*"], "block_wildcard_principal": True},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            NotPrincipal={"AWS": "arn:aws:iam::111122223333:role/Admin"},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("effect", ["Allow", "allow", None, "Bogus"])
+    async def test_non_deny_effects_are_still_validated(self, check, fetcher, effect):
+        """Anything not recognisably a Deny is validated: never fail open on a grant."""
+        config = CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={"blocked_principals": ["*"], "block_wildcard_principal": True},
+        )
+        statement = Statement(Effect=effect, Action=["s3:*"], Resource=["*"], Principal="*")
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "blocked_principal"
+
+
+class TestInvertedDenyCarveOut:
+    """AWS recommends replacing NotPrincipal with Deny + Principal "*" + ArnNotEquals.
+
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+    That rewrite carves the listed principals *out* of the deny, so the carve-out is the
+    exposure -- and a carve-out of "*" excludes everyone, denying nothing.
+    """
+
+    @pytest.fixture
+    def check(self):
+        return PrincipalValidationCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(
+            check_id="principal_validation",
+            enabled=True,
+            config={
+                "principal_condition_requirements": [
+                    {
+                        "principals": ["*"],
+                        "required_conditions": {"any_of": [{"condition_key": "aws:SourceArn"}]},
+                    }
+                ],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_aws_documented_role_carve_out_is_clean(self, check, fetcher, config):
+        """The exact example from the AWS NotPrincipal page must not be flagged."""
+        statement = Statement(
+            Sid="DenyCrossAuditAccess",
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::audit"],
+            Principal="*",
+            Condition={"ArnNotEquals": {"aws:PrincipalArn": "arn:aws:iam::444455556666:role/read-only-role"}},
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operator",
+        ["ArnNotEquals", "ArnNotLike", "StringNotEquals", "StringNotLike", "StringNotEqualsIgnoreCase"],
+    )
+    async def test_equivalent_operators_on_principalarn_are_clean(self, check, fetcher, config, operator):
+        """aws:PrincipalArn accepts ARN *and* String operators; all express the same carve-out.
+
+        ARN operators are the documented preference, but the String forms are valid and
+        must not be treated as a finding here.
+        """
+        statement = Statement(
+            Sid="DenyCrossAuditAccess",
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::Bucket_Account_Audit"],
+            Principal="*",
+            Condition={operator: {"aws:PrincipalArn": "arn:aws:iam::444455556666:role/read-only-role"}},
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    async def test_wildcard_org_carve_out_is_flagged(self, check, fetcher, config):
+        """aws:PrincipalOrgID satisfies the any_of rule, so nothing else catches this.
+
+        `Deny` + `StringNotEquals aws:PrincipalOrgID: "*"` exempts every org, denying
+        nobody, and unlike the ARN keys `"*"` is a structurally valid value here.
+        """
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"StringNotEquals": {"aws:PrincipalOrgID": "*"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "ineffective_deny_carve_out"
+
+    @pytest.mark.asyncio
+    async def test_notaction_deny_is_not_a_principal_carve_out(self, check, fetcher, config):
+        """NotAction inverts the action axis, not the principal axis.
+
+        That belongs to not_action_not_resource; the principal set is still "everyone".
+        """
+        statement = Statement(
+            Effect="Deny",
+            NotAction=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    async def test_aws_documented_service_carve_out_is_clean(self, check, fetcher, config):
+        """The service-principal variant from the same page, incl. the IfExists suffix."""
+        statement = Statement(
+            Sid="DenyNotCodeBuildAccess",
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["arn:aws:s3:::bucket"],
+            Principal="*",
+            Condition={"StringNotEqualsIfExists": {"aws:PrincipalServiceName": "codebuild.amazonaws.com"}},
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    async def test_org_perimeter_deny_is_clean(self, check, fetcher, config):
+        """The canonical org-boundary RCP shape stays clean."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={
+                "StringNotEquals": {"aws:PrincipalOrgID": "o-abc123"},
+                "BoolIfExists": {"aws:PrincipalIsAWSService": "false"},
+            },
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operator,key",
+        [
+            ("ArnNotEquals", "aws:PrincipalArn"),
+            ("ArnNotLike", "aws:PrincipalArn"),
+            ("StringNotEquals", "aws:PrincipalAccount"),
+            ("StringNotEqualsIfExists", "aws:PrincipalServiceName"),
+            ("StringNotLike", "aws:PrincipalOrgPaths"),
+            ("ForAnyValue:StringNotEquals", "aws:PrincipalTag/team"),
+        ],
+    )
+    async def test_wildcard_carve_out_is_flagged(self, check, fetcher, config, operator, key):
+        """A carve-out of "*" excludes every principal, so the Deny denies nothing."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={operator: {key: "*"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "ineffective_deny_carve_out"
+        assert issues[0].field_name == "condition"
+
+    @pytest.mark.asyncio
+    async def test_wildcard_in_carve_out_list_is_flagged(self, check, fetcher, config):
+        """A "*" hidden among specific ARNs still defeats the whole deny."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"ArnNotEquals": {"aws:PrincipalArn": ["arn:aws:iam::111122223333:role/A", "*"]}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "ineffective_deny_carve_out"
+
+    @pytest.mark.asyncio
+    async def test_non_principal_key_wildcard_is_ignored(self, check, fetcher, config):
+        """A negated operator on a request key is not a principal carve-out.
+
+        The repo's own rcp-valid-enforce-encryption fixture uses StringNotEquals on
+        s3:x-amz-server-side-encryption, which must stay clean.
+        """
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:PutObject"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"StringNotEquals": {"s3:x-amz-server-side-encryption": "*"}},
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    async def test_positive_operator_wildcard_is_ignored(self, check, fetcher, config):
+        """StringEquals is not a carve-out -- it narrows the deny rather than exempting."""
+        statement = Statement(
+            Effect="Deny",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"StringEquals": {"aws:PrincipalAccount": "*"}},
+        )
+        assert await check.execute(statement, 0, fetcher, config) == []
+
+    @pytest.mark.asyncio
+    async def test_allow_with_negated_principal_condition_still_validated(self, check, fetcher, config):
+        """The carve-out path must not swallow the Allow rules."""
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:*"],
+            Resource=["*"],
+            Principal="*",
+            Condition={"ArnNotEquals": {"aws:PrincipalArn": "*"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "missing_principal_condition_any_of"


### PR DESCRIPTION
## Problem

`principal_validation` never inspects `Effect`, so all its rules — `blocked_principals`, the `{"Service": "*"}` wildcard, `allowed_principals`, `principal_condition_requirements` — also fire on `Deny`. Those rules describe an over-broad **grant**; a Deny over `Principal` grants nothing, so the findings are false positives and the fix they suggest (add `aws:SourceArn` / `aws:PrincipalOrgID`) would *narrow the deny*.

This repo's own `rcp-valid-enforce-encryption.json` — the fixture named **valid** — reports 3 criticals as `RESOURCE_POLICY` or `TRUST_POLICY`. One is `forbidden_principal_condition` from `PREVENT_INSECURE_TRANSPORT`, a rule whose description says HTTP must never be *"explicitly allowed"*, firing on `Deny` + `aws:SecureTransport: false` — the AWS-documented way to deny it.

## Fix

Skip Deny, matching the effect gates in `sensitive_action` and `trust_policy_validation` — **except for inverted denies**, where the carve-out is the exposure rather than the principal:

- **`NotPrincipal`** keeps the full check. `Deny` + `NotPrincipal: "*"` denies nobody.
- **Negated principal conditions** ([AWS's recommended replacement for `NotPrincipal`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html): `Principal: "*"` + `ArnNotEquals` on `aws:PrincipalArn`) are skipped — flagging them was a false positive on AWS's own guidance — but a carve-out of `"*"` exempts every principal, so it is now reported as `ineffective_deny_carve_out`.

  Matching covers every equivalent spelling — `ArnNotEquals`, `ArnNotLike`, `StringNotEquals`, `StringNotLike`, `StringNotEqualsIgnoreCase`, their `IfExists` forms and `ForAnyValue:`/`ForAllValues:` prefixes — since `aws:PrincipalArn` accepts ARN *and* String operators. Positive operators are ignored: they narrow the deny rather than exempting from it. Matching is scoped to principal identity keys, so negated operators elsewhere (`StringNotEquals` on `s3:x-amz-server-side-encryption`, org-perimeter RCPs) stay clean.

  This adds coverage rather than relabelling: `StringNotEquals` on `aws:PrincipalOrgID: "*"` is reported by nothing on `main`, because that key satisfies the `any_of` requirement. The ARN keys were already caught, but as an `invalid_value_format` error about `"*"` not parsing as an ARN.

`NotAction` is a different axis and stays with `not_action_not_resource`; the principal set of a `Deny` + `NotAction` is still "everyone". (That check has no `NotResource` + `Deny` branch at all — filed separately as #154, unrelated to this PR.)

The Deny match is case-insensitive and only skips a *positively identified* Deny, so a malformed `Effect` is still validated — under-validating a possible grant is the worse failure, and `policy_structure` reports the bad `Effect`.

Deny keeps its other coverage: this check only ever emitted policy judgements, never format/syntax findings. Principal format stays with `trust_policy_validation` / `policy_type_validation`.

## Verification

| | `main` | this PR |
|---|---|---|
| AWS doc: `ArnNotEquals` <specific role> | false positive | clean |
| AWS doc: `StringNotEqualsIfExists` <service> | false positive | clean |
| `ArnNotEquals: {aws:PrincipalArn: "*"}` | wrong finding | `ineffective_deny_carve_out` |
| `NotPrincipal: "*"` | flagged | flagged |
| Org-perimeter RCP | clean | clean |
| `Deny Principal: "*"` (plain guardrail) | false positive | clean |

Across all of `examples/`: **5 findings removed, all on `Deny…` statements; 0 added**; the 5 `Allow…`/`Public…` findings retained.

Suite **1644 passed, 23 skipped** — no existing test changed. `ruff` and `mkdocs build --strict` clean.

## Note

No `CHANGELOG.md` entry — `.claude/commands/update-changelog.md` forbids an `## Unreleased` section and I can't know the next version. Suggested entry under `### Fixed`:

> - Skip `Deny` statements in `principal_validation`, except inverted denies where the carve-out is the exposure. Its rules describe over-broad grants, so on a `Deny` they were false positives whose suggested remediation would narrow the deny; add `ineffective_deny_carve_out` for a negated principal condition of `"*"` ([#NNN])
