### PR TITLE
fix: treat the remaining three multivalued global condition keys as multivalued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 ### Fixed
 
 - Treat `aws:CalledVia` as multivalued, so a set operator on it no longer raises `set_operator_on_single_valued_key` — AWS types it `Value type - Multivalued`, and multivalued keys require one; `aws:CalledViaFirst` and `aws:CalledViaLast` stay single-valued
+- Treat `aws:PrincipalServiceNamesList`, `aws:SourceOrgPaths` and `aws:VpceOrgPaths` as multivalued, completing the set of 7 keys AWS documents as `Value type - Multivalued` — AWS states outright that each requires `ForAnyValue` or `ForAllValues`, and `principal_validation` already recommends `ForAnyValue:StringLike` on `aws:SourceOrgPaths` for OU-level confused deputy protection ([#162])
 
 ## [1.24.0] - 2026-08-21
 
@@ -754,6 +755,7 @@ _First release._
 
 ---
 
+[#162]: https://github.com/boogy/iam-policy-validator/issues/162
 [1.24.0]: https://github.com/boogy/iam-policy-validator/compare/v1.23.2...v1.24.0
 [#155]: https://github.com/boogy/iam-policy-validator/pull/155
 [#153]: https://github.com/boogy/iam-policy-validator/pull/153

--- a/iam_validator/core/condition_validators.py
+++ b/iam_validator/core/condition_validators.py
@@ -808,7 +808,9 @@ def is_multivalued_context_key(condition_key: str) -> bool:
 
     Multivalued context keys include:
     - aws:TagKeys (list of tag keys being applied)
-    - aws:PrincipalOrgPaths (organization paths)
+    - aws:PrincipalOrgPaths, aws:ResourceOrgPaths, aws:SourceOrgPaths, aws:VpceOrgPaths
+      (organization paths)
+    - aws:PrincipalServiceNamesList (service principal names of the calling service)
     - aws:CalledVia (ordered list of services in a forward access session chain)
     - Service-specific multivalued keys (e.g., s3:x-amz-grant-*)
 
@@ -846,7 +848,10 @@ def is_multivalued_context_key(condition_key: str) -> bool:
     multivalued_keys = {
         "aws:tagkeys",  # List of tag keys being applied/modified
         "aws:principalorgpaths",  # Organization paths for the principal
+        "aws:principalservicenameslist",  # Service principal names of the calling service
         "aws:resourceorgpaths",  # Organization paths for the resource
+        "aws:sourceorgpaths",  # Organization paths of the source resource owner
+        "aws:vpceorgpaths",  # Organization paths of the VPC endpoint owner
         "aws:calledvia",  # Ordered list of services in the FAS call chain
     }
 

--- a/tests/core/test_set_operator_validation.py
+++ b/tests/core/test_set_operator_validation.py
@@ -298,6 +298,54 @@ class TestSetOperatorValidationCheck:
         assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
 
     @pytest.mark.asyncio
+    async def test_principal_service_names_list_is_multivalued(self, check, config):
+        """Test aws:PrincipalServiceNamesList is recognized as multivalued."""
+        statement = Statement(
+            effect="Allow",
+            action=["s3:GetObject"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringEquals": {
+                    "aws:PrincipalServiceNamesList": ["cloudtrail.amazonaws.com"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
+
+    @pytest.mark.asyncio
+    async def test_source_org_paths_is_multivalued(self, check, config):
+        """Test aws:SourceOrgPaths is recognized as multivalued."""
+        statement = Statement(
+            effect="Allow",
+            action=["sts:AssumeRole"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringLike": {
+                    "aws:SourceOrgPaths": ["o-example12345/r-ab12/ou-ab12-11111111/*"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
+
+    @pytest.mark.asyncio
+    async def test_vpce_org_paths_is_multivalued(self, check, config):
+        """Test aws:VpceOrgPaths is recognized as multivalued."""
+        statement = Statement(
+            effect="Allow",
+            action=["s3:GetObject"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringLike": {
+                    "aws:VpceOrgPaths": ["o-example12345/r-ab12/ou-ab12-11111111/*"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
+
+    @pytest.mark.asyncio
     async def test_statement_with_sid(self, check, config):
         """Test issue includes statement SID when present."""
         statement = Statement(


### PR DESCRIPTION
Follow-up to #161, closing #162.

AWS documents exactly **7** global condition keys as `Value type – Multivalued`. After #161 `is_multivalued_context_key()` covered four; three were missing:

| key | in the set before | now |
|---|---|---|
| `aws:TagKeys` | yes | yes |
| `aws:PrincipalOrgPaths` | yes | yes |
| `aws:ResourceOrgPaths` | yes | yes |
| `aws:CalledVia` | yes (#161) | yes |
| `aws:PrincipalServiceNamesList` | **no** | yes |
| `aws:SourceOrgPaths` | **no** | yes |
| `aws:VpceOrgPaths` | **no** | yes |

Verified by extracting every `Value type` field from the [global condition keys reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html) — 7 multivalued entries, matching the table above exactly.

## The bug

`set_operator_validation` raised `set_operator_on_single_valued_key` (severity `error`) on the form AWS mandates. Reproduced on `main` before the fix, all three at severity `error`:

```
aws:PrincipalServiceNamesList    set_operator_on_single_valued_key (error)
aws:SourceOrgPaths               set_operator_on_single_valued_key (error)
aws:VpceOrgPaths                 set_operator_on_single_valued_key (error)
```

AWS states the requirement outright for each of the three: *"you must use the `ForAnyValue` or `ForAllValues` set operators with string condition operators for this key"*. Per [single-valued vs. multivalued](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html), *"Multivalued context keys require a condition set operator."*

## It flagged the project's own recommendation

`principal_validation` suggests `ForAnyValue:StringLike` on `aws:SourceOrgPaths` for OU-level confused deputy protection (`principal_requirements.py:86-96`), and `test_trust_policy_validation.py:405-412` uses that shape as the correct example. Running that exact policy through the validator before this fix:

```
✗ 1 AWS-invalid (structural errors)
  ERROR  set_operator_on_single_valued_key  Set operator `ForAnyValue` should not be
                                            used with single-valued condition key
                                            `aws:SourceOrgPaths`.
```

One check recommended the shape another check rejected.

## Why the SAR fallback can't cover these

Confirmed against the live Service Authorization Reference for s3, ec2, sts, kms and lambda: the only `aws:` keys carried per service are `aws:RequestTag/${TagKey}`, `aws:ResourceTag/${TagKey}` and `aws:TagKeys`. The other global keys don't appear at all, so the `ArrayOf`-prefix lookup in `set_operator_validation.py:47-77` never resolves them. The hardcoded set is the only path.

## Testing

Three tests mirroring `test_resource_org_paths_is_multivalued`. Each was confirmed to fail with the corresponding key removed from the set and pass with it present — they guard the behaviour rather than merely passing.

Full suite: 1415 passed, 1 skipped (excluding `tests/mcp`, which needs the `mcp` extra). `ruff check` and `ruff format` clean.

## Not included

The issue also notes that `s3:x-amz-grant-*` and `ec2:*ResourceTag/*` are hardcoded as multivalued while the SAR types them plain `String` — the inverse error, verified in [s3.json](https://servicereference.us-east-1.amazonaws.com/v1/s3/s3.json) and [ec2.json](https://servicereference.us-east-1.amazonaws.com/v1/ec2/ec2.json). `test_set_operator_validation.py:262` asserts the current behaviour, so that's a deliberate behaviour change and belongs in its own PR.