### PR TITLE
fix(github): clear labels and ignore records when findings are resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to IAM Policy Validator are documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.2] - 2026-09-11
+
+Fixes the "everything is fixed but the PR still looks dirty" case: PR labels whose names are not URL-safe could never be removed, and ignore records outlived the findings they silenced.
+
+### Fixed
+
+- `remove_label` percent-encodes the label name before putting it in the request path. httpx only escapes spaces, so a label containing `/`, `#`, `%` or `+` produced a wrong path and the delete silently 404'd — labels could be added (a JSON body) but never removed
+- `get_labels` reads through pagination instead of a single page. GitHub caps the endpoint at 30 labels per page, so on a PR carrying more than that the validator's own labels could fall outside the "current" set and never be removed
+- Ignore records are reconciled against each run's findings: once a finding is no longer reported, its record is dropped from the storage comment, so the PR summary stops showing an **Ignored Findings** count and table for issues that were already fixed. Reconciliation is scoped to the files a run validated, so a partial run cannot discard ignores for policies it never looked at
+
 ## [1.27.1] - 2026-09-10
 
 A remediation release. Trust-policy validation, PR inline-comment line resolution and condition-operator polarity are corrected across the board, and the MCP check catalog now reports what validation will actually do rather than class defaults.

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -436,6 +436,12 @@ A summary comment is posted showing:
 
 When `allow-owner-ignore: true`, code owners can reply "ignore" to dismiss specific findings. This is useful for acknowledged exceptions.
 
+Ignore records live in a hidden PR comment and are reconciled on every run: once a
+finding stops being reported — the policy was fixed — its record is dropped, so the
+summary's **Ignored Findings** count and table only ever describe live findings.
+Reconciliation is scoped to the files a run actually validated, so a run driven by a
+changed-files list cannot discard ignores belonging to policies it never looked at.
+
 ---
 
 ## Job Summary

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -388,6 +388,9 @@ settings:
   allow_template_variables: true # Support ${var.name} in ARNs
 
   # GitHub integration
+  # Labels are reconciled on every run: a severity that is still found gets
+  # its label added, a severity that is no longer found gets it removed.
+  # Label names may contain any character GitHub allows, "/" and "#" included.
   severity_labels: # Map severities to PR labels
     error: "iam-validity-error"
     critical: "iam-security-critical"

