### PR TITLE
fix: report a check that raises instead of passing the policy clean

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -149,6 +149,38 @@ Switching from `false` to `true` (or vice versa) causes a one-time churn of
 existing PR comments anchored to the now-suppressed (or now-visible) check IDs.
 Re-run the validator once after changing this setting to refresh comment state.
 
+### on_check_error
+
+A check that raises an exception returns no findings, so the statement it was given
+went unvalidated by that check. By default the validator reports this as a
+`check_execution_error` finding at severity `error`, which fails a run gated on
+`error` — a run that cannot validate a policy must not report it clean.
+
+```yaml
+settings:
+  on_check_error: fail # default: fail
+```
+
+The finding names the check and the exception, and is attributed to the failing check's
+`check_id`. It deliberately ignores that check's `ignore_patterns` and severity
+overrides: the finding is *about* the check, not *from* it, so the check cannot silence
+the notice that it crashed.
+
+**Opt out**
+
+```yaml
+settings:
+  on_check_error: warn
+```
+
+`warn` logs the failure and drops it, so a policy can pass with a check's findings
+missing. This was the behaviour before the setting existed.
+
+!!! note "Custom checks"
+A bug in a custom check now fails the run instead of degrading quietly. If you load
+third-party checks you do not control and would rather not gate on their stability,
+set `on_check_error: warn` and watch the logs.
+
 ## Check Configuration
 
 ### Disable a Check
@@ -334,6 +366,10 @@ settings:
 
   # Noise reduction
   suppress_superseded_findings: true # Collapse */* noise into one finding (default: true)
+
+  # What to do when a check raises instead of returning findings
+  # fail: report a check_execution_error finding (default) | warn: log only
+  on_check_error: fail
 
   # AWS service definitions
   aws_services_dir: null # Path to offline service definitions

