### PR TITLE
docs: add 1.27.2 comparison link and cover the security fix in its summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 
 ## [1.27.2] - 2026-09-11
 
-Fixes the "everything is fixed but the PR still looks dirty" case: PR labels whose names are not URL-safe could never be removed, and ignore records outlived the findings they silenced.
+Fixes the "everything is fixed but the PR still looks dirty" case — PR labels whose names are not URL-safe could never be removed, and ignore records outlived the findings they silenced — and enforces the ignore store's anti-tampering guarantee, which had no callers and so had never been applied.
 
 ### Fixed
 
@@ -910,6 +910,7 @@ _First release._
 
 [#164]: https://github.com/boogy/iam-policy-validator/pull/164
 [#162]: https://github.com/boogy/iam-policy-validator/issues/162
+[1.27.2]: https://github.com/boogy/iam-policy-validator/compare/v1.27.1...v1.27.2
 [1.27.1]: https://github.com/boogy/iam-policy-validator/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/boogy/iam-policy-validator/compare/v1.26.0...v1.27.0
 [1.26.0]: https://github.com/boogy/iam-policy-validator/compare/v1.25.1...v1.26.0


### PR DESCRIPTION
Release-readiness gaps found while auditing 1.27.2 before tagging. CHANGELOG-only.

- **Missing comparison link.** Every release from 1.0.0 onward has a `[x.y.z]: .../compare/...` definition at the bottom of the file. `[1.27.2]` had none, so the heading rendered as literal text instead of a link. Added `v1.27.1...v1.27.2`.
- **Summary omitted the security fix.** The 1.27.2 summary line described only the label encoding and ignore staleness fixes. It now also names the ignore tamper verification from #181, which is the most consequential change in the release.

## Verification

`prettier --check`, `ruff format --check`, `ruff check`, `mypy`, `pytest` (2120 passed / 23 skipped), and `mkdocs build --strict` all clean.