--- a/iam_validator/__version__.py
+++ b/iam_validator/__version__.py
@@ -3,7 +3,7 @@
 This file is the single source of truth for the package version.
 """
 
-__version__ = "1.27.1"
+__version__ = "1.27.2"
 # Parse version, handling pre-release suffixes like -rc, -alpha, -beta
 _version_base = __version__.split("-", maxsplit=1)[0]  # Remove pre-release suffix if present
 __version_info__ = tuple(int(part) for part in _version_base.split("."))

--- a/iam_validator/core/CLAUDE.md
+++ b/iam_validator/core/CLAUDE.md
@@ -23,7 +23,9 @@ core/
 ├── access_analyzer_report.py # markdown formatter for Access Analyzer
 ├── ignore_patterns.py      # CODEOWNERS-driven finding suppression
 ├── ignore_processor.py     # ignore-command parser
-├── ignored_findings.py     # storage (hidden PR comment with JSON payload)
+├── ignored_findings.py     # storage (hidden PR comment with JSON payload);
+│                           # prune_resolved() drops records whose finding is no
+│                           # longer reported, scoped to the run's validated files
 ├── codeowners.py
 ├── constants.py            # central markers, ARN partition regex, size limits
 ├── aws_matching.py         # case-insensitive IAM glob matching (compile_iam_glob,

--- a/iam_validator/core/ignored_findings.py
+++ b/iam_validator/core/ignored_findings.py
@@ -262,6 +262,62 @@ class IgnoredFindingsStore:
             return await self.save()
         return False
 
+    async def prune_resolved(
+        self,
+        live_finding_ids: frozenset[str] | set[str],
+        validated_files: set[str],
+    ) -> int:
+        """Drop ignore records whose finding no longer exists.
+
+        An ignore record is only meaningful while the finding it silences is
+        still being reported. Once the policy is fixed the record is dead
+        weight: it keeps inflating the "Ignored Findings" count and table in
+        the PR summary long after the underlying issue is gone.
+
+        Pruning is scoped to ``validated_files``. A run that covers a subset
+        of the repository's policies (streaming per-file passes, or a workflow
+        driven by a changed-files list) has no evidence about findings in
+        files it never looked at, so records for those files are kept.
+
+        Args:
+            live_finding_ids: Finding IDs reported by the current run, for
+                every issue in the validated files regardless of whether the
+                issue is itself ignored.
+            validated_files: Relative paths of the policy files this run
+                actually validated.
+
+        Returns:
+            Number of records removed (0 means nothing was saved).
+        """
+        if not validated_files:
+            return 0
+
+        findings = await self.load()
+        stale_ids = [
+            finding_id
+            for finding_id, finding in findings.items()
+            if finding.file_path in validated_files and finding_id not in live_finding_ids
+        ]
+        if not stale_ids:
+            return 0
+
+        # Keep the pre-prune snapshot so a failed save leaves the in-memory
+        # store agreeing with what GitHub still holds; the next run retries.
+        original = dict(findings)
+        for finding_id in stale_ids:
+            logger.info(
+                f"Pruning ignore record for resolved finding {finding_id[:8]}... "
+                f"({findings[finding_id].file_path}: {findings[finding_id].issue_type})"
+            )
+            del findings[finding_id]
+
+        self._cache = findings
+        if not await self.save():
+            logger.warning("Failed to save pruned ignored findings storage")
+            self._cache = original
+            return 0
+        return len(stale_ids)
+
     async def _find_storage_comment(self) -> dict[str, Any] | None:
         """Find the storage comment on the PR.
 

--- a/iam_validator/core/pr_commenter.py
+++ b/iam_validator/core/pr_commenter.py
@@ -171,7 +171,7 @@ class PRCommenter:
 
         # Load ignored findings for filtering
         if self.enable_codeowners_ignore:
-            await self._load_ignored_findings()
+            await self._load_ignored_findings(report)
 
         # Note: Cleanup is now handled smartly by update_or_create_review_comments()
         # It will update existing comments, create new ones, and delete resolved ones
@@ -837,8 +837,20 @@ class PRCommenter:
         if ignored_count > 0:
             logger.info(f"Processed {ignored_count} ignore command(s)")
 
-    async def _load_ignored_findings(self) -> None:
-        """Load ignored findings for the current PR."""
+    async def _load_ignored_findings(self, report: ValidationReport) -> None:
+        """Load ignored findings for the current PR, dropping resolved ones.
+
+        Ignore records outlive the findings they silence: nothing removes them
+        when the policy is fixed, so the PR summary keeps reporting an
+        "Ignored Findings" count and table for issues that no longer exist.
+        Reconciling the store against this run's findings clears them, scoped
+        to the files this run validated so a partial run cannot discard
+        ignores it has no evidence about.
+
+        Args:
+            report: The current validation report, used to determine which
+                findings are still live and which files were validated.
+        """
         if not self.github:
             return
 
@@ -849,10 +861,49 @@ class PRCommenter:
         store = IgnoredFindingsStore(self.github, comment_tag=self.comment_tag)
         # Load full ignored findings for display in summary
         self._ignored_findings = await store.load()
+
+        if self._ignored_findings:
+            live_finding_ids, validated_files = self._live_finding_scope(report)
+            pruned = await store.prune_resolved(live_finding_ids, validated_files)
+            if pruned:
+                logger.info(f"Cleared {pruned} ignore record(s) for findings that are no longer reported")
+                self._ignored_findings = await store.load()
+
         # Also get just the IDs for fast lookup
         self._ignored_finding_ids = frozenset(self._ignored_findings.keys())
         if self._ignored_finding_ids:
             logger.debug(f"Loaded {len(self._ignored_finding_ids)} ignored finding(s)")