--- a/iam_validator/core/CLAUDE.md
+++ b/iam_validator/core/CLAUDE.md
@@ -10,6 +10,7 @@ Validation engine, models, AWS integration. Extends [../../CLAUDE.md](../../CLAU
 core/
 ├── cli.py                  # CLI entry point (argparse + ALL_COMMANDS dispatch)
 ├── check_registry.py       # PolicyCheck ABC, CheckConfig, CheckRegistry, create_default_registry
+│                           # a check that raises -> check_execution_error finding (settings.on_check_error)
 ├── models.py               # Pydantic v2: IAMPolicy, Statement, ValidationIssue, PolicyValidationResult
 ├── policy_loader.py        # JSON/YAML loading + auto-detect (also embedded in CFN/Terraform)
 ├── policy_checks.py        # validate_policies() orchestrator

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -355,7 +355,12 @@ class CheckRegistry:
         issues = await registry.execute_checks_parallel(statement, idx, fetcher)
     """
 
-    def __init__(self, enable_parallel: bool = True, suppress_superseded: bool = False):
+    def __init__(
+        self,
+        enable_parallel: bool = True,
+        suppress_superseded: bool = False,
+        on_check_error: str = "fail",
+    ):
         """
         Initialize the registry.
 
@@ -363,11 +368,66 @@ class CheckRegistry:
             enable_parallel: If True, execute checks in parallel (default: True)
             suppress_superseded: If True, suppress redundant findings when a superseding
                 check fires (default: False here; config layer enables it by default)
+            on_check_error: What to do when a check raises. "fail" reports a
+                `check_execution_error` finding so the run cannot pass on an
+                incomplete validation (default); "warn" only logs, which lets a
+                policy pass with that check's findings missing.
         """
         self._checks: dict[str, PolicyCheck] = {}
         self._configs: dict[str, CheckConfig] = {}
         self.enable_parallel = enable_parallel
         self.suppress_superseded = suppress_superseded
+        self.on_check_error = on_check_error
+
+    def _handle_check_error(
+        self,
+        check_id: str,
+        error: BaseException,
+        statement_idx: int,
+    ) -> list[ValidationIssue]:
+        """Turn a check that raised into a finding, unless configured not to.
+
+        A check that raises produced no findings, so the statement it was given
+        went unvalidated by that check. Logging alone lets the run report clean,
+        which is a worse outcome than a policy AWS would reject: the result is
+        not merely wrong, it is unsound.
+
+        The finding deliberately bypasses `_process_issues`. It is not a finding
+        *from* the check, and routing it through the failing check's own
+        `ignore_patterns` and severity overrides would let a check silence the
+        notice that it crashed.
+
+        Args:
+            check_id: The check that raised
+            error: The exception it raised
+            statement_idx: Statement index for reporting (0 for policy-level checks)
+
+        Returns:
+            A single-issue list, or an empty list when on_check_error is "warn"
+        """
+        if self.on_check_error == "warn":
+            logger.warning("Check '%s' failed: %s", check_id, error)
+            return []
+
+        logger.error("Check '%s' failed: %s", check_id, error)
+        return [
+            ValidationIssue(
+                severity="error",
+                statement_index=statement_idx,
+                issue_type="check_execution_error",
+                check_id=check_id,
+                message=(
+                    f"Check `{check_id}` raised `{type(error).__name__}: {error}` and produced "
+                    f"no findings, so this policy was not fully validated"
+                ),
+                suggestion=(
+                    "This is a bug in the check, not necessarily in the policy. Re-run with "
+                    "`--log-level DEBUG` for the traceback. Set `on_check_error: warn` under "
+                    "`settings` to downgrade this to a log line, accepting that a run can then "
+                    "pass with a check's findings missing."
+                ),
+            )
+        ]
 
     def register(self, check: PolicyCheck) -> None:
         """
@@ -552,8 +612,11 @@ class CheckRegistry:
             for check in enabled_checks:
                 config = self.get_config(check.check_id)
                 if config:
-                    issues = await check.execute(statement, statement_idx, fetcher, config)
-                    issues_map[check.check_id] = self._process_issues(issues, check, config, filepath)
+                    try:
+                        issues = await check.execute(statement, statement_idx, fetcher, config)
+                        issues_map[check.check_id] = self._process_issues(issues, check, config, filepath)
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        issues_map[check.check_id] = self._handle_check_error(check.check_id, e, statement_idx)
             if self.suppress_superseded:
                 issues_map = self._apply_supersedes(statement, enabled_checks, issues_map)
             return [issue for issues in issues_map.values() for issue in issues]
@@ -577,7 +640,9 @@ class CheckRegistry:
         issues_map = {}
         for idx, result in enumerate(results):
             if isinstance(result, Exception):
-                logger.warning("Check '%s' failed: %s", task_checks[idx].check_id, result)
+                issues_map[task_checks[idx].check_id] = self._handle_check_error(
+                    task_checks[idx].check_id, result, statement_idx
+                )
             elif isinstance(result, list):
                 processed = self._process_issues(result, task_checks[idx], configs[idx], filepath)
                 issues_map[task_checks[idx].check_id] = processed
@@ -618,7 +683,7 @@ class CheckRegistry:
                     issues = await check.execute(statement, statement_idx, fetcher, config)
                     issues_map[check.check_id] = self._process_issues(issues, check, config, filepath)
                 except Exception as e:  # pylint: disable=broad-exception-caught
-                    logger.warning("Check '%s' failed: %s", check.check_id, e)
+                    issues_map[check.check_id] = self._handle_check_error(check.check_id, e, statement_idx)
 
         if self.suppress_superseded:
             issues_map = self._apply_supersedes(statement, enabled_checks, issues_map)
@@ -674,7 +739,7 @@ class CheckRegistry:
                         )
                         all_issues.extend(self._process_issues(issues, check, config, policy_file))
                     except Exception as e:  # pylint: disable=broad-exception-caught
-                        logger.warning("Check '%s' failed: %s", check.check_id, e)
+                        all_issues.extend(self._handle_check_error(check.check_id, e, 0))
             return all_issues
 
         # Execute all policy-level checks in parallel
@@ -693,9 +758,9 @@ class CheckRegistry:
         # Collect all issues, handling any exceptions and applying filters
         for idx, result in enumerate(results):
             if isinstance(result, Exception):
-                # Log error but continue with other checks
+                # Report the failure but continue with other checks
                 check = policy_level_checks[idx]
-                logger.warning("Check '%s' failed: %s", check.check_id, result)
+                all_issues.extend(self._handle_check_error(check.check_id, result, 0))
             elif isinstance(result, list):
                 check = policy_level_checks[idx]
                 config = configs[idx]
