### PR TITLE
release: 1.27.1 — review remediation, MCP catalog fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.28.0] - 2026-09-10
+## [1.27.1] - 2026-09-10
 
 A remediation release. Trust-policy validation, PR inline-comment line resolution and condition-operator polarity are corrected across the board, and the MCP check catalog now reports what validation will actually do rather than class defaults.
 
@@ -899,7 +899,7 @@ _First release._
 
 [#164]: https://github.com/boogy/iam-policy-validator/pull/164
 [#162]: https://github.com/boogy/iam-policy-validator/issues/162
-[1.28.0]: https://github.com/boogy/iam-policy-validator/compare/v1.27.0...v1.28.0
+[1.27.1]: https://github.com/boogy/iam-policy-validator/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/boogy/iam-policy-validator/compare/v1.26.0...v1.27.0
 [1.26.0]: https://github.com/boogy/iam-policy-validator/compare/v1.25.1...v1.26.0
 [1.25.1]: https://github.com/boogy/iam-policy-validator/compare/v1.25.0...v1.25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- A superseding check's suppression notice now lists only the check ids that check itself suppressed, and a superseder with nothing to suppress is no longer annotated
+- `--log-level debug` emits one `skipped_checks=` line per policy naming the enabled checks that do not apply to the resolved policy type, so a boundary policy's excluded grant-shaped checks are visible
+- `checks/utils/condition_matching.py` re-exports `base_operator`, `is_negated_operator` and `NEGATED_OPERATORS` from `core/condition_validators.py` instead of carrying a second copy; the core helper now uses the explicit negated-operator set rather than substring-matching `not`
+- The trust-policy `validation_rules` opt-out — redefining an action with only the requirements you want enforced — is documented, along with the per-action condition requirements and the operator-polarity rules
+
+### Fixed
+
+- A trust-policy action glob (`sts:AssumeRole*`) is validated against every rule it covers, not just the first one; an action naming a rule exactly is still validated against that rule alone
+- Confused-deputy detection no longer accepts a negated operator on an `Allow`, or a `Null` condition asserting the key is absent, as source restriction — the same operator-polarity rule the required-condition check already applied
+- A missing OIDC condition is reported against the statement's own provider (`token.actions.githubusercontent.com:sub`) instead of the raw `*:sub` pattern, and the example names the group that is actually missing
+- Inline PR comments resolve field lines in YAML policies again: statement line mapping is shared with `PolicyLoader` (which now also handles a `Statement` key opening on the same line as its first statement) and the field scan is bounded by the next statement instead of counting braces, which never worked for YAML
+- Statement line mapping is computed once per file per PR comment run instead of once per finding
+- `fail_on_severity` falls back to `constants.HIGH_SEVERITY_LEVELS` everywhere; `pr_commenter` previously defaulted to `["error", "critical"]`, dropping `high` findings from the failure decision
+- `suppress_superseded_findings` defaults to `true` at the config layer, matching the settings schema, defaults and docs
+- The redundant-`IfExists` and `Deny`-suggestion messages keep a `ForAllValues:`/`ForAnyValue:` prefix exactly once and drop the `IfExists` suffix even when the operator is unknown, instead of printing `ForAllValues:ForAllValues:StringBogusIfExists`
+- A `Sid` containing non-ASCII letters is reported with the characters AWS actually rejects, listed once each in the order they appear, instead of an empty or run-to-run-varying list
+- Condition-key lookup only compiles patterns that contain `${`, so the placeholder cache is no longer filled with plain keys
+
 ## [1.27.0] - 2026-09-10
 
 Detections are now policy-type aware: in an SCP or RCP an `Allow` sets a boundary rather than granting access, so grant-shaped checks no longer fire there. Action matching is case-insensitive and honours `?`, and third-party checks can register themselves without a core edit. Custom checks built on an abstract base class load again, since required-attribute enforcement moved from class definition to registration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.28.0] - 2026-09-10
+
+A remediation release. Trust-policy validation, PR inline-comment line resolution and condition-operator polarity are corrected across the board, and the MCP check catalog now reports what validation will actually do rather than class defaults.
 
 ### Changed
 
@@ -12,6 +14,7 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 - `--log-level debug` emits one `skipped_checks=` line per policy naming the enabled checks that do not apply to the resolved policy type, so a boundary policy's excluded grant-shaped checks are visible
 - `checks/utils/condition_matching.py` re-exports `base_operator`, `is_negated_operator` and `NEGATED_OPERATORS` from `core/condition_validators.py` instead of carrying a second copy; the core helper now uses the explicit negated-operator set rather than substring-matching `not`
 - The trust-policy `validation_rules` opt-out — redefining an action with only the requirements you want enforced — is documented, along with the per-action condition requirements and the operator-polarity rules
+- The MCP `iam://checks` and `iam://checks/{check_id}` resources resolve each check's `enabled` flag and `severity` through the session config on every read instead of asserting that every registered check runs at its class default; `iam://checks` entries carry `severity` and `enabled` alongside the unchanged `default_severity`
 
 ### Fixed
 
@@ -25,6 +28,7 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 - The redundant-`IfExists` and `Deny`-suggestion messages keep a `ForAllValues:`/`ForAnyValue:` prefix exactly once and drop the `IfExists` suffix even when the operator is unknown, instead of printing `ForAllValues:ForAllValues:StringBogusIfExists`
 - A `Sid` containing non-ASCII letters is reported with the characters AWS actually rejects, listed once each in the order they appear, instead of an empty or run-to-run-varying list
 - Condition-key lookup only compiles patterns that contain `${`, so the placeholder cache is no longer filled with plain keys
+- The MCP server builds its check registry on first use rather than at import, so importing `iam_validator.mcp.server` no longer loads and instantiates third-party entry-point plugins as a side effect
 
 ## [1.27.0] - 2026-09-10
 
@@ -895,6 +899,7 @@ _First release._
 
 [#164]: https://github.com/boogy/iam-policy-validator/pull/164
 [#162]: https://github.com/boogy/iam-policy-validator/issues/162
+[1.28.0]: https://github.com/boogy/iam-policy-validator/compare/v1.27.0...v1.28.0
 [1.27.0]: https://github.com/boogy/iam-policy-validator/compare/v1.26.0...v1.27.0
 [1.26.0]: https://github.com/boogy/iam-policy-validator/compare/v1.25.1...v1.26.0
 [1.25.1]: https://github.com/boogy/iam-policy-validator/compare/v1.25.0...v1.25.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,8 @@ literals. Add a constant there before introducing any of these inline:
   `aws-eusc`, all `aws-iso*`) — sourced by `DEFAULT_ARN_VALIDATION_PATTERN` and the
   trust-policy SAML/OIDC patterns
 - `SID_PATTERN` — the charset AWS's policy grammar allows in a `Sid` (`A-Z a-z 0-9`
-  only); consumed by `checks/sid_uniqueness.py`
+  only), with `SID_INVALID_CHAR_PATTERN` for the complement (ASCII-only, unlike
+  `str.isalnum()`); both consumed by `checks/sid_uniqueness.py`
 - AWS policy size limits (`MAX_MANAGED_POLICY_SIZE`, etc.)
 - GitHub comment limits (`GITHUB_COMMENT_HARD_LIMIT = 65536`,
   `GITHUB_MAX_COMMENT_LENGTH = 65000`, `GITHUB_COMMENT_SPLIT_LIMIT = 60000`)

--- a/docs/user-guide/checks/advanced-checks.md
+++ b/docs/user-guide/checks/advanced-checks.md
@@ -167,6 +167,46 @@ Only services where the role is directly bound to a compute resource owned by th
 !!! warning "All Other Services Require Conditions"
 All other AWS service principals -- including services that typically use service-linked roles (e.g., `guardduty`, `elasticloadbalancing`, `organizations`) -- require `aws:SourceArn` or `aws:SourceAccount` conditions when used in custom trust policies. If a customer writes a custom trust policy for any of these services, the confused deputy risk applies to that custom role.
 
+### Required Conditions per Assume Action
+
+Each `sts:` assume action carries its own rule. A glob action (`sts:*`, `sts:AssumeRole*`)
+is validated against every rule it covers, because it grants all of them.
+
+| Action                            | Principal types         | Required conditions              |
+| --------------------------------- | ----------------------- | -------------------------------- |
+| `sts:AssumeRole`                  | AWS, Service            | --                               |
+| `sts:AssumeRoleWithSAML`          | Federated               | `SAML:aud`                       |
+| `sts:AssumeRoleWithWebIdentity`   | Federated               | `<provider>:aud` and one of `<provider>:sub` / `<provider>:amr` |
+| `sts:TagSession`                  | AWS, Service, Federated | --                               |
+| `sts:SetSourceIdentity`           | AWS, Service, Federated | --                               |
+
+A list inside `required_conditions` is an "any one of" group. Provider-scoped keys are
+written `*:aud` in configuration and rendered against the statement's own provider
+(`token.actions.githubusercontent.com:aud`) in the finding.
+
+Negated operators (`StringNotEquals`) on an `Allow`, and `Null` conditions asserting a
+key is _absent_, do not count as constraining the key.
+
+### Overriding or Opting Out of the Rules
+
+`validation_rules` replaces `DEFAULT_RULES` wholesale, so it is the opt-out for any
+individual requirement -- redefine the action with only the parts you want enforced:
+
+```yaml
+checks:
+  trust_policy_validation:
+    enabled: true
+    validation_rules:
+      sts:AssumeRoleWithWebIdentity:
+        allowed_principal_types: ["Federated"]
+        # `*:aud` only; drops the `*:sub` / `*:amr` requirement
+        required_conditions: ["*:aud"]
+```
+
+Omit `required_conditions` entirely to enforce no conditions for that action, and omit
+`provider_pattern` to skip provider-ARN format validation. Actions left out of
+`validation_rules` are not validated at all.
+
 ### Trust Policy Types
 
 #### AWS Service

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.28.0"
+__version__ = "1.27.1"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/checks/CLAUDE.md
+++ b/iam_validator/checks/CLAUDE.md
@@ -14,8 +14,10 @@ Use `/add-check my_check_name` to scaffold automatically. Manual steps:
 3. Register in `iam_validator/core/check_registry.py:create_default_registry()`.
 4. Test in `tests/checks/test_my_check.py` (see `tests/checks/conftest.py` for `mock_fetcher`).
 