+
+    def _live_finding_scope(self, report: ValidationReport) -> tuple[frozenset[str], set[str]]:
+        """Collect this run's finding IDs and the files they were found in.
+
+        Every issue is fingerprinted, ignored ones included — an ignored
+        finding that is still reported must keep its ignore record. Files
+        whose path cannot be made repository-relative are left out of both
+        sets so they are treated as "not validated" rather than "clean".
+
+        Args:
+            report: The current validation report
+
+        Returns:
+            Tuple of (finding IDs present in this run, validated file paths)
+        """
+        from iam_validator.core.finding_fingerprint import (  # pylint: disable=import-outside-toplevel
+            FindingFingerprint,
+        )
+
+        live_finding_ids: set[str] = set()
+        validated_files: set[str] = set()
+
+        for result in report.results:
+            relative_path = self._make_relative_path(result.policy_file)
+            if not relative_path:
+                continue
+            validated_files.add(relative_path)
+            for issue in result.issues:
+                live_finding_ids.add(FindingFingerprint.from_issue(issue, relative_path).to_hash())
+
+        return frozenset(live_finding_ids), validated_files
 
     def _is_issue_ignored(self, issue: ValidationIssue, file_path: str) -> bool:
         """Check if an issue should be ignored.

--- a/iam_validator/integrations/CLAUDE.md
+++ b/iam_validator/integrations/CLAUDE.md
@@ -18,7 +18,10 @@ Surface organized by concern:
 - **Comment lifecycle helpers** — `_sync_comments_with_identifier` (used by both
   general and multi-part summary paths), `_find_all_comments_with_identifier` (paginated)
 - **Deduplication** — `_get_bot_comments_by_fingerprint`, `_extract_finding_id`
-- **Labels** — `add_labels`, `remove_label`, `get_labels`, `set_labels`
+- **Labels** — `add_labels`, `remove_label`, `get_labels`, `set_labels`.
+  `remove_label` percent-encodes the name (it is a path segment; httpx escapes
+  only spaces, so `/`, `#`, `%` and `+` must be encoded or the delete 404s).
+  `get_labels` is paginated — the endpoint defaults to 30 per page.
 - **PR info** — `get_pr_info`, `get_pr_files`, `get_pr_commits`
 - **Status checks** — `set_commit_status`
 - **CODEOWNERS** — `get_codeowners_content`, `get_team_members`, `is_user_codeowner`
@@ -84,6 +87,7 @@ Mock the API surface — no real HTTP. See `tests/integrations/`:
 
 - `test_github_pagination.py` — paginated request behaviour
 - `test_label_manager.py` — severity → label mapping
+- `test_github_labels.py` — label-name encoding and paginated `get_labels`
 - `test_comment_deduplication.py` — fingerprint and location matching
 - `test_review_comment_noise.py` — inline noise-minimization invariants
 - `test_summary_comment_staleness.py` — summary lifecycle (paginated find, orphan cleanup)

--- a/iam_validator/integrations/github_integration.py
+++ b/iam_validator/integrations/github_integration.py
@@ -12,6 +12,7 @@ import re
 import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 import httpx
 
@@ -1384,6 +1385,11 @@ class GitHubIntegration:
     async def remove_label(self, label: str) -> bool:
         """Remove a label from the PR.
 
+        The label name is percent-encoded because it is a path segment.
+        httpx only escapes spaces, so an unencoded name containing "/", "#",
+        "%" or "+" would produce a wrong path and the delete would silently
+        404 while ``add_labels`` (a JSON body) kept working.
+
         Args:
             label: Label name to remove
 