@@ -708,6 +773,7 @@ def create_default_registry(
     enable_parallel: bool = True,
     include_builtin_checks: bool = True,
     suppress_superseded: bool = False,
+    on_check_error: str = "fail",
 ) -> CheckRegistry:
     """
     Create a registry with all built-in checks registered.
@@ -720,11 +786,17 @@ def create_default_registry(
         include_builtin_checks: If True, register built-in checks (default: True)
         suppress_superseded: If True, suppress redundant findings when a superseding
             check fires (default: False here; config layer enables it by default)
+        on_check_error: "fail" to report a `check_execution_error` finding when a
+            check raises (default), "warn" to only log it
 
     Returns:
         CheckRegistry with all built-in checks registered (if include_builtin_checks=True)
     """
-    registry = CheckRegistry(enable_parallel=enable_parallel, suppress_superseded=suppress_superseded)
+    registry = CheckRegistry(
+        enable_parallel=enable_parallel,
+        suppress_superseded=suppress_superseded,
+        on_check_error=on_check_error,
+    )
 
     if include_builtin_checks:
         # Import and register built-in checks

--- a/iam_validator/core/config/defaults.py
+++ b/iam_validator/core/config/defaults.py
@@ -135,6 +135,11 @@ DEFAULT_CONFIG = {
         "comment_tag": None,
         # Suppress redundant findings for statements already flagged by full_wildcard.
         "suppress_superseded_findings": True,
+        # What to do when a check raises instead of returning findings.
+        # fail: report a `check_execution_error` finding (severity error) so a run
+        #       cannot report clean on a validation that did not fully run (default)
+        # warn: log only, which lets a policy pass with that check's findings missing
+        "on_check_error": "fail",
     },
     # ========================================================================
     # AWS IAM Validation Checks (17 checks total)