-Required `ClassVar`s on the subclass (enforced by `PolicyCheck.__init_subclass__`; a
-missing one raises `NotImplementedError`):
+Required `ClassVar`s on the subclass (enforced by `CheckRegistry.register()`, which
+raises `NotImplementedError` for a missing or empty one — `PolicyCheck.__init_subclass__`
+only enforces that a subclass overrides `execute()` or `execute_policy()`, raising
+`TypeError` when neither is):
 
 - `check_id: str` — unique snake_case id
 - `description: str` — short help text
@@ -23,11 +25,12 @@ missing one raises `NotImplementedError`):
 Optional `ClassVar`s:
 
 - `default_severity: str` — `low|medium|high|critical|error|warning|none`
-  (`none` suppresses output entirely). Defaults to `"warning"` when omitted; not
-  enforced by `__init_subclass__`, so set it explicitly whenever `"warning"` isn't
-  the intended severity.
+  (`none` suppresses output entirely). Defaults to `"warning"` when omitted and is
+  never enforced, so set it explicitly whenever `"warning"` isn't the intended
+  severity.
 - `applies_to_policy_types: frozenset[str] | None` — policy types the check runs on;
-  `None` (the default) means all, as does an unresolved policy type. In an SCP or RCP an
+  `None` (the default) means all, as does an unresolved policy type. `register()` raises
+  `ValueError` on a value that is not a `PolicyType`. In an SCP or RCP an
   `Allow` declines to restrict and never grants access, so grant-shaped checks exclude
   `SERVICE_CONTROL_POLICY` and `RESOURCE_CONTROL_POLICY`. `principal_validation`
   excludes only RCP, where `Principal: "*"` is required by AWS syntax.
@@ -131,7 +134,9 @@ Use these instead of reimplementing:
 - `wildcard_expansion.py` — `compile_wildcard_pattern()` (alias of `compile_iam_glob`),
   `expand_wildcard_actions()`
 - `aws_matching.py` — `action_matches()`, `compile_iam_glob()`, `iam_glob_match()`
-- `condition_matching.py` — `base_operator()`, `is_negated_operator()`, `is_deny()`, `has_condition_key()`
+- `condition_matching.py` — `is_deny()`, `has_condition_key()`; re-exports
+  `base_operator()`, `is_negated_operator()`, `NEGATED_OPERATORS` from
+  `core/condition_validators.py` (the single definition)
 - `sensitive_action_matcher.py` — `get_sensitive_actions_by_categories()`, `check_sensitive_actions()`
 - `policy_level_checks.py` — `check_policy_level_actions()`, `_check_all_of_pattern()`
 - `formatting.py` — `format_list_with_backticks()`

--- a/iam_validator/checks/ifexists_condition_check.py
+++ b/iam_validator/checks/ifexists_condition_check.py
@@ -22,6 +22,22 @@ from iam_validator.core.condition_validators import (
 )
 from iam_validator.core.models import Statement, ValidationIssue
 
+_IFEXISTS = "IfExists"
+
+
+def _render_operator(operator: str, *, if_exists: bool) -> str:
+    """Spell ``operator`` with or without ``IfExists``, keeping its set prefix once."""
+    base_op, expected_type, set_prefix = normalize_operator(operator)
+    if expected_type is None:
+        # Unresolved operator: normalize_operator echoes the raw string, prefix included.
+        stem = operator.split(":", 1)[1] if set_prefix else operator
+        if stem.lower().endswith(_IFEXISTS.lower()):
+            stem = stem[: -len(_IFEXISTS)]
+    else:
+        stem = base_op
+    name = f"{stem}{_IFEXISTS}" if if_exists else stem
+    return f"{set_prefix}:{name}" if set_prefix else name
+
 
 class IfExistsConditionCheck(PolicyCheck):
     """Check for improper or risky usage of IfExists condition operators."""
@@ -70,7 +86,6 @@ class IfExistsConditionCheck(PolicyCheck):
         for operator, conditions in statement.condition.items():
             has_ifexists = has_if_exists_suffix(operator)
             is_negated = is_negated_operator(operator)
-            base_op, _, _ = normalize_operator(operator)
 
             for condition_key in conditions:
                 # Normalize condition key for case-insensitive comparison
@@ -85,9 +100,7 @@ class IfExistsConditionCheck(PolicyCheck):
                     if warn_always_present_keys:
                         always_present_match = any(k.lower() == key_lower for k in ALWAYS_PRESENT_CONDITION_KEYS)
                         if always_present_match:
-                            # Reconstruct the operator without IfExists for the message
-                            base_op, _base_type, base_prefix = normalize_operator(operator)
-                            base_without_ifexists = f"{base_prefix}:{base_op}" if base_prefix else base_op
+                            base_without_ifexists = _render_operator(operator, if_exists=False)
 
                             issues.append(
                                 ValidationIssue(
@@ -172,15 +185,17 @@ class IfExistsConditionCheck(PolicyCheck):
                         is_always_present = any(k.lower() == key_lower for k in ALWAYS_PRESENT_CONDITION_KEYS)
                         is_security_key = any(k.lower() == key_lower for k in security_keys)
                         if not is_always_present and is_security_key:
+                            plain_operator = _render_operator(operator, if_exists=False)
+                            ifexists_operator = _render_operator(operator, if_exists=True)
                             issues.append(
                                 ValidationIssue(
                                     severity="info",
                                     message=(
-                                        f"Consider using `{base_op}IfExists` instead "
-                                        f"of `{base_op}` in this Deny statement. "
+                                        f"Consider using `{ifexists_operator}` instead "
+                                        f"of `{plain_operator}` in this Deny statement. "
                                         f"Without `IfExists`, the `Deny` does not apply "
                                         f"when `{condition_key}` is missing from the "
-                                        f"request context. With `{base_op}IfExists`, "
+                                        f"request context. With `{ifexists_operator}`, "
                                         f"the `Deny` still applies even when the key is "
                                         f"absent."
                                     ),

--- a/iam_validator/checks/sid_uniqueness.py
+++ b/iam_validator/checks/sid_uniqueness.py
@@ -16,7 +16,7 @@ from typing import ClassVar
 
 from iam_validator.core.aws_service import AWSServiceFetcher
 from iam_validator.core.check_registry import CheckConfig, PolicyCheck
-from iam_validator.core.constants import SID_PATTERN
+from iam_validator.core.constants import SID_INVALID_CHAR_PATTERN, SID_PATTERN
 from iam_validator.core.models import IAMPolicy, ValidationIssue
 
 
@@ -51,7 +51,7 @@ def _check_sid_uniqueness_impl(policy: IAMPolicy, severity: str) -> list[Validat
                 issue_msg = f"Statement ID `{statement.sid}` contains spaces, which are not allowed by AWS"
                 suggestion = f"Remove spaces from the SID. Example: `{statement.sid.replace(' ', '')}`"
             else:
-                invalid_chars = "".join(set(c for c in statement.sid if not c.isalnum()))
+                invalid_chars = "".join(dict.fromkeys(SID_INVALID_CHAR_PATTERN.findall(statement.sid)))
                 issue_msg = f"Statement ID `{statement.sid}` contains invalid characters: `{invalid_chars}`"
                 suggestion = "SIDs must contain only alphanumeric characters (A-Z, a-z, 0-9)"
 

--- a/iam_validator/checks/trust_policy_validation.py
+++ b/iam_validator/checks/trust_policy_validation.py
@@ -174,47 +174,21 @@ class TrustPolicyValidationCheck(PolicyCheck):
             if action.strip() == "*":
                 continue
 
-            # Treat the literal sts:* wildcard as matching all STS assume actions.
-            # (A concrete action like sts:AssumeRole is handled below via
-            # _find_matching_rule, which validates it against its own single rule.)
-            if action.strip().lower() == "sts:*":
-                for rule_action, rule in validation_rules.items():
-                    principal_issues = self._validate_principal_type(
+            for rule_action, rule in self._find_matching_rules(action, validation_rules):
+                principal_issues = self._validate_principal_type(statement, rule_action, rule, statement_idx, config)
+                issues.extend(principal_issues)
+
+                if "provider_pattern" in rule:
+                    provider_issues = self._validate_provider_format(
                         statement, rule_action, rule, statement_idx, config
                     )
-                    issues.extend(principal_issues)
+                    issues.extend(provider_issues)
 
-                    if "provider_pattern" in rule:
-                        provider_issues = self._validate_provider_format(
-                            statement, rule_action, rule, statement_idx, config
-                        )
-                        issues.extend(provider_issues)
-
-                    if "required_conditions" in rule:
-                        condition_issues = self._validate_required_conditions(
-                            statement, rule_action, rule, statement_idx, config
-                        )
-                        issues.extend(condition_issues)
-                continue
-
-            # Find matching rule (exact matches for assume actions)
-            rule = self._find_matching_rule(action, validation_rules)
-            if not rule:
-                continue  # Not an assume action we validate
-
-            # Validate principal type for this action
-            principal_issues = self._validate_principal_type(statement, action, rule, statement_idx, config)
-            issues.extend(principal_issues)
-
-            # Validate provider ARN format if required
-            if "provider_pattern" in rule:
-                provider_issues = self._validate_provider_format(statement, action, rule, statement_idx, config)
-                issues.extend(provider_issues)
-
-            # Validate required conditions
-            if "required_conditions" in rule:
-                condition_issues = self._validate_required_conditions(statement, action, rule, statement_idx, config)
-                issues.extend(condition_issues)
+                if "required_conditions" in rule:
+                    condition_issues = self._validate_required_conditions(
+                        statement, rule_action, rule, statement_idx, config
+                    )
+                    issues.extend(condition_issues)
 
         # Check for confused deputy vulnerability (only on Allow statements with Service principals)
         if statement.effect == "Allow":
@@ -235,12 +209,59 @@ class TrustPolicyValidationCheck(PolicyCheck):
         return statement.get_actions()
 
     @staticmethod
-    def _find_matching_rule(action: str, rules: dict[str, Any]) -> dict[str, Any] | None:
-        """Find the rule covering ``action``, matching case-insensitively in both directions."""
+    def _find_matching_rules(action: str, rules: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+        """Rules covering ``action``, matched case-insensitively.
+
+        An action naming a rule exactly is validated against that rule alone; a glob
+        (``sts:*``, ``sts:AssumeRole*``) is validated against every rule it covers,
+        since it grants all of them.
+        """
+        normalized = action.strip().lower()
         for rule_action, rule_config in rules.items():
-            if action_matches(action, rule_action):
-                return rule_config
-        return None
+            if normalized == rule_action.strip().lower():
+                return [(rule_action, rule_config)]
+        return [
+            (rule_action, rule_config)
+            for rule_action, rule_config in rules.items()
+            if action_matches(action, rule_action)
+        ]
+
+    @staticmethod
+    def _effective_condition_keys(statement: Statement) -> set[str]:
+        """Condition keys that actually constrain the statement.
+
+        A negated operator outside a ``Deny`` and a ``Null`` asserting a key's absence
+        restrict nothing, so neither satisfies a condition requirement.
+        """
+        keys: set[str] = set()
+        if not statement.condition:
+            return keys
+
+        accept_negated = is_deny(statement)
+        for operator, keys_dict in statement.condition.items():
+            if not isinstance(keys_dict, dict):
+                continue
+            if not accept_negated and is_negated_operator(operator):
+                continue
+            is_null_op = base_operator(operator) == "null"
+            for key, value in keys_dict.items():
+                if is_null_op and _asserts_key_absent(value):
+                    continue
+                keys.add(key)
+        return keys
+
+    def _resolve_condition_key(self, required: str, statement: Statement) -> str:
+        """Render a glob requirement such as ``*:aud`` against the statement's provider."""
+        if not required.startswith("*:"):
+            return required
+
+        suffix = required[2:]
+        for principal in self._extract_principal_types(statement).get("Federated", []):
+            if ":oidc-provider/" in principal:
+                return f"{principal.split(':oidc-provider/', 1)[1]}:{suffix}"
+            if principal.lower() in WEB_IDENTITY_PROVIDER_DOMAINS:
+                return f"{principal}:{suffix}"
+        return f"<provider-url>:{suffix}"
 
     def _extract_principal_types(self, statement: Statement) -> dict[str, list[str]]:
         """Extract principals grouped by type (AWS, Service, Federated, etc.).
@@ -395,32 +416,23 @@ class TrustPolicyValidationCheck(PolicyCheck):
         if not required_conditions:
             return issues
 
-        # Get all condition keys from statement
-        condition_keys: set[str] = set()
-        if statement.condition:
-            accept_negated = is_deny(statement)
-            for operator, keys_dict in statement.condition.items():
-                if not isinstance(keys_dict, dict):
-                    continue
-                if not accept_negated and is_negated_operator(operator):
-                    continue
-                is_null_op = base_operator(operator) == "null"
-                for key, value in keys_dict.items():
-                    if is_null_op and _asserts_key_absent(value):
-                        continue
-                    condition_keys.add(key)
+        condition_keys = self._effective_condition_keys(statement)
 
         # Check for missing required conditions (supports wildcards like *:aud).
         # A list entry is an any-of group: satisfied when any alternative is present.
         missing_conditions: list[str] = []
+        example_key: str | None = None
         for required_cond in required_conditions:
             alternatives = _condition_alternatives(required_cond)
             if any(iam_glob_match(alt, key) for alt in alternatives for key in condition_keys):
                 continue
-            if len(alternatives) == 1:
-                missing_conditions.append(f"`{alternatives[0]}`")
+            resolved = [self._resolve_condition_key(alt, statement) for alt in alternatives]
+            if example_key is None:
+                example_key = resolved[0]
+            if len(resolved) == 1:
+                missing_conditions.append(f"`{resolved[0]}`")
             else:
-                missing_conditions.append("one of: " + format_list_with_backticks(alternatives))
+                missing_conditions.append("one of: " + format_list_with_backticks(resolved))
 
         if missing_conditions:
             missing_list = ", ".join(missing_conditions)
@@ -437,7 +449,7 @@ class TrustPolicyValidationCheck(PolicyCheck):
                     suggestion=f"Add required condition(s) to restrict when `{action}` can be performed. "
                     f"Missing: {missing_list}\n\n"
                     f"{rule.get('description', '')}",
-                    example=self._get_condition_example(action, _condition_alternatives(required_conditions[0])[0]),
+                    example=self._get_condition_example(action, example_key or ""),
                     field_name="condition",
                 )
             )
@@ -474,11 +486,7 @@ class TrustPolicyValidationCheck(PolicyCheck):
             return issues
 
         # Check if conditions include confused deputy protections
-        condition_keys: set[str] = set()
-        if statement.condition:
-            for _operator, keys_dict in statement.condition.items():
-                if isinstance(keys_dict, dict):
-                    condition_keys.update(k.lower() for k in keys_dict.keys())
+        condition_keys = {key.lower() for key in self._effective_condition_keys(statement)}
 
         # aws:SourceOrgID / aws:SourceOrgPaths are the org-wide equivalents of
         # aws:SourceArn / aws:SourceAccount and count as protection too.

--- a/iam_validator/checks/utils/condition_matching.py
+++ b/iam_validator/checks/utils/condition_matching.py
@@ -2,32 +2,20 @@
 
 from typing import Any
 
+from iam_validator.core.condition_validators import (
+    NEGATED_OPERATORS,
+    base_operator,
+    is_negated_operator,
+)
 from iam_validator.core.models import Statement
 
-#: Operators that exclude a value rather than constrain to one. On an ``Allow`` these
-#: do not satisfy a "this key must be constrained" requirement; on a ``Deny`` they do.
-NEGATED_OPERATORS: frozenset[str] = frozenset(
-    {
-        "arnnotequals",
-        "arnnotlike",
-        "datenotequals",
-        "notipaddress",
-        "numericnotequals",
-        "stringnotequals",
-        "stringnotequalsignorecase",
-        "stringnotlike",
-    }
-)
-
-
-def base_operator(operator: str) -> str:
-    """Lowercase operator without set prefix (ForAnyValue:/ForAllValues:) or IfExists suffix."""
-    return operator.strip().lower().rsplit(":", 1)[-1].removesuffix("ifexists")
-
-
-def is_negated_operator(operator: str) -> bool:
-    """True if the operator excludes values instead of constraining them."""
-    return base_operator(operator) in NEGATED_OPERATORS
+__all__ = [
+    "NEGATED_OPERATORS",
+    "base_operator",
+    "has_condition_key",
+    "is_deny",
+    "is_negated_operator",
+]
 
 
 def is_deny(statement: Statement) -> bool:

--- a/iam_validator/commands/analyze.py
+++ b/iam_validator/commands/analyze.py
@@ -413,7 +413,7 @@ Examples:
             # Load config to get fail_on_severity, severity_labels, and ignore settings
             config_path = getattr(args, "config", None)
             config = ConfigLoader.load_config(config_path)
-            fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+            fail_on_severities = config.get_setting("fail_on_severity", list(constants.HIGH_SEVERITY_LEVELS))
             severity_labels = config.get_setting("severity_labels", {})
 
             # Get ignore settings from config

--- a/iam_validator/commands/validate.py
+++ b/iam_validator/commands/validate.py
@@ -6,6 +6,7 @@ import os
 from typing import cast
 
 from iam_validator.commands.base import Command
+from iam_validator.core import constants
 from iam_validator.core.models import PolicyType, ValidationReport
 from iam_validator.core.policy_checks import validate_policies
 from iam_validator.core.policy_loader import PolicyLoader
@@ -406,7 +407,7 @@ Examples:
 
             # Load config to get fail_on_severity, severity_labels, and ignore settings
             config = ConfigLoader.load_config(config_path)
-            fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+            fail_on_severities = config.get_setting("fail_on_severity", list(constants.HIGH_SEVERITY_LEVELS))
             severity_labels = config.get_setting("severity_labels", {})
 
             # Get ignore settings from config, but CLI flag can override
@@ -569,7 +570,7 @@ Examples:
 
             # Load config to get fail_on_severity, severity_labels, and ignore settings
             config = ConfigLoader.load_config(config_path)
-            fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+            fail_on_severities = config.get_setting("fail_on_severity", list(constants.HIGH_SEVERITY_LEVELS))
             severity_labels = config.get_setting("severity_labels", {})
 
             # Get ignore settings from config, but CLI flag can override
@@ -642,7 +643,7 @@ Examples:
                 # Load config to get fail_on_severity and ignore settings
                 config_path = getattr(args, "config", None)
                 config = ConfigLoader.load_config(config_path)
-                fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+                fail_on_severities = config.get_setting("fail_on_severity", list(constants.HIGH_SEVERITY_LEVELS))
 
                 # Get ignore settings from config, but CLI flag can override
                 ignore_settings = config.get_setting("ignore_settings", {})
@@ -754,7 +755,7 @@ Examples:
                 # Load config
                 config_path = getattr(args, "config", None)
                 config = ConfigLoader.load_config(config_path)
-                fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+                fail_on_severities = config.get_setting("fail_on_severity", list(constants.HIGH_SEVERITY_LEVELS))
                 severity_labels = config.get_setting("severity_labels", {})
 
                 # Get ignore settings

--- a/iam_validator/core/CLAUDE.md
+++ b/iam_validator/core/CLAUDE.md
@@ -28,6 +28,9 @@ core/
 ├── constants.py            # central markers, ARN partition regex, size limits
 ├── aws_matching.py         # case-insensitive IAM glob matching (compile_iam_glob,
 │                           # iam_glob_match, action_matches); re-exported by checks/utils/
+├── condition_validators.py # operator normalisation + polarity (normalize_operator,
+│                           # base_operator, is_negated_operator, NEGATED_OPERATORS);
+│                           # re-exported by checks/utils/condition_matching.py
 ├── aws_service/            # service-reference fetcher (memory LRU + disk TTL 7 days)
 ├── config/                 # YAML config + sensitive_actions / condition_requirements
 └── formatters/             # 7 output formatters
@@ -54,6 +57,10 @@ Policies are validated concurrently under an `asyncio.Semaphore` bounded by
 only a direct `validate_policies()` call can override it). Within a
 policy, statements are gathered concurrently and unbounded; statement order is preserved
 because `ignore_patterns` and PR-comment fingerprints anchor to it.
+
+`PRCommenter` resolves a finding's line through `PolicyLoader.find_statement_line_numbers`
+(JSON and YAML), memoized per file, so its mapping agrees with the `line_number` the
+validator attached; a field search is bounded by the next statement's line.
 
 `PRCommenter` then runs diff-aware filtering with 3 tiers (changed line → inline review
 comment, modified statement / unchanged line → off-diff pipeline → context-issue table

--- a/iam_validator/core/aws_service/validators.py
+++ b/iam_validator/core/aws_service/validators.py
@@ -94,6 +94,8 @@ def find_matching_condition_key(condition_key: str, condition_keys: list[str] | 
             return key
 
     for pattern in condition_keys:
+        if "${" not in pattern:
+            continue
         placeholder = _compile_placeholder_pattern(pattern)
         if placeholder is not None and placeholder.match(condition_key):
             return pattern

--- a/iam_validator/core/check_registry.py
+++ b/iam_validator/core/check_registry.py
@@ -591,19 +591,26 @@ class CheckRegistry:
         if not superseding:
             return issues_map
         superseder_ids = {check.check_id for check, _ in superseding}
-        declared: set[str] = set()
-        for check, _ in superseding:
-            declared |= set(check.supersedes)
-        suppressed_ids = (declared & set(issues_map.keys())) - superseder_ids
+        present = set(issues_map.keys())
+        suppressed_by: dict[str, set[str]] = {
+            check.check_id: (set(check.supersedes) & present) - superseder_ids for check, _ in superseding
+        }
+        suppressed_ids: set[str] = set()
+        for own in suppressed_by.values():
+            suppressed_ids |= own
         if not suppressed_ids:
             return issues_map
-        for _, s_issues in superseding:
+        for check, s_issues in superseding:
+            own = suppressed_by[check.check_id]
+            if not own:
+                continue
+            note = (
+                f"\n\n**{len(own)} checks suppressed** for this statement "
+                f"({', '.join(sorted(own))}). "
+                "Scope the statement and re-run to see remaining findings."
+            )
             for issue in s_issues:
-                issue.message = (
-                    issue.message + f"\n\n**{len(suppressed_ids)} checks suppressed** for this statement "
-                    f"({', '.join(sorted(suppressed_ids))}). "
-                    "Scope the statement and re-run to see remaining findings."
-                )
+                issue.message += note
         return {check_id: issues for check_id, issues in issues_map.items() if check_id not in suppressed_ids}
 
     async def execute_checks_parallel(

--- a/iam_validator/core/condition_validators.py
+++ b/iam_validator/core/condition_validators.py
@@ -79,6 +79,21 @@ _SET_OPERATOR_PREFIXES_LOWER: frozenset[str] = frozenset(p.lower() for p in SET_
 # casing used in the policy (matching the case-insensitive base-operator lookup).
 _SET_OPERATOR_PREFIX_CANONICAL: dict[str, str] = {p.lower(): p for p in SET_OPERATOR_PREFIXES}
 _NULL_OPERATOR_LOWER = "null"
+
+#: Operators that exclude a value rather than constrain to one. On an ``Allow`` these
+#: do not satisfy a "this key must be constrained" requirement; on a ``Deny`` they do.
+NEGATED_OPERATORS: frozenset[str] = frozenset(
+    {
+        "arnnotequals",
+        "arnnotlike",
+        "datenotequals",
+        "notipaddress",
+        "numericnotequals",
+        "stringnotequals",
+        "stringnotequalsignorecase",
+        "stringnotlike",
+    }
+)
 _IFEXISTS_SUFFIX_LEN = len("IfExists")
 
 # Condition keys that are sometimes absent from the request context AND are
@@ -676,6 +691,11 @@ def is_condition_key_match(documented_key: str, policy_key: str) -> bool:
     return False
 
 
+def base_operator(operator: str) -> str:
+    """Lowercase operator without set prefix (ForAnyValue:/ForAllValues:) or IfExists suffix."""
+    return operator.strip().lower().rsplit(":", 1)[-1].removesuffix("ifexists")
+
+
 def is_negated_operator(operator: str) -> bool:
     """
     Determine if a condition operator is negated (NotEquals, NotLike, etc.).
@@ -705,19 +725,7 @@ def is_negated_operator(operator: str) -> bool:
     Reference:
         https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html
     """
-    # Remove set operator prefix if present (case-insensitive, see SET_OPERATOR_PREFIXES)
-    cleaned = operator
-    if ":" in operator:
-        parts = operator.split(":", 1)
-        if parts[0].lower() in _SET_OPERATOR_PREFIXES_LOWER:
-            cleaned = parts[1]
-
-    # Remove IfExists suffix
-    if cleaned.endswith("IfExists"):
-        cleaned = cleaned[:-8]
-
-    # Check if operator contains "Not" (case-insensitive)
-    return "not" in cleaned.lower()
+    return base_operator(operator) in NEGATED_OPERATORS
 
 
 def is_operator_supports_policy_variables(operator: str) -> bool:

--- a/iam_validator/core/constants.py
+++ b/iam_validator/core/constants.py
@@ -46,6 +46,9 @@ MAX_ARN_LENGTH = 2048
 #: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html
 SID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-zA-Z0-9]+$")
 
+#: Characters ``SID_PATTERN`` rejects. ASCII-only, unlike ``str.isalnum()``.
+SID_INVALID_CHAR_PATTERN: Final[re.Pattern[str]] = re.compile(r"[^a-zA-Z0-9]")
+
 # ============================================================================
 # Federated identity condition keys
 # ============================================================================

--- a/iam_validator/core/policy_checks.py
+++ b/iam_validator/core/policy_checks.py
@@ -209,7 +209,7 @@ async def validate_policies(
     enable_parallel = config.get_setting("parallel_execution", True)
     enable_builtin_checks = config.get_setting("enable_builtin_checks", True)
 
-    suppress_superseded = config.get_setting("suppress_superseded_findings", False)
+    suppress_superseded = config.get_setting("suppress_superseded_findings", True)
     on_check_error = config.get_setting("on_check_error", "fail")
     registry = create_default_registry(
         enable_parallel=enable_parallel,
@@ -331,6 +331,16 @@ async def _validate_policy_with_registry(
         PolicyValidationResult with all findings
     """
     result = PolicyValidationResult(policy_file=policy_file, is_valid=True, policy_type=policy_type)
+
+    if logger.isEnabledFor(logging.DEBUG):
+        skipped = sorted(c.check_id for c in registry.get_enabled_checks() if not c.applies_to(policy_type))
+        if skipped:
+            logger.debug(
+                "policy_type=%s file=%s skipped_checks=%s",
+                policy_type,
+                Path(policy_file).name,
+                ",".join(skipped),
+            )
 
     # Load raw dict if not provided (for structural validation)
     if raw_policy_dict is None:

--- a/iam_validator/core/policy_loader.py
+++ b/iam_validator/core/policy_loader.py
@@ -171,13 +171,13 @@ class PolicyLoader:
         current_statement_first_field = None
 
         for line_num, line in enumerate(lines, start=1):
-            # Look for "Statement" array
-            if '"Statement"' in line or "'Statement'" in line:
-                in_statement_array = True
-                continue
-
             if not in_statement_array:
-                continue
+                key_match = re.search(r"[\"']Statement[\"']", line)
+                if not key_match:
+                    continue
+                in_statement_array = True
+                # A statement may open on the same line as the key ("Statement": [{).
+                line = line[key_match.end() :]
 
             # Track opening braces for statement objects
             for char in line:
@@ -265,6 +265,13 @@ class PolicyLoader:
                     statement_line_numbers.append(stmt["__line__"])
 
         return statement_line_numbers
+
+    @staticmethod
+    def find_statement_line_numbers(file_content: str, file_path: str | Path) -> list[int]:
+        """Line number of each statement, picking the JSON or YAML scanner by suffix."""
+        if str(file_path).lower().endswith((".yaml", ".yml")):
+            return PolicyLoader._find_yaml_statement_line_numbers(file_content)
+        return PolicyLoader._find_statement_line_numbers(file_content)
 
     @staticmethod
     def parse_statement_field_lines(file_content: str) -> PolicyLineMap:

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from iam_validator.core.constants import (
     BOT_IDENTIFIER,
+    HIGH_SEVERITY_LEVELS,
     REVIEW_IDENTIFIER,
     SUMMARY_IDENTIFIER,
     scoped_marker,
@@ -107,7 +108,7 @@ class PRCommenter:
         """
         self.github = github
         self.cleanup_old_comments = cleanup_old_comments
-        self.fail_on_severities = fail_on_severities or ["error", "critical"]
+        self.fail_on_severities = fail_on_severities or list(HIGH_SEVERITY_LEVELS)
         self.severity_labels = severity_labels or {}
         self.enable_codeowners_ignore = enable_codeowners_ignore
         self.allowed_ignore_users = allowed_ignore_users or []
@@ -127,6 +128,7 @@ class PRCommenter:
         self._policy_line_maps: dict[str, PolicyLineMap] = {}
         # Cache for raw file lines per file (avoids re-reading for each lookup)
         self._file_lines_cache: dict[str, list[str]] = {}
+        self._statement_line_maps: dict[str, dict[int, int]] = {}
         # Track whether workspace path has been logged (avoid spam)
         self._logged_workspace: bool = False
 
@@ -700,42 +702,24 @@ class PRCommenter:
         return self._file_lines_cache[policy_file]
 
     def _get_line_mapping(self, policy_file: str) -> dict[int, int]:
-        """Get mapping of statement indices to line numbers.
+        """Map each statement index to its starting line, for JSON and YAML alike.
 
-        Args:
-            policy_file: Path to policy file
-
-        Returns:
-            Dict mapping statement index to line number
+        Shares ``PolicyLoader``'s scanners so the mapping agrees with the
+        ``line_number`` the validator attaches to statements.
         """
+        cached = self._statement_line_maps.get(policy_file)
+        if cached is not None:
+            return cached
+
+        mapping: dict[int, int] = {}
         try:
-            lines = self._read_policy_lines(policy_file)
-
-            mapping: dict[int, int] = {}
-            statement_count = 0
-            in_statement_array = False
-
-            for line_num, line in enumerate(lines, start=1):
-                stripped = line.strip()
-
-                # Detect "Statement": [ or "Statement" : [
-                if '"Statement"' in stripped or "'Statement'" in stripped:
-                    in_statement_array = True
-                    if stripped.endswith("{"):
-                        mapping[statement_count] = line_num
-                        statement_count += 1
-                    continue
-
-                # Detect statement object start
-                if in_statement_array and stripped.startswith("{"):
-                    mapping[statement_count] = line_num
-                    statement_count += 1
-
-            return mapping
-
+            content = "".join(self._read_policy_lines(policy_file))
+            mapping = dict(enumerate(PolicyLoader.find_statement_line_numbers(content, policy_file)))
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.warning(f"Could not parse {policy_file} for line mapping: {e}")
-            return {}
+
+        self._statement_line_maps[policy_file] = mapping
+        return mapping
 
     def _find_issue_line(
         self,
@@ -815,7 +799,8 @@ class PRCommenter:
         Returns:
             Line number or None
         """
-        start_line = self._get_line_mapping(policy_file).get(statement_idx)
+        mapping = self._get_line_mapping(policy_file)
+        start_line = mapping.get(statement_idx)
         if start_line is None:
             return None
 
@@ -825,14 +810,12 @@ class PRCommenter:
             logger.debug(f"Could not search {policy_file}: {e}")
             return None
 
-        depth = 0
-        for line_num, line in enumerate(lines[start_line - 1 :], start=start_line):
+        following = [line for line in mapping.values() if line > start_line]
+        end_line = min(following) if following else len(lines) + 1
+
+        for line_num, line in enumerate(lines[start_line - 1 : end_line - 1], start=start_line):
             if search_term in line:
                 return line_num
-            stripped = line.strip()
-            depth += stripped.count("{") - stripped.count("}")
-            if depth <= 0:
-                return None
 
         return None
 
@@ -957,7 +940,7 @@ async def post_report_to_pr(
         )
 
         config = ConfigLoader.load_config(config_path)
-        fail_on_severities = config.get_setting("fail_on_severity", ["error", "critical"])
+        fail_on_severities = config.get_setting("fail_on_severity", list(HIGH_SEVERITY_LEVELS))
         severity_labels = config.get_setting("severity_labels", {})
 
         # Get ignore settings

--- a/iam_validator/mcp/CLAUDE.md
+++ b/iam_validator/mcp/CLAUDE.md
@@ -45,6 +45,12 @@ mcp/
 `server.py` lifespan owns one shared `AWSServiceFetcher` AND a per-`(region,
 profile)` boto3 session cache so all tool calls reuse them.
 
+`server.py:_get_registry()` builds the metadata registry lazily (not at import — it
+loads third-party entry-point plugins). `_get_check_catalog()` and `get_check_details`
+resolve each check's `enabled` / `severity` through `SessionConfigManager` on every
+call, so the catalog agrees with what `validate_policy` runs; nothing memoizes the
+resolved values.
+
 ---
 
 ## Tools (33) — tagged for `--profile` gating
@@ -93,7 +99,8 @@ Static resources cache client-side and don't count against per-turn token
 budget the way tool descriptions do:
 
 - `iam://templates` — list of available policy templates
-- `iam://checks` — registered check catalog (id, description, default_severity)
+- `iam://checks` — registered check catalog (id, description, default_severity, plus
+  the session-config-resolved `severity` and `enabled`)
 - `iam://sensitive-categories` — sensitive-action category descriptions
 - `iam://sensitive-actions/{category}` — actions for a category (parameterized)
 - `iam://checks/{check_id}` — per-check docs, registry-driven (parameterized)

--- a/iam_validator/mcp/server.py
+++ b/iam_validator/mcp/server.py
@@ -108,31 +108,51 @@ def get_shared_fetcher(ctx: Any) -> AWSServiceFetcher | None:
 
 
 # =============================================================================
-# Cached Registry for list_checks and registry-driven guidance
+# Check catalog for the iam://checks resources and registry-driven guidance
 # =============================================================================
-
-# Module-level: built once at import. Tools just read.
-# create_default_registry() is sync and cheap (no I/O, just instantiates check
-# classes), so eager init eliminates any race-condition surface.
-_REGISTRY: CheckRegistry = create_default_registry()
 
 
 @functools.lru_cache(maxsize=1)
-def _get_cached_checks() -> tuple[dict[str, Any], ...]:
-    """Get cached check registry (initialized once, thread-safe via lru_cache)."""
-    return tuple(
-        sorted(
-            [
-                {
-                    "check_id": check_instance.check_id,
-                    "description": check_instance.description,
-                    "default_severity": check_instance.default_severity,
-                }
-                for check_instance in _REGISTRY.get_all_checks()
-            ],
-            key=lambda x: x["check_id"],
-        )
+def _get_registry() -> CheckRegistry:
+    """Registry backing the catalog resources; built on first use, not at import.
+
+    create_default_registry() imports and instantiates third-party entry-point
+    plugins, which must not run as a side effect of importing this module.
+    """
+    return create_default_registry()
+
+
+def _effective_check_settings(check_id: str, default_severity: str) -> tuple[bool, str]:
+    """``(enabled, severity)`` after the session config that validate_policy applies."""
+    from iam_validator.mcp.session_config import SessionConfigManager
+
+    config = SessionConfigManager.get_config()
+    if config is None:
+        return True, default_severity
+    return (
+        config.is_check_enabled(check_id),
+        config.get_check_severity(check_id) or default_severity,
     )
+
+
+def _get_check_catalog() -> tuple[dict[str, Any], ...]:
+    """Every registered check, with session-config enablement and severity resolved.
+
+    Not cached: the session config can change between calls.
+    """
+    catalog: list[dict[str, Any]] = []
+    for check_instance in _get_registry().get_all_checks():
+        enabled, severity = _effective_check_settings(check_instance.check_id, check_instance.default_severity)
+        catalog.append(
+            {
+                "check_id": check_instance.check_id,
+                "description": check_instance.description,
+                "default_severity": check_instance.default_severity,
+                "severity": severity,
+                "enabled": enabled,
+            }
+        )
+    return tuple(sorted(catalog, key=lambda x: x["check_id"]))
 
 
 # =============================================================================
@@ -909,7 +929,7 @@ async def get_issue_guidance(check_id: str) -> dict[str, Any]:
     """
     from iam_validator.mcp.check_metadata import get_check_metadata
 
-    check = _REGISTRY.get_check(check_id)
+    check = _get_registry().get_check(check_id)
     metadata = get_check_metadata(check_id)
 
     if check is None and not metadata:
@@ -962,7 +982,7 @@ async def get_check_details(check_id: str) -> dict[str, Any]:
     """
     from iam_validator.mcp.check_metadata import get_check_metadata
 
-    check = _REGISTRY.get_check(check_id)
+    check = _get_registry().get_check(check_id)
     metadata = get_check_metadata(check_id)
 
     if check is None:
@@ -977,6 +997,8 @@ async def get_check_details(check_id: str) -> dict[str, Any]:
             "related": metadata.get("related", []),
         }
 
+    enabled, severity = _effective_check_settings(check_id, check.default_severity)
+
     return {
         "check_id": check_id,
         "description": check.description,
@@ -984,7 +1006,7 @@ async def get_check_details(check_id: str) -> dict[str, Any]:
         "category": metadata.get("category", "general"),
         "example_violation": metadata.get("example_violation"),
         "example_fix": metadata.get("example_fix"),
-        "configuration": {"enabled": True, "severity": check.default_severity},
+        "configuration": {"enabled": enabled, "severity": severity},
         "related": metadata.get("related", []),
     }
 
@@ -1983,12 +2005,13 @@ async def templates_resource() -> str:
 async def checks_resource() -> str:
     """List of all available validation checks.
 
-    This resource provides metadata about all validation checks
-    including their IDs, descriptions, and default severities.
+    Each entry carries the check's id, description and class ``default_severity``
+    plus the ``severity`` and ``enabled`` flag the current session config resolves
+    to, so the catalog matches what validate_policy will actually run.
     """
     import json
 
-    return json.dumps(_get_cached_checks(), indent=2)
+    return json.dumps(_get_check_catalog(), indent=2)
 
 
 @mcp.resource("iam://sensitive-categories")

--- a/tests/checks/test_ifexists_condition_check.py
+++ b/tests/checks/test_ifexists_condition_check.py
@@ -341,3 +341,44 @@ class TestCheckMetadata:
         )
         issues = await check.execute(statement, 0, None, config)
         assert len(issues) == 0
+
+
+class TestOperatorRendering:
+    """Message operator names keep the set prefix once and never echo IfExists back."""
+
+    @pytest.fixture
+    def check(self):
+        return IfExistsConditionCheck()
+
+    @pytest.mark.asyncio
+    async def test_unresolved_operator_keeps_prefix_once_and_drops_suffix(self, check):
+        config = CheckConfig(check_id="ifexists_condition_usage")
+        statement = Statement(
+            Effect="Allow",
+            Action=["s3:GetObject"],
+            Resource=["*"],
+            Condition={"ForAllValues:StringBogusIfExists": {"aws:PrincipalAccount": "123456789012"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        redundant = [i for i in issues if i.issue_type == "ifexists_on_always_present_key"]
+        assert len(redundant) == 1
+        assert "same effect as `ForAllValues:StringBogus`" in redundant[0].message
+
+    @pytest.mark.asyncio
+    async def test_deny_suggestion_keeps_set_prefix(self, check):
+        config = CheckConfig(
+            check_id="ifexists_condition_usage",
+            config={"suggest_deny_ifexists": True},
+        )
+        statement = Statement(
+            Effect="Deny",
+            Action=["*"],
+            Resource=["*"],
+            Condition={"ForAnyValue:StringNotEquals": {"aws:SourceVpc": "vpc-123456"}},
+        )
+        issues = await check.execute(statement, 0, None, config)
+        suggestions = [i for i in issues if i.issue_type == "ifexists_deny_suggestion"]
+        assert len(suggestions) == 1
+        message = suggestions[0].message
+        assert "`ForAnyValue:StringNotEqualsIfExists`" in message
+        assert "instead of `ForAnyValue:StringNotEquals`" in message

--- a/tests/checks/test_sid_uniqueness_check.py
+++ b/tests/checks/test_sid_uniqueness_check.py
@@ -145,3 +145,36 @@ def test_sid_pattern_is_defined_only_in_constants():
     package = Path(__file__).resolve().parents[2] / "iam_validator"
     defining = [p for p in package.rglob("*.py") if literal in p.read_text(encoding="utf-8")]
     assert [p.name for p in defining] == ["constants.py"]
+
+
+class TestInvalidSidCharacterReporting:
+    @pytest.fixture
+    def check(self):
+        return SidUniquenessCheck()
+
+    @pytest.fixture
+    def config(self):
+        return CheckConfig(check_id="sid_uniqueness")
+
+    @pytest.fixture
+    def fetcher(self):
+        return AWSServiceFetcher()
+
+    async def _report(self, check, config, fetcher, sid):
+        policy = IAMPolicy(
+            Version="2012-10-17",
+            Statement=[Statement(Sid=sid, Effect="Allow", Action=["s3:GetObject"], Resource=["*"])],
+        )
+        issues = await check.execute_policy(policy, "test.json", fetcher, config)
+        assert len(issues) == 1
+        return issues[0].message
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_letters_are_reported(self, check, config, fetcher):
+        message = await self._report(check, config, fetcher, "Statementé")
+        assert "invalid characters: `é`" in message
+
+    @pytest.mark.asyncio
+    async def test_repeated_characters_listed_once_in_first_seen_order(self, check, config, fetcher):
+        message = await self._report(check, config, fetcher, "a-b_c-d_e.f")
+        assert "invalid characters: `-_.`" in message

--- a/tests/checks/utils/test_condition_matching.py
+++ b/tests/checks/utils/test_condition_matching.py
@@ -118,3 +118,11 @@ def test_accept_negated_override_wins_over_effect():
 def test_is_deny_is_case_and_whitespace_insensitive():
     assert is_deny(Statement(effect=" deny ", action=["*"], resource=["*"])) is True
     assert is_deny(Statement(effect="Allow", action=["*"], resource=["*"])) is False
+
+
+def test_operator_polarity_helpers_are_reexports_of_core():
+    from iam_validator.core import condition_validators
+
+    assert NEGATED_OPERATORS is condition_validators.NEGATED_OPERATORS
+    assert base_operator is condition_validators.base_operator
+    assert is_negated_operator is condition_validators.is_negated_operator

--- a/tests/core/test_condition_key_pattern_matching.py
+++ b/tests/core/test_condition_key_pattern_matching.py
@@ -687,3 +687,21 @@ def test_amr_is_multivalued_for_oidc_providers(condition_key):
 def test_amr_is_not_multivalued_for_non_provider_prefixes(condition_key):
     """``amr`` is only multivalued as an OIDC/web-identity provider claim."""
     assert is_multivalued_context_key(condition_key) is False
+
+
+def test_plain_patterns_do_not_reach_the_placeholder_cache():
+    """Only templated patterns are compiled, so the LRU keeps real provider patterns."""
+    from iam_validator.core.aws_service.validators import _compile_placeholder_pattern
+
+    _compile_placeholder_pattern.cache_clear()
+    assert find_matching_condition_key("s3:prefix", ["s3:delimiter", "aws:ResourceTag/tag-key"]) is None
+    assert _compile_placeholder_pattern.cache_info().currsize == 0
+
+    assert (
+        find_matching_condition_key(
+            "token.actions.acme.ghe.com:actor",
+            ["token.actions.${Domain}.ghe.com:actor"],
+        )
+        == "token.actions.${Domain}.ghe.com:actor"
+    )
+    assert _compile_placeholder_pattern.cache_info().currsize == 1

--- a/tests/core/test_full_wildcard_suppression.py
+++ b/tests/core/test_full_wildcard_suppression.py
@@ -698,3 +698,52 @@ def test_supersedes_only_suppresses_declared_ids():
     assert "1 checks suppressed" in result["dominant"][0].message
     assert "subsumed" in result["dominant"][0].message
     assert "unrelated" not in result["dominant"][0].message
+
+
+class TestSuppressionNoticeAttribution:
+    """Each superseding check names only the findings it made redundant."""
+
+    async def _run_two_superseders(self):
+        registry = _make_registry(suppress=True)
+
+        for superseder, superseded in (("super_a", "victim_a"), ("super_b", "victim_b")):
+            cls = _make_issue_check_class(superseder)
+            cls.supersedes = frozenset({superseded})
+            registry.register(cls())
+            registry.configure_check(superseder, CheckConfig(check_id=superseder, enabled=True))
+            _add_issue_check(registry, superseded)
+
+        statement = Statement(effect="Allow", action=["*"], resource=["*"])
+        issues = await registry.execute_checks_parallel(statement, 0, _make_mock_fetcher())
+        return {issue.check_id: issue.message for issue in issues}
+
+    async def test_notice_lists_only_the_checks_that_check_suppressed(self):
+        messages = await self._run_two_superseders()
+
+        assert set(messages) == {"super_a", "super_b"}
+        assert "victim_a" in messages["super_a"]
+        assert "victim_b" not in messages["super_a"]
+        assert "victim_b" in messages["super_b"]
+        assert "victim_a" not in messages["super_b"]
+        assert "**1 checks suppressed**" in messages["super_a"]
+
+    async def test_superseder_with_nothing_to_suppress_is_not_annotated(self):
+        registry = _make_registry(suppress=True)
+
+        cls = _make_issue_check_class("super_a")
+        cls.supersedes = frozenset({"victim_a"})
+        registry.register(cls())
+        registry.configure_check("super_a", CheckConfig(check_id="super_a", enabled=True))
+        _add_issue_check(registry, "victim_a")
+
+        quiet = _make_issue_check_class("super_quiet")
+        quiet.supersedes = frozenset({"absent_check"})
+        registry.register(quiet())
+        registry.configure_check("super_quiet", CheckConfig(check_id="super_quiet", enabled=True))
+
+        statement = Statement(effect="Allow", action=["*"], resource=["*"])
+        issues = await registry.execute_checks_parallel(statement, 0, _make_mock_fetcher())
+        messages = {issue.check_id: issue.message for issue in issues}
+
+        assert "suppressed" in messages["super_a"]
+        assert "suppressed" not in messages["super_quiet"]

--- a/tests/core/test_pr_commenter_diff_filtering.py
+++ b/tests/core/test_pr_commenter_diff_filtering.py
@@ -1139,7 +1139,7 @@ class TestSearchForFieldLineScoping:
         )
         commenter = _bare_commenter()
 
-        assert PRCommenter._get_line_mapping(commenter, str(policy)) == {0: 3}
+        assert PRCommenter._get_line_mapping(commenter, str(policy)) == {0: 4}
         assert PRCommenter._search_for_field_line(commenter, str(policy), 0, "s3:GetObject") == 6
         assert PRCommenter._search_for_field_line(commenter, str(policy), 0, "s3:PutObject") is None
 
@@ -1149,6 +1149,7 @@ def _bare_commenter() -> PRCommenter:
     commenter = PRCommenter.__new__(PRCommenter)
     commenter._file_lines_cache = {}
     commenter._policy_line_maps = {}
+    commenter._statement_line_maps = {}
     return commenter
 
 
@@ -1204,8 +1205,41 @@ class TestPolicyFileReadCaching:
             first = PRCommenter._get_line_mapping(commenter, str(policy_file))
             second = PRCommenter._get_line_mapping(commenter, str(policy_file))
 
-        assert first == second == {0: 4}
+        assert first == second == {0: 5}
         assert len(calls) == 1
+
+
+class TestYamlLineMapping:
+    """YAML policies must resolve statement lines like JSON ones."""
+
+    @pytest.fixture
+    def yaml_policy(self, tmp_path):
+        policy = tmp_path / "policy.yaml"
+        policy.write_text(
+            """Version: "2012-10-17"
+Statement:
+  - Sid: First
+    Effect: Allow
+    Action: s3:GetObject
+    Resource: "*"
+  - Sid: Second
+    Effect: Deny
+    Action: s3:PutObject
+    Resource: "*"
+""",
+            encoding="utf-8",
+        )
+        return policy
+
+    def test_get_line_mapping_handles_yaml(self, yaml_policy):
+        commenter = _bare_commenter()
+        assert PRCommenter._get_line_mapping(commenter, str(yaml_policy)) == {0: 3, 1: 7}
+
+    def test_search_for_field_line_is_scoped_per_yaml_statement(self, yaml_policy):
+        commenter = _bare_commenter()
+        assert PRCommenter._search_for_field_line(commenter, str(yaml_policy), 0, "s3:GetObject") == 5
+        assert PRCommenter._search_for_field_line(commenter, str(yaml_policy), 1, "s3:PutObject") == 9
+        assert PRCommenter._search_for_field_line(commenter, str(yaml_policy), 0, "s3:PutObject") is None
 
 
 if __name__ == "__main__":

--- a/tests/core/test_trust_policy_oidc_aud_required.py
+++ b/tests/core/test_trust_policy_oidc_aud_required.py
@@ -287,5 +287,6 @@ async def test_missing_subject_group_is_rendered_as_an_any_of_group(mock_fetcher
     issues = await TrustPolicyValidationCheck().execute(statement, 0, mock_fetcher, default_config)
     missing = [i for i in issues if i.issue_type == "missing_required_condition_for_assume_action"]
     assert len(missing) == 1
-    assert "one of: `*:sub`, `*:amr`" in missing[0].message
+    provider = "token.actions.githubusercontent.com"
+    assert f"one of: `{provider}:sub`, `{provider}:amr`" in missing[0].message
     assert "['*:sub', '*:amr']" not in missing[0].message

--- a/tests/core/test_trust_policy_validation.py
+++ b/tests/core/test_trust_policy_validation.py
@@ -229,10 +229,10 @@ class TestTrustPolicyValidationCheck:
         assert "missing_required_condition_for_assume_action" in issue_types
 
     @pytest.mark.asyncio
-    async def test_sts_glob_action_only_validated_against_matching_rule(self, check, fetcher, config):
-        """A glob narrower than the full sts:* wildcard (e.g. sts:AssumeRole*) is
-        validated against its single matching rule via _find_matching_rule, not
-        broadened to every STS assume-role rule."""
+    async def test_sts_glob_action_validated_against_every_rule_it_covers(self, check, fetcher, config):
+        """A glob narrower than sts:* (e.g. sts:AssumeRole*) still grants
+        AssumeRoleWithSAML and AssumeRoleWithWebIdentity, so their provider and
+        condition requirements apply too."""
         statement = Statement(
             Effect="Allow",
             Principal={"Federated": "arn:aws:iam::123456789012:saml-provider/MyProvider"},
@@ -241,7 +241,11 @@ class TestTrustPolicyValidationCheck:
         issues = await check.execute(statement, 0, fetcher, config)
         issue_types = {issue.issue_type for issue in issues}
         assert "invalid_principal_type_for_assume_action" in issue_types
-        assert "missing_required_condition_for_assume_action" not in issue_types
+        assert "missing_required_condition_for_assume_action" in issue_types
+        assert {i.action for i in issues if i.issue_type == "missing_required_condition_for_assume_action"} == {
+            "sts:AssumeRoleWithSAML",
+            "sts:AssumeRoleWithWebIdentity",
+        }
 
     @pytest.mark.asyncio
     async def test_custom_validation_rules(self, check, fetcher):
@@ -597,20 +601,115 @@ class TestTrustPolicyPartitionCoverage:
         assert any(i.issue_type == "invalid_provider_format" for i in issues)
 
 
-def test_find_matching_rule_is_case_insensitive():
+def test_find_matching_rules_is_case_insensitive():
     check = TrustPolicyValidationCheck()
     rules = {"sts:AssumeRole": {"allowed_principal_types": ["AWS"]}}
-    assert check._find_matching_rule("sts:assumerole", rules) is not None
-    assert check._find_matching_rule("STS:ASSUMEROLE", rules) is not None
+    assert [a for a, _ in check._find_matching_rules("sts:assumerole", rules)] == ["sts:AssumeRole"]
+    assert [a for a, _ in check._find_matching_rules("STS:ASSUMEROLE", rules)] == ["sts:AssumeRole"]
 
 
-def test_find_matching_rule_matches_statement_glob_against_rule():
+def test_find_matching_rules_returns_every_rule_a_glob_covers():
     check = TrustPolicyValidationCheck()
-    rules = {"sts:AssumeRoleWithWebIdentity": {"allowed_principal_types": ["Federated"]}}
-    assert check._find_matching_rule("sts:AssumeRoleWith*", rules) is not None
+    matched = [a for a, _ in check._find_matching_rules("sts:AssumeRole*", check.DEFAULT_RULES)]
+    assert matched == ["sts:AssumeRole", "sts:AssumeRoleWithSAML", "sts:AssumeRoleWithWebIdentity"]
 
 
-def test_find_matching_rule_returns_none_for_unrelated_action():
+def test_find_matching_rules_prefers_the_exact_rule_over_globs():
+    check = TrustPolicyValidationCheck()
+    rules = {
+        "sts:AssumeRole*": {"allowed_principal_types": ["AWS"]},
+        "sts:AssumeRole": {"allowed_principal_types": ["Service"]},
+    }
+    assert [a for a, _ in check._find_matching_rules("sts:AssumeRole", rules)] == ["sts:AssumeRole"]
+
+
+def test_find_matching_rules_returns_empty_for_unrelated_action():
     check = TrustPolicyValidationCheck()
     rules = {"sts:AssumeRole": {"allowed_principal_types": ["AWS"]}}
-    assert check._find_matching_rule("s3:GetObject", rules) is None
+    assert check._find_matching_rules("s3:GetObject", rules) == []
+
+
+class TestConfusedDeputyOperatorPolarity:
+    @pytest.mark.asyncio
+    async def test_negated_source_account_on_allow_is_not_protection(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Service": "sns.amazonaws.com"},
+            Action=["sts:AssumeRole"],
+            Condition={"StringNotEquals": {"aws:SourceAccount": "123456789012"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert any(i.issue_type == "confused_deputy_risk" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_null_asserting_absence_is_not_protection(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Service": "sns.amazonaws.com"},
+            Action=["sts:AssumeRole"],
+            Condition={"Null": {"aws:SourceArn": "true"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert any(i.issue_type == "confused_deputy_risk" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_positive_source_account_is_protection(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Service": "sns.amazonaws.com"},
+            Action=["sts:AssumeRole"],
+            Condition={"StringEquals": {"aws:SourceAccount": "123456789012"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert not any(i.issue_type == "confused_deputy_risk" for i in issues)
+
+    @pytest.mark.asyncio
+    async def test_negated_source_account_on_deny_is_protection(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Deny",
+            Principal={"Service": "sns.amazonaws.com"},
+            Action=["sts:AssumeRole"],
+            Condition={"StringNotEquals": {"aws:SourceAccount": "123456789012"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        assert not any(i.issue_type == "confused_deputy_risk" for i in issues)
+
+
+class TestRequiredConditionRendering:
+    @pytest.mark.asyncio
+    async def test_oidc_requirement_is_rendered_for_the_statement_provider(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"},
+            Action=["sts:AssumeRoleWithWebIdentity"],
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        issue = next(i for i in issues if i.issue_type == "missing_required_condition_for_assume_action")
+        assert "`token.actions.githubusercontent.com:aud`" in issue.message
+        assert "`token.actions.githubusercontent.com:sub`" in issue.message
+        assert "*:aud" not in issue.message
+        assert "token.actions.githubusercontent.com:aud" in (issue.example or "")
+
+    @pytest.mark.asyncio
+    async def test_bare_web_identity_domain_is_rendered(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Federated": "accounts.google.com"},
+            Action=["sts:AssumeRoleWithWebIdentity"],
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        issue = next(i for i in issues if i.issue_type == "missing_required_condition_for_assume_action")
+        assert "`accounts.google.com:aud`" in issue.message
+
+    @pytest.mark.asyncio
+    async def test_example_uses_the_first_missing_group_not_the_first_requirement(self, check, fetcher, config):
+        statement = Statement(
+            Effect="Allow",
+            Principal={"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"},
+            Action=["sts:AssumeRoleWithWebIdentity"],
+            Condition={"StringEquals": {"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"}},
+        )
+        issues = await check.execute(statement, 0, fetcher, config)
+        issue = next(i for i in issues if i.issue_type == "missing_required_condition_for_assume_action")
+        assert "token.actions.githubusercontent.com:sub" in (issue.example or "")
+        assert ":aud" not in (issue.example or "")

--- a/tests/mcp/test_check_metadata.py
+++ b/tests/mcp/test_check_metadata.py
@@ -86,3 +86,17 @@ async def test_curated_entry_returns_example_pair(check_id: str):
     result = await get_issue_guidance(check_id)
     assert result["example_before"] is not None, f"missing example_before for {check_id}"
     assert result["example_after"] is not None, f"missing example_after for {check_id}"
+
+
+async def test_get_check_details_configuration_reflects_session_config():
+    """get_check_details reports the session config's enablement and severity, not defaults."""
+    from iam_validator.mcp.session_config import SessionConfigManager
+
+    SessionConfigManager.clear_config()
+    try:
+        SessionConfigManager.set_config({"checks": {"wildcard_action": {"enabled": False, "severity": "low"}}})
+        result = await get_check_details("wildcard_action")
+        assert result["configuration"] == {"enabled": False, "severity": "low"}
+        assert result["default_severity"] != "low"
+    finally:
+        SessionConfigManager.clear_config()

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -16,32 +16,75 @@ import pytest
 # Skip all tests in this module if fastmcp is not installed
 fastmcp = pytest.importorskip("fastmcp", reason="MCP tests require 'pip install iam-policy-validator[mcp]'")
 
-from iam_validator.mcp.server import _get_cached_checks, mcp  # noqa: E402
+from iam_validator.mcp.server import _get_check_catalog, mcp  # noqa: E402
+from iam_validator.mcp.session_config import SessionConfigManager  # noqa: E402
 
 
-class TestCachedChecks:
-    """Test the cached check registry."""
+class TestCheckCatalog:
+    """Test the check catalog backing the iam://checks resources."""
 
-    def test_cached_checks_returns_all_checks(self):
-        """Cached checks should return all 20 validation checks."""
-        checks = _get_cached_checks()
+    @pytest.fixture(autouse=True)
+    def _no_session_config(self):
+        SessionConfigManager.clear_config()
+        yield
+        SessionConfigManager.clear_config()
+
+    def test_catalog_returns_all_checks(self):
+        checks = _get_check_catalog()
         assert len(checks) >= 15  # At least 15 checks exist
         assert all("check_id" in c for c in checks)
         assert all("description" in c for c in checks)
         assert all("default_severity" in c for c in checks)
 
-    def test_cached_checks_is_idempotent(self):
-        """Calling _get_cached_checks twice returns same object."""
-        checks1 = _get_cached_checks()
-        checks2 = _get_cached_checks()
-        # Should be the exact same list object (cached)
-        assert checks1 is checks2
-
-    def test_cached_checks_sorted_by_id(self):
-        """Checks should be sorted by check_id."""
-        checks = _get_cached_checks()
+    def test_catalog_sorted_by_id(self):
+        checks = _get_check_catalog()
         check_ids = [c["check_id"] for c in checks]
         assert check_ids == sorted(check_ids)
+
+    def test_catalog_defaults_to_enabled_at_default_severity(self):
+        entry = next(c for c in _get_check_catalog() if c["check_id"] == "wildcard_action")
+        assert entry["enabled"] is True
+        assert entry["severity"] == entry["default_severity"]
+
+    def test_catalog_reflects_session_config_disable_and_override(self):
+        SessionConfigManager.set_config(
+            {
+                "checks": {
+                    "wildcard_action": {"enabled": False},
+                    "wildcard_resource": {"severity": "critical"},
+                }
+            }
+        )
+        by_id = {c["check_id"]: c for c in _get_check_catalog()}
+
+        assert by_id["wildcard_action"]["enabled"] is False
+        assert by_id["wildcard_resource"]["severity"] == "critical"
+        assert by_id["wildcard_resource"]["default_severity"] != "critical"
+
+    def test_registry_is_not_built_at_import_time(self):
+        """Entry-point plugin imports must not be a side effect of importing the server."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import iam_validator.mcp.server as s; print(s._get_registry.cache_info().currsize)",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "0"
+
+    def test_catalog_follows_a_config_change(self):
+        before = next(c for c in _get_check_catalog() if c["check_id"] == "wildcard_action")
+        SessionConfigManager.set_config({"checks": {"wildcard_action": {"enabled": False}}})
+        after = next(c for c in _get_check_catalog() if c["check_id"] == "wildcard_action")
+
+        assert before["enabled"] is True
+        assert after["enabled"] is False
 
 
 class TestMCPServer:


### PR DESCRIPTION
Release 1.27.1. Remediates the 15 findings from the `xhigh` review of #178, plus an MCP check-catalog fidelity fix.

## Trust policies

- An action glob (`sts:AssumeRole*`) is validated against every rule it covers, not just the first match; an action naming a rule exactly still validates against that rule alone.
- Confused-deputy detection no longer accepts a negated operator on an `Allow`, or a `Null` condition asserting the key is absent, as source restriction.
- A missing OIDC condition is reported against the statement's own provider (`token.actions.githubusercontent.com:sub`) instead of the raw `*:sub` pattern, and the example names the group actually missing.
- Documented the per-action condition requirements, the operator-polarity rules, and the `validation_rules` opt-out.

## PR inline comments

- YAML field lines resolve again: statement line mapping is shared with `PolicyLoader` (which now handles a `Statement` key opening on the same line as its first statement), and the field scan is bounded by the next statement instead of counting braces, which never worked for YAML.
- The line map is computed once per file per run instead of once per finding.

## Condition operators

- `checks/utils/condition_matching.py` re-exports `base_operator`, `is_negated_operator` and `NEGATED_OPERATORS` from `core/condition_validators.py` instead of carrying a second copy; the core helper now uses the explicit negated set rather than substring-matching `not`.
- The redundant-`IfExists` and `Deny`-suggestion messages keep a `ForAllValues:`/`ForAnyValue:` prefix exactly once and drop the `IfExists` suffix even for an unknown operator.

## Config and reporting

- `fail_on_severity` falls back to `constants.HIGH_SEVERITY_LEVELS` everywhere; `pr_commenter` previously defaulted to `["error", "critical"]`, dropping `high` findings from the failure decision.
- `suppress_superseded_findings` defaults to `true` at the config layer, matching the schema, defaults and docs.
- A superseding check's suppression notice lists only the ids that check suppressed; a superseder with nothing to suppress is no longer annotated.
- `--log-level debug` emits a `skipped_checks=` line per policy.
- A `Sid` with non-ASCII letters is reported with the characters AWS actually rejects, listed once each in order.
- Condition-key lookup only compiles patterns containing `${`, so the placeholder cache no longer fills with plain keys.

## MCP

- `iam://checks` and `iam://checks/{check_id}` resolve each check's `enabled` and `severity` through `SessionConfigManager` on every read. They previously asserted every registered check was enabled at its class `default_severity`, contradicting the config `validate_policy` applies. `iam://checks` entries gained `severity` and `enabled` alongside the unchanged `default_severity`.
- The metadata registry is built on first use rather than at import, so importing `iam_validator.mcp.server` no longer loads and instantiates third-party entry-point plugins as a side effect.

## Verification

`uv run ruff check` clean, `uv run mypy iam_validator/` clean (123 files), `uv run pytest` 2078 passed / 23 skipped. Each fix was mutation-tested: the pre-fix code was reinjected and the guarding test confirmed to fail.
