### PR TITLE
fix: treat s3:x-amz-grant-* and ec2:ResourceTag/* as single-valued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 
 ## [Unreleased]
 
+### Changed
+
+- Treat `s3:x-amz-grant-*` and `ec2:ResourceTag/*` as single-valued, so a set operator on them now raises `set_operator_on_single_valued_key` — the Service Authorization Reference types both as `String`, not `ArrayOfString`, and `ec2:ResourceTag/*` was the only `ResourceTag` variant exempt from the error that `aws:ResourceTag/*` and every other service prefix already produced. Genuinely multivalued service keys keep working: they are resolved from their `ArrayOf` prefix in the Service Authorization Reference ([#164])
+
 ### Fixed
 
 - Treat `aws:CalledVia` as multivalued, so a set operator on it no longer raises `set_operator_on_single_valued_key` — AWS types it `Value type - Multivalued`, and multivalued keys require one; `aws:CalledViaFirst` and `aws:CalledViaLast` stay single-valued
@@ -755,6 +759,7 @@ _First release._
 
 ---
 
+[#164]: https://github.com/boogy/iam-policy-validator/pull/164
 [#162]: https://github.com/boogy/iam-policy-validator/issues/162
 [1.24.0]: https://github.com/boogy/iam-policy-validator/compare/v1.23.2...v1.24.0
 [#155]: https://github.com/boogy/iam-policy-validator/pull/155

--- a/iam_validator/core/condition_validators.py
+++ b/iam_validator/core/condition_validators.py
@@ -812,7 +812,9 @@ def is_multivalued_context_key(condition_key: str) -> bool:
       (organization paths)
     - aws:PrincipalServiceNamesList (service principal names of the calling service)
     - aws:CalledVia (ordered list of services in a forward access session chain)
-    - Service-specific multivalued keys (e.g., s3:x-amz-grant-*)
+
+    Service-specific multivalued keys are not listed here; they carry an ArrayOf prefix
+    in the Service Authorization Reference and are resolved from that data instead.
 
     Single-valued context keys include:
     - aws:SourceIp (single IP address)
@@ -859,14 +861,7 @@ def is_multivalued_context_key(condition_key: str) -> bool:
     if key_lower in multivalued_keys:
         return True
 
-    # Service-specific multivalued patterns
-    # S3 grant headers are multivalued
-    if key_lower.startswith("s3:x-amz-grant-"):
-        return True
-
-    # EC2 resource tags in requests can be multivalued
-    if "ec2:" in key_lower and ":resourcetag/" in key_lower:
-        return True
-
-    # Most condition keys are single-valued by default
+    # Most condition keys are single-valued by default. Service-specific multivalued
+    # keys carry an ArrayOf prefix in the Service Authorization Reference and are
+    # resolved from that data by the caller.
     return False

--- a/tests/core/test_set_operator_validation.py
+++ b/tests/core/test_set_operator_validation.py
@@ -262,8 +262,12 @@ class TestSetOperatorValidationCheck:
         assert issues[0].issue_type == "forallvalues_allow_without_null_check"
 
     @pytest.mark.asyncio
-    async def test_s3_grant_header_is_multivalued(self, check, config):
-        """Test S3 grant headers are recognized as multivalued."""
+    async def test_s3_grant_header_is_single_valued(self, check, config):
+        """Test S3 grant headers are flagged as single-valued.
+
+        The Service Authorization Reference types every s3:x-amz-grant-* key as
+        `String`, not `ArrayOfString`.
+        """
         statement = Statement(
             effect="Allow",
             action=["s3:PutObjectAcl"],
@@ -278,8 +282,23 @@ class TestSetOperatorValidationCheck:
             },
         )
         issues = await check.execute(statement, 0, None, config)
-        # Should not generate set_operator_on_single_valued_key error
-        assert all(issue.issue_type != "set_operator_on_single_valued_key" for issue in issues)
+        assert any(issue.issue_type == "set_operator_on_single_valued_key" for issue in issues)
+
+    @pytest.mark.asyncio
+    async def test_ec2_resource_tag_is_single_valued(self, check, config):
+        """Test ec2:ResourceTag is flagged as single-valued, like aws:ResourceTag."""
+        statement = Statement(
+            effect="Allow",
+            action=["ec2:StartInstances"],
+            resource=["*"],
+            condition={
+                "ForAnyValue:StringEquals": {
+                    "ec2:ResourceTag/Environment": ["production"],
+                },
+            },
+        )
+        issues = await check.execute(statement, 0, None, config)
+        assert any(issue.issue_type == "set_operator_on_single_valued_key" for issue in issues)
 
     @pytest.mark.asyncio
     async def test_resource_org_paths_is_multivalued(self, check, config):


### PR DESCRIPTION
Closes the "Separately" note in #162, the inverse of the bug fixed in #161 and #163.

`is_multivalued_context_key()` hardcoded two service-specific patterns as multivalued:

```python
if key_lower.startswith("s3:x-amz-grant-"):
    return True

if "ec2:" in key_lower and ":resourcetag/" in key_lower:
    return True
```

The Service Authorization Reference types every one of those keys as `String`, not `ArrayOfString`:

| key | SAR `Types` |
|---|---|
| `s3:x-amz-grant-read` | `["String"]` |
| `s3:x-amz-grant-write` | `["String"]` |
| `s3:x-amz-grant-read-acp` | `["String"]` |
| `s3:x-amz-grant-write-acp` | `["String"]` |
| `s3:x-amz-grant-full-control` | `["String"]` |
| `ec2:ResourceTag/${TagKey}` | `["String"]` |

Verified against [s3.json](https://servicereference.us-east-1.amazonaws.com/v1/s3/s3.json) and [ec2.json](https://servicereference.us-east-1.amazonaws.com/v1/ec2/ec2.json).

Per [single-valued vs. multivalued](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html), the `ArrayOf` prefix in the SAR is precisely what marks a key multivalued:

> Multivalued context keys in the Service Authorization Reference use an `ArrayOf` prefix followed by the condition operator category type, such as `ArrayOfString` or `ArrayOfARN`, indicating that the request may include multiple values for a condition context key.

That page also names `aws:ResourceTag/tag-key` as single-valued, for the reason that applies equally to the `ec2:` variant: *"even though there can be multiple tag-key values, each `tag-key` can have only one value."*

## Impact

A missed detection. `set_operator_validation` stayed silent on a set operator applied to a single-valued key — the case AWS warns *"can lead to overly permissive policies"*.

It also left the codebase inconsistent with itself. Same key shape, same cardinality, opposite verdicts before this change:

```
aws:ResourceTag/Env    → set_operator_on_single_valued_key
rds:ResourceTag/Env    → set_operator_on_single_valued_key
ec2:ResourceTag/Env    → no finding
```

`ec2:` was the only `ResourceTag` variant exempt.

## Genuinely multivalued service keys are unaffected

Removing the hardcoded patterns does not cause false positives for real `ArrayOf` keys — the SAR lookup in `set_operator_validation.py` already resolves those. Verified end to end against live service data:

| statement | key | result |
|---|---|---|
| `S3Grant` | `s3:x-amz-grant-read` | `set_operator_on_single_valued_key` ✅ now flagged |
| `Ec2Tag` | `ec2:ResourceTag/Environment` | `set_operator_on_single_valued_key` ✅ now flagged |
| `RealArrayKey` | `ec2:Phase1DHGroup` (`ArrayOfString`) | no finding ✅ |
| `RealArrayKeyS3` | `s3:RequestObjectTagKeys` (`ArrayOfString`) | no finding ✅ |

## Behaviour change

Unlike #161 and #163, this direction **adds** errors. A policy using a set operator on these keys passes today and will now report `set_operator_on_single_valued_key` at severity `error`. That is the point of the fix, but it is worth calling out for anyone pinning on current output.

`test_s3_grant_header_is_multivalued` asserted the old behaviour and is inverted to `test_s3_grant_header_is_single_valued`; a matching `test_ec2_resource_tag_is_single_valued` is added. Both were confirmed to fail with the old patterns restored.

## Testing

Full suite: 1416 passed, 1 skipped (excluding `tests/mcp`, which needs the `mcp` extra). `ruff check` and `ruff format` clean.

Original report by @nat-n in #162.