--- a/iam_validator/core/policy_checks.py
+++ b/iam_validator/core/policy_checks.py
@@ -187,10 +187,12 @@ async def validate_policies(
     enable_builtin_checks = config.get_setting("enable_builtin_checks", True)
 
     suppress_superseded = config.get_setting("suppress_superseded_findings", False)
+    on_check_error = config.get_setting("on_check_error", "fail")
     registry = create_default_registry(
         enable_parallel=enable_parallel,
         include_builtin_checks=enable_builtin_checks,
         suppress_superseded=suppress_superseded,
+        on_check_error=on_check_error,
     )
 
     if not enable_builtin_checks:

--- a/tests/core/test_check_registry.py
+++ b/tests/core/test_check_registry.py
@@ -485,8 +485,12 @@ class TestCheckRegistry:
         # Should not raise, but continue with working check
         issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
 
-        # Should still get issues from working check
-        assert len(issues) == 1
+        # The working check's issue, plus a check_execution_error for the failing one:
+        # a check that raised validated nothing, so the run must not report clean.
+        assert len(issues) == 2
+        by_type = {issue.issue_type: issue for issue in issues}
+        assert by_type["check_execution_error"].check_id == "failing_check"
+        assert by_type["check_execution_error"].severity == "error"
 
     @pytest.mark.asyncio
     async def test_execute_checks_parallel_disabled_checks_skipped(self, registry, mock_statement, mock_fetcher):
@@ -526,8 +530,9 @@ class TestCheckRegistry:
 
         issues = await registry.execute_checks_sequential(mock_statement, 0, mock_fetcher)
 
-        # Should still get issues from working check
-        assert len(issues) == 1
+        # As in the parallel path: the working check's issue plus a check_execution_error.
+        assert len(issues) == 2
+        assert {issue.issue_type for issue in issues} >= {"check_execution_error"}
 
     @pytest.mark.asyncio
     async def test_parallel_disabled_falls_back_to_sequential(self, mock_statement, mock_fetcher):
@@ -685,3 +690,92 @@ class TestCreateDefaultRegistry:
         registry = create_default_registry(enable_parallel=False, include_builtin_checks=False)
 
         assert registry.enable_parallel is False
+
+
+class TestOnCheckError:
+    """A check that raises must not let the run report clean.
+
+    Logging alone means the policy passes with that check's findings missing --
+    the result is not merely wrong but unsound, and an unsound pass is worse
+    than a policy AWS would reject. `on_check_error: warn` restores the old
+    log-only behaviour for anyone who wants it.
+    """
+
+    @pytest.fixture
+    def mock_statement(self):
+        return Statement(Effect="Allow", Action=["s3:GetObject"], Resource=["arn:aws:s3:::bucket/*"])
+
+    @pytest.fixture
+    def mock_fetcher(self):
+        return MagicMock()
+
+    def _registry(self, on_check_error="fail", enable_parallel=True, with_working_check=True):
+        registry = CheckRegistry(enable_parallel=enable_parallel, on_check_error=on_check_error)
+        registry.register(FailingCheck())
+        registry.configure_check("failing_check", CheckConfig(check_id="failing_check", enabled=True))
+        if with_working_check:
+            registry.register(IssueGeneratingCheck(num_issues=1))
+            registry.configure_check("issue_check", CheckConfig(check_id="issue_check", enabled=True))
+        return registry
+
+    def test_default_is_fail(self):
+        assert CheckRegistry().on_check_error == "fail"
+        assert create_default_registry().on_check_error == "fail"
+
+    async def test_fail_mode_reports_the_failure(self, mock_statement, mock_fetcher):
+        registry = self._registry(with_working_check=False)
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == "check_execution_error"
+        assert issues[0].severity == "error"
+        assert issues[0].check_id == "failing_check"
+        assert "not fully validated" in issues[0].message
+        assert "on_check_error: warn" in (issues[0].suggestion or "")
+
+    async def test_warn_mode_keeps_the_old_behaviour(self, mock_statement, mock_fetcher):
+        registry = self._registry(on_check_error="warn", with_working_check=False)
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert issues == []
+
+    @pytest.mark.parametrize("enable_parallel", [True, False])
+    async def test_every_statement_path_reports(self, mock_statement, mock_fetcher, enable_parallel):
+        # enable_parallel=False routes execute_checks_parallel to its inline
+        # sequential branch, which previously had no exception handling at all.
+        registry = self._registry(enable_parallel=enable_parallel)
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert "check_execution_error" in {issue.issue_type for issue in issues}
+
+    async def test_sequential_path_reports(self, mock_statement, mock_fetcher):
+        registry = self._registry()
+
+        issues = await registry.execute_checks_sequential(mock_statement, 0, mock_fetcher)
+
+        assert "check_execution_error" in {issue.issue_type for issue in issues}
+
+    async def test_a_failing_check_does_not_hide_a_working_one(self, mock_statement, mock_fetcher):
+        registry = self._registry()
+
+        issues = await registry.execute_checks_parallel(mock_statement, 0, mock_fetcher)
+
+        assert {issue.issue_type for issue in issues} == {"check_execution_error", "test_issue"}
+
+    async def test_failure_is_not_silenced_by_the_failing_checks_own_config(self, mock_statement, mock_fetcher):
+        # A check whose own config hides every severity must not thereby hide the
+        # notice that it crashed - the finding is about the check, not from it.
+        registry = CheckRegistry(on_check_error="fail")
+        registry.register(FailingCheck())
+        registry.configure_check(
+            "failing_check",
+            CheckConfig(check_id="failing_check", enabled=True, severity="none"),
+        )
+
+        issues = await registry.execute_checks_sequential(mock_statement, 0, mock_fetcher)
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == "check_execution_error"


### PR DESCRIPTION
## Summary

Follow-up to #172, which I flagged there: a check that raises an exception returns no findings, so the statement it was given went unvalidated by that check. The registry logged `Check '<id>' failed` at **warning** level and dropped the check's entry, so a run gated on `error` reported the policy clean. Nothing in the output said validation had been incomplete.

That is a worse failure mode than a policy AWS would reject — the result is not merely wrong, it is unsound, and it looks identical to a clean run. #172 fixed one way to trigger it (`*:Untag*` raising out of `parse_action`); this fixes the class.

Concretely, before this change:

```
$ iam-validator validate --path policy.json --custom-checks-dir ./checks
WARNING - Check 'boom' failed: simulated check bug
$ echo $?
0
```

After: one `error` finding naming the check and the exception, exit 1.

**This is a behaviour change**, hence the minor bump — anyone whose checks were crashing silently will start seeing failures. That is the point, but it is why `settings.on_check_error: warn` exists to restore the old behaviour, which is worth reaching for if you load third-party custom checks you do not control.

I took a position on the two judgement calls rather than leaving them open, and both are one-line reversals if you disagree:

- **Severity `error`.** Strictly, this repo defines `error` as "AWS will reject the policy", which a crashed check is not. But anything below `error` is outside the default `fail_on_severity`, so it would stay exactly as silent as the log line — the finding would not do its job. An unsound *pass* seemed the more serious condition of the two.
- **Default `fail`.** A knob defaulting to today's behaviour would preserve the silence for everyone who never reads the setting, i.e. the people the change is for.

## Changes

- `core/check_registry.py`: `_handle_check_error` turns the exception into a `check_execution_error` finding. All five execution paths go through it, which also fixes an inconsistency — the single-enabled-check branch of `execute_checks_parallel` had no exception handling at all and propagated, so the registry's behaviour on a failing check depended on how many checks were enabled and whether `parallel_execution` was on.
- The finding bypasses `_process_issues` on purpose: it is *about* the check, not *from* it, so the failing check's own `ignore_patterns` and severity overrides must not be able to silence the notice that it crashed. There is a test for that.
- `core/config/defaults.py`, `core/policy_checks.py`: `settings.on_check_error` (`fail` | `warn`), threaded through `create_default_registry`.
- `tests/core/test_check_registry.py`: 8 new tests. Two existing tests (`test_execute_checks_parallel_with_failing_check`, `test_execute_checks_sequential_handles_failures`) asserted the swallow and now assert the finding — those are the intended assertion changes to review.
- `docs/user-guide/configuration.md`, `iam_validator/core/CLAUDE.md`: document the setting and the registry's contract.

No CHANGELOG entry or version bump here on purpose — a separate PR will handle those for both this and #172. Worth noting it is a minor bump when it happens, since a check that raises now fails a run gated on `error`.

## Testing

- `uv run pytest` — 1689 passed, 23 skipped; `ruff` and `mypy iam_validator/` clean
- **Blast-radius check:** ran the CLI over all 55 policies in `examples/` (`iam-test-policies`, `access-analyzer`, `quick-start`, `configs`, `github-actions`) — 132+ findings, **zero** `check_execution_error`. No built-in check raises on real input, so the fail-closed default does not turn existing green runs red.
- End-to-end with a deliberately raising custom check: default → exit 1 with the finding; `on_check_error: warn` → exit 0 and silent, as before.

## Note on merge order

Branched off `main` and independent of #172 — the two touch disjoint files now that the changelog and version bump are out, so they merge in either order with no rebase. Happy to retarget this onto #172 if you would rather take them as a stack.

## Second pass, after review

A review of the first cut found three ways the finding was discarded *after* the registry emitted it — two of which restored the exact silent pass this PR exists to prevent. All reproduced live, all fixed here:

| Where | Effect before |
| --- | --- |
| `_apply_supersedes` (`check_registry.py`) | Dropped on the **default** path (`suppress_superseded_findings: true`). Worse, the crashed check was listed under "N checks suppressed", which is not why it produced nothing. |
| `skipped_check_ids` (`policy_checks.py`) | The finding carries the failing check's `check_id`, so a crash in `wildcard_resource` / `service_wildcard` / `full_wildcard` on an SCP, or `principal_validation` on an RCP, reported **`is_valid=True` with no finding**. |
| `statement_idx=0` | This repo uses `-1` for a whole-policy finding (`policy_size`, `policy_structure`) and formatters special-case it. `0` renders as "Statement 1", blaming the first statement, and is dropped outright by the suppressed-statement filter. |

`CHECK_EXECUTION_ERROR` and `POLICY_LEVEL_STATEMENT_INDEX` now live in `constants.py` so the emitting site and the two exemption sites cannot drift apart.

Also fixed: a check returning a non-list (a custom check returning `None`) fell through both arms of the gather result handling and produced nothing at all, silently — the same class of unsoundness.

**Tests.** The test meant to pin the `_process_issues` bypass used `severity="none"`, which that filter never consults, so it passed against a version that did not bypass at all. It now parametrises over `hide_severities` and `ignore_patterns`, the two configs that actually filter. Added coverage for `suppress_superseded=True`, for a failing policy-level check (`execute_policy_checks` had no test at all), and for a check returning `None`.

**One correction to the review that prompted this:** it held that the other enumerated settings raise on a bad value, so `on_check_error` should too. They don't — `off_diff_comment_mode: bogus` and `fail_on_severity: [bogus]` are both accepted at runtime, because `get_setting` reads the raw settings dict and `SettingsSchema` is not applied on the CLI path. I added the field and validator anyway, since that is the right place and consistent with its neighbours, but it does not make a typo fail. Runtime validation of `settings` looks like a separate, pre-existing gap.