@@ -1392,7 +1398,7 @@ class GitHubIntegration:
         """
         result = await self._make_request(
             "DELETE",
-            f"issues/{self.pr_number}/labels/{label}",
+            f"issues/{self.pr_number}/labels/{quote(label, safe='')}",
         )
 
         if result is not None:  # DELETE returns empty dict on success
@@ -1406,20 +1412,19 @@ class GitHubIntegration:
         Returns:
             List of label names
         """
-        result = await self._make_request(
-            "GET",
-            f"issues/{self.pr_number}/labels",
-        )
+        # Paginated: GitHub caps this endpoint at 30 items per page by
+        # default, so a PR carrying more labels than that would report an
+        # incomplete "current" set and validator labels past the cut-off
+        # would never be removed.
+        result = await self._make_paginated_request(f"issues/{self.pr_number}/labels")
 
-        if result and isinstance(result, list):
-            labels: list[str] = []
-            for label in result:
-                if isinstance(label, dict):
-                    name = label.get("name")
-                    if isinstance(name, str):
-                        labels.append(name)
-            return labels
-        return []
+        labels: list[str] = []
+        for label in result:
+            if isinstance(label, dict):
+                name = label.get("name")
+                if isinstance(name, str):
+                    labels.append(name)
+        return labels
 
     async def set_labels(self, labels: list[str]) -> bool:
         """Set labels on the PR, replacing any existing labels.

--- a/tests/core/test_ignored_findings_prune.py
+++ b/tests/core/test_ignored_findings_prune.py
@@ -1,0 +1,129 @@
+"""Tests for pruning ignore records whose findings are no longer reported.
+
+Ignore records used to outlive the findings they silenced: nothing removed
+them when the policy was fixed, so the PR summary kept reporting an
+"Ignored Findings" count and table for issues that no longer existed.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from iam_validator.core.constants import IGNORED_FINDINGS_IDENTIFIER
+from iam_validator.core.ignored_findings import IgnoredFindingsStore
+
+
+def storage_comment(*findings: dict) -> list[dict]:
+    """Build a PR comment list containing the ignore storage comment."""
+    payload = json.dumps({"version": 1, "ignored_findings": list(findings)})
+    return [
+        {
+            "id": 999,
+            "body": f"{IGNORED_FINDINGS_IDENTIFIER}\n\n```json\n{payload}\n```\n",
+        }
+    ]
+
+
+def record(finding_id: str, file_path: str) -> dict:
+    return {
+        "finding_id": finding_id,
+        "file_path": file_path,
+        "check_id": "sensitive_action",
+        "issue_type": "sensitive_action",
+        "ignored_by": "owner",
+        "ignored_at": "2024-01-15T10:30:00Z",
+        "reason": "approved",
+    }
+
+
+@pytest.fixture
+def mock_github():
+    github = MagicMock()
+    github.post_comment = AsyncMock(return_value=True)
+    github._update_comment = AsyncMock(return_value=True)
+    github.get_issue_comments = AsyncMock(return_value=[])
+    return github
+
+
+@pytest.mark.asyncio
+async def test_prunes_record_for_resolved_finding(mock_github):
+    """A record for a validated file with no matching finding is dropped."""
+    mock_github.get_issue_comments = AsyncMock(return_value=storage_comment(record("a1b2c3d4e5f60718", "policy.json")))
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset(), {"policy.json"})
+
+    assert pruned == 1
+    assert await store.load() == {}
+    mock_github._update_comment.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_keeps_record_while_finding_is_still_reported(mock_github):
+    """An ignored finding that is still reported keeps its record."""
+    mock_github.get_issue_comments = AsyncMock(return_value=storage_comment(record("a1b2c3d4e5f60718", "policy.json")))
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset({"a1b2c3d4e5f60718"}), {"policy.json"})
+
+    assert pruned == 0
+    assert "a1b2c3d4e5f60718" in await store.load()
+    mock_github._update_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_keeps_records_for_files_this_run_did_not_validate(mock_github):
+    """A partial run must not discard ignores it has no evidence about."""
+    mock_github.get_issue_comments = AsyncMock(
+        return_value=storage_comment(
+            record("a1b2c3d4e5f60718", "validated.json"),
+            record("0918273645aabbcc", "untouched.json"),
+        )
+    )
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset(), {"validated.json"})
+
+    assert pruned == 1
+    remaining = await store.load()
+    assert "0918273645aabbcc" in remaining
+    assert "a1b2c3d4e5f60718" not in remaining
+
+
+@pytest.mark.asyncio
+async def test_no_validated_files_is_a_noop(mock_github):
+    """With nothing validated there is no evidence to prune on."""
+    mock_github.get_issue_comments = AsyncMock(return_value=storage_comment(record("a1b2c3d4e5f60718", "policy.json")))
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset(), set())
+
+    assert pruned == 0
+    mock_github._update_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_save_reports_nothing_pruned(mock_github):
+    """A failed storage update must not be reported as a successful prune."""
+    mock_github.get_issue_comments = AsyncMock(return_value=storage_comment(record("a1b2c3d4e5f60718", "policy.json")))
+    mock_github._update_comment = AsyncMock(return_value=False)
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset(), {"policy.json"})
+
+    assert pruned == 0
+    # The record is still in GitHub, so it must still be in the store.
+    assert "a1b2c3d4e5f60718" in await store.load()
+
+
+@pytest.mark.asyncio
+async def test_empty_store_never_creates_a_storage_comment(mock_github):
+    """Pruning an empty store must not post a new storage comment."""
+    store = IgnoredFindingsStore(mock_github)
+
+    pruned = await store.prune_resolved(frozenset(), {"policy.json"})
+
+    assert pruned == 0
+    mock_github.post_comment.assert_not_awaited()
+    mock_github._update_comment.assert_not_awaited()

