### PR TITLE
fix: treat aws:CalledVia as a multivalued context key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Treat `aws:CalledVia` as multivalued, so a set operator on it no longer raises `set_operator_on_single_valued_key` — AWS types it `Value type - Multivalued`, and multivalued keys require one; `aws:CalledViaFirst` and `aws:CalledViaLast` stay single-valued
+
 ## [1.24.0] - 2026-08-21
 
 ### Added

--- a/iam_validator/core/condition_validators.py
+++ b/iam_validator/core/condition_validators.py
@@ -809,6 +809,7 @@ def is_multivalued_context_key(condition_key: str) -> bool:
     Multivalued context keys include:
     - aws:TagKeys (list of tag keys being applied)
     - aws:PrincipalOrgPaths (organization paths)
+    - aws:CalledVia (ordered list of services in a forward access session chain)
     - Service-specific multivalued keys (e.g., s3:x-amz-grant-*)
 
     Single-valued context keys include:
@@ -846,6 +847,7 @@ def is_multivalued_context_key(condition_key: str) -> bool:
         "aws:tagkeys",  # List of tag keys being applied/modified
         "aws:principalorgpaths",  # Organization paths for the principal
         "aws:resourceorgpaths",  # Organization paths for the resource
+        "aws:calledvia",  # Ordered list of services in the FAS call chain
     }
 
     # Check exact matches

--- a/tests/core/test_set_operator_validation.py
+++ b/tests/core/test_set_operator_validation.py
@@ -126,6 +126,28 @@ class TestSetOperatorValidationCheck:
         assert "single-valued" in issues[0].message.lower()
 
     @pytest.mark.asyncio
+    async def test_foranyvalue_with_calledvia(self, check, config):
+        """Test ForAnyValue with aws:CalledVia is accepted.
+
+        AWS documents aws:CalledVia as `Data type - String (list)` and
+        `Value type - Multivalued`, and multivalued keys require a set operator.
+        Both the Athena and forward-access-sessions guides use
+        ForAnyValue:StringEquals with this key.
+        """
+        statement = Statement(
+            effect="Allow",
+            action=["lambda:InvokeFunction"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": ["athena.amazonaws.com"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert issues == []
+
+    @pytest.mark.asyncio
     async def test_forallvalues_allow_without_null_check(self, check, config):
         """Test ForAllValues with Allow effect without Null check generates warning."""
         statement = Statement(


### PR DESCRIPTION
`is_multivalued_context_key()` did not list `aws:calledvia`, so `set_operator_validation` reported `set_operator_on_single_valued_key` (severity error) for `ForAnyValue:StringEquals` on that key.

AWS documents the key as:
- Data type  - String (list)
- Value type - Multivalued

and the single-vs-multivalued reference states that "Multivalued context keys require a condition set operator" while "Do not use condition set operators ForAllValues or ForAnyValue with single-valued context keys". So the check flagged the required form and accepted the bare operator, which matches nothing once the request carries more than one service in the chain.

AWS's own examples use the flagged form: the Athena CalledVia guide and the forward-access-sessions guide both pair `aws:CalledVia` with `ForAnyValue:StringEquals`.

Observed in practice on a DataZone-initiated forward access session: with `StringEquals` the sso:* action was denied, and with `ForAnyValue:StringEquals` the identical call by the identical principal succeeded.

`aws:CalledViaFirst` and `aws:CalledViaLast` each name a single service and are left single-valued.

Refs:
- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html
- https://docs.aws.amazon.com/athena/latest/ug/security-iam-athena-calledvia.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/access_forward_access_sessions.html