### PR TITLE
chore: bump version to 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.25.0] - 2026-08-30
 
 ### Changed
 
@@ -761,6 +761,7 @@ _First release._
 
 [#164]: https://github.com/boogy/iam-policy-validator/pull/164
 [#162]: https://github.com/boogy/iam-policy-validator/issues/162
+[1.25.0]: https://github.com/boogy/iam-policy-validator/compare/v1.24.0...v1.25.0
 [1.24.0]: https://github.com/boogy/iam-policy-validator/compare/v1.23.2...v1.24.0
 [#155]: https://github.com/boogy/iam-policy-validator/pull/155
 [#153]: https://github.com/boogy/iam-policy-validator/pull/153

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.24.0"
+__version__ = "1.25.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))


### PR DESCRIPTION
Version bump for the `set_operator_validation` cardinality fixes: #161, #163, #164.

Minor rather than patch because #164 **adds** findings — a policy using a set operator on `s3:x-amz-grant-*` or `ec2:ResourceTag/*` passes on 1.24.0 and reports `set_operator_on_single_valued_key` at severity `error` on 1.25.0.

## Changes

- `iam_validator/__version__.py`: `1.24.0` → `1.25.0`
- `CHANGELOG.md`: `[Unreleased]` promoted to `## [1.25.0] - 2026-08-30`, comparison link added

`pyproject.toml` is intentionally untouched — it declares `dynamic = ["version"]` with `[tool.hatch.version] path = "iam_validator/__version__.py"`. Verified: `uv build --wheel` produces `iam_policy_validator-1.25.0-py3-none-any.whl`.

## Release contents

**Changed**
- `s3:x-amz-grant-*` and `ec2:ResourceTag/*` are single-valued, matching the Service Authorization Reference ([#164])

**Fixed**
- `aws:CalledVia` is multivalued ([#161])
- `aws:PrincipalServiceNamesList`, `aws:SourceOrgPaths`, `aws:VpceOrgPaths` are multivalued, completing AWS's documented set of 7 ([#163], closes #162)

All four originally reported by @nat-n in #161 / #162.

## Verification

Every one of AWS's 7 documented multivalued keys accepts a set operator; `aws:CalledViaFirst`/`Last`, `s3:x-amz-grant-read`, `ec2:ResourceTag/*`, `aws:ResourceTag/*` and `aws:SourceIp` are all flagged.

Full suite 1416 passed, 1 skipped (excluding `tests/mcp`, which needs the `mcp` extra). `ruff check` and `ruff format --check` clean.

Tag `v1.25.0` will be created and signed on `main` after this merges.