### PR TITLE
chore: bump version to 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2026-08-21
+
+### Added
+
+- Add `not_resource_deny_review` (low) and `not_resource_deny_ineffective` findings to `not_action_not_resource` for `NotResource` used with `Deny` — mirrors the existing `NotAction` + `Deny` checks on the resource axis; a `NotResource: "*"` exclusion denies nothing ([#155])
+- Add `ineffective_deny_carve_out` finding to `principal_validation` for a `Deny` with a negated principal condition (e.g. `ArnNotEquals` on `aws:PrincipalArn`) that carves out every principal, closing the gap left when migrating off `NotPrincipal` ([#153])
+
+### Fixed
+
+- Skip `Deny` statements in `principal_validation` (blocked principals, the `{"Service": "*"}` wildcard, `allowed_principals`, `principal_condition_requirements`) — a `Deny` over `Principal` grants nothing, so these rules produced false positives; `NotPrincipal` denies remain fully checked ([#153])
+
 ## [1.23.2] - 2026-08-07
 
 ### Fixed
@@ -737,6 +748,9 @@ _First release._
 
 ---
 
+[1.24.0]: https://github.com/boogy/iam-policy-validator/compare/v1.23.2...v1.24.0
+[#155]: https://github.com/boogy/iam-policy-validator/pull/155
+[#153]: https://github.com/boogy/iam-policy-validator/pull/153
 [1.23.2]: https://github.com/boogy/iam-policy-validator/compare/v1.23.1...v1.23.2
 [1.23.1]: https://github.com/boogy/iam-policy-validator/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/boogy/iam-policy-validator/compare/v1.22.0...v1.23.0

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.23.2"
+__version__ = "1.24.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
## Summary

- Bump version to 1.24.0 (minor: two new detection findings landed via #153 and #155)
- Add CHANGELOG.md entry for 1.24.0

## Changes

- `iam_validator/__version__.py`: 1.23.2 → 1.24.0
- `CHANGELOG.md`: add `[1.24.0]` section
  - Added: `not_resource_deny_review` / `not_resource_deny_ineffective` in `not_action_not_resource` (#155)
  - Added: `ineffective_deny_carve_out` in `principal_validation` (#153)
  - Fixed: `principal_validation` no longer false-positives on `Deny` statements (#153)

## Testing

- [x] `uv run ruff check .` passes
- [x] `uv run pytest -x -q` — 1652 passed, 23 skipped

## Checklist

- [x] Commit is signed (GPG/SSH)
- [x] CHANGELOG.md updated
- [x] No code/behavior changes — version + changelog only