--- a/tests/core/test_pr_commenter_resolved_findings.py
+++ b/tests/core/test_pr_commenter_resolved_findings.py
@@ -1,0 +1,175 @@
+"""End-to-end tests for the "everything was fixed" run.
+
+When a PR's findings are all resolved, the next run must leave the PR clean:
+severity labels removed, inline comments cleaned up, the summary reporting a
+pass, and no leftover "Ignored Findings" table for issues that are gone.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from iam_validator.core.constants import IGNORED_FINDINGS_IDENTIFIER
+from iam_validator.core.models import PolicyValidationResult, ValidationIssue
+from iam_validator.core.pr_commenter import PRCommenter
+from iam_validator.core.report import ReportGenerator
+
+SEVERITY_LABELS = {"critical": "security-critical", "high": "security-high"}
+
+
+def ignore_storage_comment(*findings: dict) -> dict:
+    payload = json.dumps({"version": 1, "ignored_findings": list(findings)})
+    return {
+        "id": 999,
+        "body": f"{IGNORED_FINDINGS_IDENTIFIER}\n\n```json\n{payload}\n```\n",
+    }
+
+
+def ignore_record(finding_id: str, file_path: str, issue_type: str) -> dict:
+    return {
+        "finding_id": finding_id,
+        "file_path": file_path,
+        "check_id": issue_type,
+        "issue_type": issue_type,
+        "ignored_by": "owner",
+        "ignored_at": "2024-01-15T10:30:00Z",
+        "reason": "approved by security",
+    }
+
+
+@pytest.fixture
+def mock_github():
+    """A PR carrying a severity label and a stale inline comment from run 1."""
+    github = MagicMock()
+    github.is_configured = MagicMock(return_value=True)
+    github.get_labels = AsyncMock(return_value=["security-critical", "unrelated"])
+    github.add_labels = AsyncMock(return_value=True)
+    github.remove_label = AsyncMock(return_value=True)
+    github.get_pr_files = AsyncMock(return_value=[{"filename": "policy.json", "patch": "@@ -1 +1,2 @@\n+ x\n"}])
+    github.get_pr_info = AsyncMock(return_value={"head": {"sha": "sha1"}})
+    github.get_issue_comments = AsyncMock(return_value=[])
+    github.get_review_comments = AsyncMock(return_value=[])
+    github.post_comment = AsyncMock(return_value=True)
+    github._update_comment = AsyncMock(return_value=True)
+    github.post_multipart_comments = AsyncMock(return_value=True)
+    github.update_or_create_review_comments = AsyncMock(return_value=True)
+    github.scan_for_ignore_commands = AsyncMock(return_value=[])
+    return github
+
+
+def clean_report():
+    return ReportGenerator().generate_report(
+        [PolicyValidationResult(policy_file="policy.json", is_valid=True, issues=[])]
+    )
+
+
+def summary_body(mock_github: MagicMock) -> str:
+    mock_github.post_multipart_comments.assert_awaited_once()
+    parts = mock_github.post_multipart_comments.await_args.args[0]
+    assert len(parts) == 1
+    return parts[0]
+
+
+@pytest.mark.asyncio
+async def test_resolved_run_removes_labels_and_cleans_comments(mock_github):
+    commenter = PRCommenter(
+        mock_github,
+        cleanup_old_comments=True,
+        severity_labels=SEVERITY_LABELS,
+        enable_codeowners_ignore=False,
+    )
+
+    assert await commenter.post_findings_to_pr(clean_report()) is True
+
+    mock_github.remove_label.assert_awaited_once_with("security-critical")
+    mock_github.add_labels.assert_not_awaited()
+    # Cleanup must still run so run-1 inline comments are deleted.
+    kwargs = mock_github.update_or_create_review_comments.await_args.kwargs
+    assert kwargs["comments"] == []
+    assert kwargs["skip_cleanup"] is False
+    assert kwargs["validated_files"] == {"policy.json"}
+    assert "IAM Policy Validation Passed" in summary_body(mock_github)
+
+
+@pytest.mark.asyncio
+async def test_resolved_run_clears_stale_ignored_findings(mock_github):
+    """The regression: ignore records outlived the findings they silenced."""
+    mock_github.get_issue_comments = AsyncMock(
+        return_value=[ignore_storage_comment(ignore_record("deadbeefdeadbeef", "policy.json", "full_wildcard"))]
+    )
+    commenter = PRCommenter(
+        mock_github,
+        cleanup_old_comments=True,
+        severity_labels=SEVERITY_LABELS,
+        enable_codeowners_ignore=True,
+    )
+
+    assert await commenter.post_findings_to_pr(clean_report()) is True
+
+    # Storage comment rewritten without the resolved record.
+    mock_github._update_comment.assert_awaited_once()
+    saved_body = mock_github._update_comment.await_args.args[1]
+    assert "deadbeefdeadbeef" not in saved_body
+
+    body = summary_body(mock_github)
+    assert "Ignored Findings" not in body
+    assert "full_wildcard" not in body
+    assert "IAM Policy Validation Passed" in body
+
+
+@pytest.mark.asyncio
+async def test_still_reported_ignored_finding_survives(mock_github):
+    """An ignored finding that is still present keeps its record and display."""
+    issue = ValidationIssue(
+        severity="critical",
+        statement_index=0,
+        issue_type="full_wildcard",
+        message="Full wildcard",
+        check_id="full_wildcard",
+    )
+    result = PolicyValidationResult(policy_file="policy.json", is_valid=False, issues=[issue])
+    report = ReportGenerator().generate_report([result])
+
+    from iam_validator.core.finding_fingerprint import FindingFingerprint
+
+    finding_id = FindingFingerprint.from_issue(issue, "policy.json").to_hash()
+    mock_github.get_issue_comments = AsyncMock(
+        return_value=[ignore_storage_comment(ignore_record(finding_id, "policy.json", "full_wildcard"))]
+    )
+
+    commenter = PRCommenter(
+        mock_github,
+        cleanup_old_comments=True,
+        severity_labels=SEVERITY_LABELS,
+        enable_codeowners_ignore=True,
+    )
+
+    assert await commenter.post_findings_to_pr(report) is True
+
+    mock_github._update_comment.assert_not_awaited()
+    assert "Ignored Findings" in summary_body(mock_github)
+
+
+@pytest.mark.asyncio
+async def test_partial_run_keeps_ignores_for_unvalidated_files(mock_github):
+    """A run over one file must not drop ignores belonging to another."""
+    mock_github.get_issue_comments = AsyncMock(
+        return_value=[
+            ignore_storage_comment(
+                ignore_record("aaaaaaaaaaaaaaaa", "policy.json", "full_wildcard"),
+                ignore_record("bbbbbbbbbbbbbbbb", "other.json", "sensitive_action"),
+            )
+        ]
+    )
+    commenter = PRCommenter(
+        mock_github,
+        cleanup_old_comments=True,
+        enable_codeowners_ignore=True,
+    )
+
+    assert await commenter.post_findings_to_pr(clean_report()) is True
+
+    saved_body = mock_github._update_comment.await_args.args[1]
+    assert "aaaaaaaaaaaaaaaa" not in saved_body
+    assert "bbbbbbbbbbbbbbbb" in saved_body

--- a/tests/integrations/test_github_labels.py
+++ b/tests/integrations/test_github_labels.py
@@ -1,0 +1,80 @@
+"""Tests for the GitHub label endpoints.
+
+Label removal puts the label name in the URL path. httpx only escapes
+spaces, so an unencoded name containing "/", "#", "%" or "+" produced a
+wrong path and the delete silently 404'd — while ``add_labels`` (a JSON
+body) kept working, so labels could be added but never removed.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from iam_validator.integrations.github_integration import GitHubIntegration
+
+
+@pytest.fixture
+def github():
+    with patch.dict(
+        "os.environ",
+        {
+            "GITHUB_TOKEN": "ghp_" + "x" * 36,
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_PR_NUMBER": "42",
+        },
+        clear=False,
+    ):
+        integration = GitHubIntegration()
+    assert integration.is_configured()
+    return integration
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_segment"),
+    [
+        ("iam-validity-error", "iam-validity-error"),
+        ("needs review", "needs%20review"),
+        ("iam/critical", "iam%2Fcritical"),
+        ("bug#1", "bug%231"),
+        ("100% done", "100%25%20done"),
+        ("c++", "c%2B%2B"),
+        ("security: critical", "security%3A%20critical"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_remove_label_percent_encodes_name(github, label, expected_segment):
+    """Every character that is unsafe in a path segment must be encoded."""
+    with patch.object(github, "_make_request", new=AsyncMock(return_value={})) as request:
+        assert await github.remove_label(label) is True
+
+    request.assert_awaited_once_with("DELETE", f"issues/42/labels/{expected_segment}")
+
+
+@pytest.mark.asyncio
+async def test_remove_label_reports_failure(github):
+    """A failed delete must not be reported as a successful removal."""
+    with patch.object(github, "_make_request", new=AsyncMock(return_value=None)):
+        assert await github.remove_label("iam/critical") is False
+
+
+@pytest.mark.asyncio
+async def test_get_labels_is_paginated(github):
+    """Labels must be read through pagination, not a single 30-item page."""
+    page = [{"name": f"label-{i}"} for i in range(45)]
+    with patch.object(github, "_make_paginated_request", new=AsyncMock(return_value=page)) as request:
+        labels = await github.get_labels()
+
+    request.assert_awaited_once_with("issues/42/labels")
+    assert len(labels) == 45
+    assert labels[-1] == "label-44"
+
+
+@pytest.mark.asyncio
+async def test_get_labels_skips_malformed_entries(github):
+    """Entries without a string name are ignored rather than crashing."""
+    with patch.object(
+        github,
+        "_make_paginated_request",
+        new=AsyncMock(return_value=[{"name": "ok"}, {"color": "red"}, {"name": 5}, "junk"]),
+    ):
+        assert await github.get_labels() == ["ok"]

--- a/tests/integrations/test_parallel_runs.py
+++ b/tests/integrations/test_parallel_runs.py
@@ -30,6 +30,7 @@ from iam_validator.core.constants import (
 )
 from iam_validator.core.ignored_findings import IgnoredFinding, IgnoredFindingsStore
 from iam_validator.core.pr_commenter import PRCommenter
+from iam_validator.core.report import ReportGenerator
 from iam_validator.integrations.github_integration import GitHubIntegration
 
 
@@ -503,7 +504,9 @@ class TestIgnoredFindingsScoped:
         )
 
         commenter = PRCommenter(github=github, comment_tag="role")
-        await commenter._load_ignored_findings()
+        # An empty report validates no files, so nothing is pruned and the
+        # test stays about which store the commenter reads from.
+        await commenter._load_ignored_findings(ReportGenerator().generate_report([]))
 
         # The role-tagged commenter must see ONLY the role store. If the
         # plumbing is broken (no comment_tag forwarded), it would load the


### PR DESCRIPTION
Release **1.27.2**. Three defects left a PR looking dirty after every finding had been fixed.

## Fixed

**`remove_label` did not encode the label name** (`integrations/github_integration.py`)

The name is a path segment, but it was spliced in raw. httpx escapes only spaces, so:

| label | resulting path |
| --- | --- |
| `iam/critical` | `labels/iam/critical` → 404 |
| `bug#1` | `labels/bug` (`#1` became a fragment) |
| `100% done` | `labels/100%%20done` → invalid |

`add_labels` uses a JSON body, so labels could be added but never removed. Now `quote(label, safe="")`.

**`get_labels` read a single page**

GitHub caps the endpoint at 30 labels per page. On a PR carrying more, the validator's own labels could fall outside the "current" set and never be removed. Now goes through `_make_paginated_request`.

**Ignore records outlived their findings** (`core/ignored_findings.py`, `core/pr_commenter.py`)

`verify_ignored_findings` and `remove_invalid_findings` had no callers anywhere, so nothing ever reconciled the store. Once a finding was ignored the record persisted forever, and the summary kept rendering it after the policy was fixed:

```
| **Total Issues Found** | 0 | ✨ |
| **Ignored Findings** | 2 | 🔕 |
### 🔕 Ignored Findings
| `gone.json` | `sensitive_action` | @bob | legacy |
```

`IgnoredFindingsStore.prune_resolved(live_finding_ids, validated_files)` now drops records whose finding is no longer reported. Scoping matters: a run over a subset of policies (streaming per-file passes, or a changed-files-driven workflow) has no evidence about files it never opened, so those records are kept. A failed save rolls the in-memory store back rather than reporting a prune it did not persist.

## Test plan

- `tests/integrations/test_github_labels.py` — label-name encoding across `/ # % + :` and space, failure reporting, paginated `get_labels`
- `tests/core/test_ignored_findings_prune.py` — prunes resolved, keeps live, keeps unvalidated files, no-op on empty scope, rollback on failed save
- `tests/core/test_pr_commenter_resolved_findings.py` — end-to-end "everything fixed" run: label removed, inline cleanup invoked with `skip_cleanup=False`, summary reports a pass, no leftover Ignored Findings table

Each new test was run against the pre-fix code and fails there (14 + 2 failures), then passes after. Full suite: 2098 passed, 23 skipped; `ruff check` and `mypy` clean.

## Not fixed (deliberate)

When no policy files are found, `action.yaml` skips the validator (`iam-policy-count > 0`) and streaming validation returns early before cleanup. So if the "fix" was deleting or renaming a policy, labels and comments are never cleaned up. Clearing them there would mean wiping all bot state whenever a `path` input is misconfigured — that needs a separate decision, not a silent change.